### PR TITLE
Prevent page jumping to top when clicking on 'request new password' link...

### DIFF
--- a/login.php
+++ b/login.php
@@ -112,6 +112,7 @@ default:
 				jQuery("#new_passwd_form").slideToggle(100, function() {
 					jQuery("#new_passwd_username").focus()
 				});
+				return false;
 			});
 		');
 

--- a/modules_v3/login_block/module.php
+++ b/modules_v3/login_block/module.php
@@ -48,6 +48,7 @@ class login_block_WT_Module extends WT_Module implements WT_Module_Block {
 					jQuery("#new_passwd").slideToggle(100, function() {
 						jQuery("#new_passwd_username").focus();
 					});
+					return false;
 				});
 			');
 		if (WT_USER_ID) {


### PR DESCRIPTION
Hi Greg,

I think this one is clear. A little change to prevent the page jumping to top when clicking on the 'request new password' link. This happens mostly on the login block on the homepage because the screen is larger and it is more likely that someone has scrolled down a bit before clicking on the link. But I also changed the same function in the login form.
