### PR TITLE
Fixed incorrect translation

### DIFF
--- a/language/de.po
+++ b/language/de.po
@@ -8663,7 +8663,7 @@ msgstr "Ehename"
 
 #: library/WT/Gedcom/Tag.php:733
 msgid "Married surname"
-msgstr "Nachname nach der Ehe"
+msgstr "Nachname in der Ehe"
 
 #: library/WT/Stats.php:3895
 msgid "Marshall Islands"


### PR DESCRIPTION
Corrected the german meaning to "surname in marriage", old meaning was "surname after marriage".
