### PR TITLE
Bug#1222698 fix and enhanced note display

### DIFF
--- a/includes/functions/functions_print.php
+++ b/includes/functions/functions_print.php
@@ -86,20 +86,20 @@ function print_pedigree_person($person, $style=1, $count=0, $personcount="1") {
 			$personlinks .= '<li><a href="pedigree.php?rootid='.$pid.'&amp;show_full='.$PEDIGREE_FULL_DETAILS.'&amp;PEDIGREE_GENERATIONS='.$OLD_PGENS.'&amp;talloffset='.$talloffset.'&amp;ged='.rawurlencode($GEDCOM).'"><b>'.WT_I18N::translate('Pedigree').'</b></a></li>';
 			if (array_key_exists('googlemap', WT_Module::getActiveModules())) {
 				$personlinks .= '<li><a href="module.php?mod=googlemap&amp;mod_action=pedigree_map&amp;rootid='.$pid.'&amp;ged='.WT_GEDURL.'"><b>'.WT_I18N::translate('Pedigree map').'</b></a></li>';
-			}			
+			}
 			if (WT_USER_GEDCOM_ID && WT_USER_GEDCOM_ID!=$pid) {
 				$personlinks .= '<li><a href="relationship.php?show_full='.$PEDIGREE_FULL_DETAILS.'&amp;pid1='.WT_USER_GEDCOM_ID.'&amp;pid2='.$pid.'&amp;show_full='.$PEDIGREE_FULL_DETAILS.'&amp;pretty=2&amp;followspouse=1&amp;ged='.WT_GEDURL.'"><b>'.WT_I18N::translate('Relationship to me').'</b></a></li>';
-			}			
-			$personlinks .= '<li><a href="descendancy.php?rootid='.$pid.'&amp;show_full='.$PEDIGREE_FULL_DETAILS.'&amp;generations='.$generations.'&amp;box_width='.$box_width.'&amp;ged='.rawurlencode($GEDCOM).'"><b>'.WT_I18N::translate('Descendants').'</b></a></li>';			
-			$personlinks .= '<li><a href="ancestry.php?rootid='.$pid.'&amp;show_full='.$PEDIGREE_FULL_DETAILS.'&amp;chart_style='.$chart_style.'&amp;PEDIGREE_GENERATIONS='.$OLD_PGENS.'&amp;box_width='.$box_width.'&amp;ged='.rawurlencode($GEDCOM).'"><b>'.WT_I18N::translate('Ancestors').'</b></a></li>';			
-			$personlinks .= '<li><a href="compact.php?rootid='.$pid.'&amp;ged='.rawurlencode($GEDCOM).'"><b>'.WT_I18N::translate('Compact tree').'</b></a></li>';			
+			}
+			$personlinks .= '<li><a href="descendancy.php?rootid='.$pid.'&amp;show_full='.$PEDIGREE_FULL_DETAILS.'&amp;generations='.$generations.'&amp;box_width='.$box_width.'&amp;ged='.rawurlencode($GEDCOM).'"><b>'.WT_I18N::translate('Descendants').'</b></a></li>';
+			$personlinks .= '<li><a href="ancestry.php?rootid='.$pid.'&amp;show_full='.$PEDIGREE_FULL_DETAILS.'&amp;chart_style='.$chart_style.'&amp;PEDIGREE_GENERATIONS='.$OLD_PGENS.'&amp;box_width='.$box_width.'&amp;ged='.rawurlencode($GEDCOM).'"><b>'.WT_I18N::translate('Ancestors').'</b></a></li>';
+			$personlinks .= '<li><a href="compact.php?rootid='.$pid.'&amp;ged='.rawurlencode($GEDCOM).'"><b>'.WT_I18N::translate('Compact tree').'</b></a></li>';
 			if (function_exists("imagettftext")) {
 				$personlinks .= '<li><a href="fanchart.php?rootid='.$pid.'&amp;PEDIGREE_GENERATIONS='.$OLD_PGENS.'&amp;ged='.rawurlencode($GEDCOM).'"><b>'.WT_I18N::translate('Fan chart').'</b></a></li>';
-			}			
-			$personlinks .= '<li><a href="hourglass.php?rootid='.$pid.'&amp;show_full='.$PEDIGREE_FULL_DETAILS.'&amp;chart_style='.$chart_style.'&amp;PEDIGREE_GENERATIONS='.$OLD_PGENS.'&amp;box_width='.$box_width.'&amp;ged='.rawurlencode($GEDCOM).'&amp;show_spouse='.$show_spouse.'"><b>'.WT_I18N::translate('Hourglass chart').'</b></a></li>';			
+			}
+			$personlinks .= '<li><a href="hourglass.php?rootid='.$pid.'&amp;show_full='.$PEDIGREE_FULL_DETAILS.'&amp;chart_style='.$chart_style.'&amp;PEDIGREE_GENERATIONS='.$OLD_PGENS.'&amp;box_width='.$box_width.'&amp;ged='.rawurlencode($GEDCOM).'&amp;show_spouse='.$show_spouse.'"><b>'.WT_I18N::translate('Hourglass chart').'</b></a></li>';
 			if (array_key_exists('tree', WT_Module::getActiveModules())) {
 				$personlinks .= '<li><a href="module.php?mod=tree&amp;mod_action=treeview&amp;ged='.WT_GEDURL.'&amp;rootid='.$pid.'"><b>'.WT_I18N::translate('Interactive tree').'</b></a></li>';
-			}			
+			}
 			foreach ($person->getSpouseFamilies() as $family) {
 				$spouse = $family->getSpouse($person);
 				if ($spouse) {
@@ -148,29 +148,29 @@ function print_pedigree_person($person, $style=1, $count=0, $personcount="1") {
 	//-- find the name
 	$name = $person->getFullName();
 	$shortname = $person->getShortName();
-	
+
 	if ($SHOW_HIGHLIGHT_IMAGES) {
 		$thumbnail = $person->displayImage();
 	} else {
 		$thumbnail = '';
 	}
-	
+
 	//-- find additional name, e.g. Hebrew
 	$addname=$person->getAddName();
-	
+
 	if ($PEDIGREE_SHOW_GENDER && $show_full) {
 		$genderImage = " ".$person->getSexImage('small', "box-$boxID-gender");
 	}
-	
+
 	// Here for alternate name2
 	if ($addname) {
 		$addname = "<br><span id=\"addnamedef-$boxID\" class=\"name1\"> ".$addname."</span>";
 	}
-	
+
 	if ($SHOW_LDS_AT_GLANCE && $show_full) {
 		$addname = ' <span class="details$style">'.get_lds_glance($person).'</span>' . $addname;
 	}
-	
+
 	if ($show_full && $person->canShow()) {
 		$opt_tags=preg_split('/\W/', $CHART_BOX_TAGS, 0, PREG_SPLIT_NO_EMPTY);
 		// Show BIRT or equivalent event
@@ -222,7 +222,7 @@ function print_pedigree_person($person, $style=1, $count=0, $personcount="1") {
 	}
 }
 
-// print HTML header meta links 
+// print HTML header meta links
 // previously identical code in each theme's header.php file
 // now added as a function here.
 
@@ -391,65 +391,47 @@ function contact_links($ged_id=WT_GED_ID) {
 * @return boolean
 */
 function print_note_record($text, $nlevel, $nrec, $textOnly=false) {
-	global $EXPAND_SOURCES, $EXPAND_NOTES;
-	$elementID = 'N-'.(int)(microtime()*1000000);
+	global $EXPAND_NOTES;
 
-	$text .= get_cont($nlevel, $nrec);
-
+	$note = null;
 	// Check if shared note
 	if (preg_match('/^0 @('.WT_REGEX_XREF.')@ NOTE/', $nrec, $match)) {
 		$note = WT_Note::getInstance($match[1]);
+	}
+	if ($note === null) {
+		$type = WT_I18N::translate('Note');
+		$text = WT_Filter::expandUrls($text . get_cont($nlevel, $nrec));
+	} else {
+		$type = WT_I18N::translate('Shared note');
 		// Check if using census assistant
-		if ($note && array_key_exists('GEDFact_assistant', WT_Module::getActiveModules())) {
+		if (array_key_exists('GEDFact_assistant', WT_Module::getActiveModules())) {
 			$text = GEDFact_assistant_WT_Module::formatCensusNote($note);
 		} else {
-			$text = $note->getNote();
-			$text = WT_Filter::expandUrls($text);
+			$text = WT_Filter::expandUrls($note->getNote());
 		}
-	} else {
-		$note = null;
-		$text = WT_Filter::expandUrls($text);
 	}
 
 	if ($textOnly) {
 		return strip_tags($text);
 	}
 
-
-	$brpos = strpos($text, '<br>');
 	$data = '<div class="fact_NOTE"><span class="label">';
-	if ($brpos !== false) {
-		if ($EXPAND_NOTES) $plusminus='minus'; else $plusminus='plus';
-		$data .= '<a href="#" onclick="expand_layer(\''.$elementID.'\'); return false;"><i id="'.$elementID.'_img" class="icon-'.$plusminus.'"></i></a> ';
-	}
-
-	if ($note) {
-		$data .= WT_I18N::translate('Shared note').': </span> ';
+	if ($note !== null && preg_match('/(<span class="note_title">.*?<\/span>|.*?\n)(.*)/si', $text, $match)) {
+		// $match[1] - the header line, will become a link
+		// $match[2] - the remainder of the note text
+		$eID = 'N-' . (int) (microtime() * 1000000);
+		$sign = $EXPAND_NOTES ? 'minus' : 'plus';
+		$data .= '<a href="#" onclick="expand_layer(\'' . $eID . '\'); return false;"><i id="' . $eID . '_img" class="icon-' . $sign . '"></i></a> ';
+		$data .= $type . ': </span> ';
+		$data .= '<span class="field" dir="auto"><a href="' . $note->getHtmlUrl() . '">' . $match[1] . '</a></span>';
+		// Shared notes may be created outside of census assistant so need
+		// to replace "\n" with "<br>"
+		$data .= '<div id="' . $eID . '" class="note_details" dir="auto">' . str_replace("\n", "<br>", $match[2]) . '</div>';
 	} else {
-		$data .= WT_I18N::translate('Note').': </span>';
-	}
-
-	if ($brpos !== false) {
-		$line1 = substr($text, 0, $brpos);
-		if ($note) {
-			$line1 = '<a href="' . $note->getHtmlUrl() . '">' . $line1 . '</a>';
-		}
-		$data .= '<span class="field" dir="auto">' . $line1 . '</span>';
-		$data .= '<div id="' . $elementID . '"';
-		if ($EXPAND_NOTES) {
-			$data .= ' style="display:block"';
-		}
-		$data .= ' class="note_details" dir="auto">';
-		$data .= substr($text, $brpos + 4);
-		$data .= '</div>';
-	} else {
-		if ($note) {
-			$text = '<a href="' . $note->getHtmlUrl() . '">' . $text . '</a>';
-		}
-		$data .= '<span class="field" dir="auto">'.$text. '</span>';
+		$data .= $type . ': </span>';
+		$data .= '<span class="field" dir="auto">' . $text . '</span>';
 	}
 	$data .= "</div>";
-
 	return $data;
 }
 
@@ -604,7 +586,7 @@ function print_asso_rela_record(WT_Fact $event, WT_GedcomRecord $record) {
 					if ($record instanceof WT_Family) {
 						$label_2=$associate->getSexImage().$label_2;
 					}
-	
+
 					if ($SEARCH_SPIDER) {
 						$html[]=$label_2; // Search engines cannot use the relationship chart.
 					} else {

--- a/modules_v3/GEDFact_assistant/CENS_ctrl.php
+++ b/modules_v3/GEDFact_assistant/CENS_ctrl.php
@@ -30,9 +30,6 @@ check_record_access($person);
 
 $controller
 	->setPageTitle(WT_I18N::translate('Create a new shared note using assistant'))
-	->addInlineJavascript(
-		'jQuery("head").append(\'<link rel="stylesheet" href="' . WT_STATIC_URL . WT_MODULES_DIR . 'GEDFact_assistant/css/cens_style.css" type="text/css">\');'
-	)
 	->pageHeader();
 
 echo '<div id="edit_interface-page">';
@@ -48,7 +45,7 @@ echo '<h3>', $controller->getPageTitle(), '&nbsp;&nbsp;';
 		break;
 	}
 echo '</h3>';
-	
+
 ?>
 <div class="center" style="width:100%;">
 	<?php

--- a/modules_v3/GEDFact_assistant/css/cens_style.css
+++ b/modules_v3/GEDFact_assistant/css/cens_style.css
@@ -21,7 +21,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
- 
+
 .cens_header {text-align:left; margin:5px; height:40px;}
 .cens_container {float:left; width:575px; margin:5px 0; padding:0;}
 .cens_container span {margin:0 3px;}
@@ -54,9 +54,10 @@ textarea#NOTE {font-size: 12px;height:250px; width:98.5%; overflow:auto;}
 .rtlnav {position:absolute; top:-15px; right:40px;}
 .headimg {margin-top:-4px; border:0;}
 .headimg2 {height:17px;	border-style:none;margin:-3px;margin-left:0px;}
-.note1 {font-weight: bold;}
-.note2 {font-weight: bold;}
-.notecell {white-space: nowrap;}
+.note_body{margin:10px 0;font-size:11px;}
+.note_body th{text-align:left;font-weight: bold;}
+.note_body td{padding:0 2px;}
+.note_text{white-space:normal;display:block;}
 #edit_interface-page input#personid {width:160px;}
 
 html[dir='rtl'] .cens_header {text-align:right;}

--- a/modules_v3/GEDFact_assistant/module.php
+++ b/modules_v3/GEDFact_assistant/module.php
@@ -60,7 +60,7 @@ class GEDFact_assistant_WT_Module extends WT_Module {
 		global $MEDIA_DIRECTORY;
 
 		$controller=new WT_Controller_Simple();
-		
+
 		$type           ='indi';
 		$filter         =WT_Filter::get('filter');
 		$action         =WT_Filter::get('action');
@@ -73,18 +73,18 @@ class GEDFact_assistant_WT_Module extends WT_Module {
 		$all            =WT_Filter::getBool('all');
 		$subclick       =WT_Filter::get('subclick');
 		$choose         =WT_Filter::get('choose');
-		
+
 		$controller
 			->setPageTitle(WT_I18N::translate('Find an individual'))
 			->pageHeader();
-		
+
 		echo '<script>';
 		?>
-		
+
 			function pasterow(id, name, gend, yob, age, bpl) {
 				window.opener.opener.insertRowToTable(id, name, '', gend, '', yob, age, 'Y', '', bpl);
 			}
-		
+
 			function pasteid(id, name, thumb) {
 				if (thumb) {
 					window.opener.<?php echo $callback; ?>(id, name, thumb);
@@ -123,7 +123,7 @@ class GEDFact_assistant_WT_Module extends WT_Module {
 			}
 		<?php
 		echo '</script>';
-		
+
 		echo "<div align=\"center\">";
 		echo "<table class=\"list_table width90\" border=\"0\">";
 		echo "<tr><td style=\"padding: 10px;\" valign=\"top\" class=\"facts_label03 width90\">"; // start column for find text header
@@ -134,7 +134,7 @@ class GEDFact_assistant_WT_Module extends WT_Module {
 		echo "<br>";
 		echo '<button onclick="window.close();">', WT_I18N::translate('close'), '</button>';
 		echo "<br>";
-		
+
 		$filter = trim($filter);
 		$filter_array=explode(' ', preg_replace('/ {2,}/', ' ', $filter));
 		echo "<table class=\"tabs_table width90\"><tr>";
@@ -152,7 +152,7 @@ class GEDFact_assistant_WT_Module extends WT_Module {
 					'".(1901-$indi->getbirthyear())."' ,
 					'".$indi->getbirthplace()."'); return false;\">
 					<b>".$indi->getFullName()."</b>&nbsp;&nbsp;&nbsp;";
-	
+
 				$born=WT_Gedcom_Tag::getLabel('BIRT');
 				echo "</span><br><span class=\"list_item\">", $born, " ", $indi->getbirthyear(), "&nbsp;&nbsp;&nbsp;", $indi->getbirthplace(), "</span></a></li>";
 			echo "<hr>";
@@ -174,7 +174,7 @@ class GEDFact_assistant_WT_Module extends WT_Module {
 		$controller
 			->setPageTitle(WT_I18N::translate('Link to an existing media object'))
 			->pageHeader();
-		
+
 		$record=WT_GedcomRecord::getInstance($iid2);
 		if ($record) {
 			$headjs='';
@@ -196,7 +196,7 @@ class GEDFact_assistant_WT_Module extends WT_Module {
 			}
 			</script>
 			<?php
-		
+
 		} else {
 			?>
 			<script>
@@ -207,7 +207,7 @@ class GEDFact_assistant_WT_Module extends WT_Module {
 			</script>
 			<?php
 		}
-		?>		
+		?>
 		<script>window.onLoad = insertId();</script>
 		<?php
 	}
@@ -229,7 +229,7 @@ class GEDFact_assistant_WT_Module extends WT_Module {
 			'ChD'        => 'Children who have died',
 			'ChL'        => 'Children still living',
 			'DOB'        => 'Date of birth',
-			'Edu'        => 'Education - At School, Can Read, Can Write', // or "Cannot Read, Cannot Write" ?? 
+			'Edu'        => 'Education - At School, Can Read, Can Write', // or "Cannot Read, Cannot Write" ??
 			'EmD'        => 'Employed?',
 			'EmN'        => 'Unemployed?',
 			'EmR'        => 'Employer?',
@@ -293,21 +293,14 @@ class GEDFact_assistant_WT_Module extends WT_Module {
 				$tbody .= '</tr>';
 			}
 
-			// TODO: why doesn't this work?  Why do we need to add the javascript inline?
-			//$controller->addInlineJavascript(
-			//	'jQuery("head").append(\'<link rel="stylesheet" href="' . WT_STATIC_URL . WT_MODULES_DIR . 'GEDFact_assistant/css/cens_style.css" type="text/css">\');'
-			//);
-
 			return
-				'<script>jQuery("head").append(\'<link rel="stylesheet" href="' . WT_STATIC_URL . WT_MODULES_DIR . 'GEDFact_assistant/css/cens_style.css" type="text/css">\');</script>' .
-				'<span class="note1">' . $title . '</span>' .
-				'<br>' . // Needed to allow the first line to be converted to a link
-				'<span class="note1">' . $preamble . '</span>' .
-				'<table class="note2">' .
+				'<span class="note_title">' . $title . '</span>' .
+				'<span class="note_text">' . $preamble . '</span>' .
+				'<table class="note_body">' .
 				'<thead>' .  $thead .  '</thead>' .
 				'<tbody>' .  $tbody .  '</tbody>' .
 				'</table>' .
-				'<span class="note1">' . $postamble . '</span>';
+				'<span class="note_text">' . $postamble . '</span>';
 		} else {
 			// Not a census-assistant shared note - apply default formatting
 			return WT_Filter::expandUrls($note->getNote());
@@ -334,7 +327,7 @@ class GEDFact_assistant_WT_Module extends WT_Module {
 		if (++$n != 2) {
 			return '';
 		}
-		
+
 		$controller->addInlineJavascript('
 			var pid_array=jQuery("#pid_array");
 			function set_pid_array(pa) {

--- a/themes/clouds/header.php
+++ b/themes/clouds/header.php
@@ -31,7 +31,7 @@ $this
 	->addExternalJavascript(WT_JQUERY_COLORBOX_URL)
 	->addExternalJavascript(WT_JQUERY_WHEELZOOM_URL)
 	->addInlineJavascript('activate_colorbox();')
-	->addInlineJavascript('jQuery.extend(jQuery.colorbox.settings, {width:"70%", height:"70%", transition:"none", slideshowStart:"'. WT_I18N::translate('Play').'", slideshowStop:"'. WT_I18N::translate('Stop').'"})') 
+	->addInlineJavascript('jQuery.extend(jQuery.colorbox.settings, {width:"70%", height:"70%", transition:"none", slideshowStart:"'. WT_I18N::translate('Play').'", slideshowStop:"'. WT_I18N::translate('Stop').'"})')
 	->addInlineJavascript('
 		jQuery.extend(jQuery.colorbox.settings, {
 			title:	function(){
@@ -61,14 +61,16 @@ case 'msie':
 if (WT_USE_LIGHTBOX) {
 		echo '<link rel="stylesheet" type="text/css" href="', WT_STATIC_URL, WT_MODULES_DIR, 'lightbox/css/album_page.css" media="screen">';
 }
-
+if (array_key_exists('GEDFact_assistant', WT_Module::getActiveModules())) {
+	echo '<link rel="stylesheet" type="text/css" href="', WT_STATIC_URL, WT_MODULES_DIR, 'GEDFact_assistant/css/cens_style.css">';
+}
 echo
 	'</head>',
 	'<body id="body">';
 
 if  ($view!='simple') { // Use "simple" headers for popup windows
 	global $WT_IMAGES;
-	echo 
+	echo
 	'<div id="clouds-container">',
 		'<div id="header">',
 			'<div class="header" >',
@@ -100,19 +102,19 @@ if  ($view!='simple') { // Use "simple" headers for popup windows
 	foreach (WT_MenuBar::getModuleMenus() as $menu) {
 		$menu_items[]=$menu;
 	}
- 
+
 	// Print the menu bar
 	echo
 	'<div id="topMenu">',
-		'<ul id="main-menu">'; 
+		'<ul id="main-menu">';
 		foreach ($menu_items as $menu) {
 			if ($menu) {
 				echo getMenuAsCustomList($menu);
 			}
 		}
-	echo 
+	echo
 	'</ul>';
-	echo 
+	echo
 	'<div id="menu-right">',
 	'<ul class="makeMenu">';
 	if (WT_USER_ID) {

--- a/themes/colors/header.php
+++ b/themes/colors/header.php
@@ -34,7 +34,7 @@ $this
 	->addExternalJavascript(WT_JQUERY_COLORBOX_URL)
 	->addExternalJavascript(WT_JQUERY_WHEELZOOM_URL)
 	->addInlineJavascript('activate_colorbox();')
-	->addInlineJavascript('jQuery.extend(jQuery.colorbox.settings, {width:"70%", height:"70%", transition:"none", slideshowStart:"'. WT_I18N::translate('Play').'", slideshowStop:"'. WT_I18N::translate('Stop').'"})') 
+	->addInlineJavascript('jQuery.extend(jQuery.colorbox.settings, {width:"70%", height:"70%", transition:"none", slideshowStart:"'. WT_I18N::translate('Play').'", slideshowStop:"'. WT_I18N::translate('Stop').'"})')
 
 	->addInlineJavascript('
 		jQuery.extend(jQuery.colorbox.settings, {
@@ -74,7 +74,9 @@ case 'ipad':
 if (WT_USE_LIGHTBOX) {
 		echo '<link rel="stylesheet" type="text/css" href="', WT_STATIC_URL, WT_MODULES_DIR, 'lightbox/css/album_page.css" media="screen">';
 }
-
+if (array_key_exists('GEDFact_assistant', WT_Module::getActiveModules())) {
+	echo '<link rel="stylesheet" type="text/css" href="', WT_STATIC_URL, WT_MODULES_DIR, 'GEDFact_assistant/css/cens_style.css">';
+}
 echo
 	'</head>',
 	'<body id="body">';
@@ -85,8 +87,8 @@ if  ($view!='simple') { // Use "simple" headers for popup windows
 	'<div id="header">',
 	'<span class="title" dir="auto">', WT_TREE_TITLE, '</span>';
 
-	// Top row right 
-	echo 
+	// Top row right
+	echo
 	'<ul class="makeMenu">';
 
 	if (WT_USER_ID) {
@@ -132,7 +134,7 @@ if  ($view!='simple') { // Use "simple" headers for popup windows
 	// Second Row menu and palette selection
 	// Menu
 	$menu_items=array(
-		WT_MenuBar::getGedcomMenu(), 
+		WT_MenuBar::getGedcomMenu(),
 		WT_MenuBar::getMyPageMenu(),
 		WT_MenuBar::getChartsMenu(),
 		WT_MenuBar::getListsMenu(),
@@ -147,7 +149,7 @@ if  ($view!='simple') { // Use "simple" headers for popup windows
 	// Print the menu bar
 	echo
 
-		'<ul id="main-menu">'; 
+		'<ul id="main-menu">';
 		foreach ($menu_items as $menu) {
 			if ($menu) {
 			echo getMenuAsCustomList($menu);
@@ -155,9 +157,9 @@ if  ($view!='simple') { // Use "simple" headers for popup windows
 		}
 	unset($menu_items, $menu);
 	echo
-		'</ul>'; 
+		'</ul>';
 }
-// Remove list from home when only 1 gedcom 
+// Remove list from home when only 1 gedcom
 $this->addInlineJavaScript(
 	'if (jQuery("#menu-tree ul li").length == 2) jQuery("#menu-tree ul li:last-child").remove();'
 );

--- a/themes/fab/header.php
+++ b/themes/fab/header.php
@@ -31,7 +31,7 @@ $this
 	->addExternalJavascript(WT_JQUERY_COLORBOX_URL)
 	->addExternalJavascript(WT_JQUERY_WHEELZOOM_URL)
 	->addInlineJavascript('activate_colorbox();')
-	->addInlineJavascript('jQuery.extend(jQuery.colorbox.settings, {width:"70%", height:"70%", transition:"none", slideshowStart:"'. WT_I18N::translate('Play').'", slideshowStop:"'. WT_I18N::translate('Stop').'"})') 
+	->addInlineJavascript('jQuery.extend(jQuery.colorbox.settings, {width:"70%", height:"70%", transition:"none", slideshowStart:"'. WT_I18N::translate('Play').'", slideshowStop:"'. WT_I18N::translate('Stop').'"})')
 	->addInlineJavascript('
 		jQuery.extend(jQuery.colorbox.settings, {
 			title:	function(){
@@ -61,7 +61,9 @@ case 'msie':
 if (WT_USE_LIGHTBOX) {
 		echo '<link rel="stylesheet" type="text/css" href="', WT_STATIC_URL, WT_MODULES_DIR, 'lightbox/css/album_page.css" media="screen">';
 }
-
+if (array_key_exists('GEDFact_assistant', WT_Module::getActiveModules())) {
+	echo '<link rel="stylesheet" type="text/css" href="', WT_STATIC_URL, WT_MODULES_DIR, 'GEDFact_assistant/css/cens_style.css">';
+}
 echo
 	'</head>',
 	'<body id="body">';

--- a/themes/minimal/header.php
+++ b/themes/minimal/header.php
@@ -31,7 +31,7 @@ $this
 	->addExternalJavascript(WT_JQUERY_COLORBOX_URL)
 	->addExternalJavascript(WT_JQUERY_WHEELZOOM_URL)
 	->addInlineJavascript('activate_colorbox();')
-	->addInlineJavascript('jQuery.extend(jQuery.colorbox.settings, {width:"70%", height:"70%", transition:"none", slideshowStart:"'. WT_I18N::translate('Play').'", slideshowStop:"'. WT_I18N::translate('Stop').'"})') 
+	->addInlineJavascript('jQuery.extend(jQuery.colorbox.settings, {width:"70%", height:"70%", transition:"none", slideshowStart:"'. WT_I18N::translate('Play').'", slideshowStop:"'. WT_I18N::translate('Stop').'"})')
 	->addInlineJavascript('
 		jQuery.extend(jQuery.colorbox.settings, {
 			title:	function(){
@@ -62,7 +62,9 @@ case 'msie':
 if (WT_USE_LIGHTBOX) {
 		echo '<link rel="stylesheet" type="text/css" href="', WT_STATIC_URL, WT_MODULES_DIR, 'lightbox/css/album_page.css" media="screen">';
 }
-
+if (array_key_exists('GEDFact_assistant', WT_Module::getActiveModules())) {
+	echo '<link rel="stylesheet" type="text/css" href="', WT_STATIC_URL, WT_MODULES_DIR, 'GEDFact_assistant/css/cens_style.css">';
+}
 echo
 	'</head>',
 	'<body id="body">';

--- a/themes/webtrees/header.php
+++ b/themes/webtrees/header.php
@@ -35,19 +35,22 @@ $this
 	->addInlineJavascript('jQuery.extend(jQuery.colorbox.settings, { width:"70%", height:"70%", transition:"none", slideshowStart:"'. WT_I18N::translate('Play').'", slideshowStop:"'. WT_I18N::translate('Stop').'", title: function() { var img_title = jQuery(this).data("title"); return img_title; } } );');
 ?>
 <!DOCTYPE html>
-<html <?php echo WT_I18N::html_markup(); ?>> 
-<head> 
-	<meta charset="UTF-8"> 
-	<title><?php echo WT_Filter::escapeHtml($title); ?></title> 
-	<?php echo header_links($META_DESCRIPTION, $META_ROBOTS, $META_GENERATOR, $LINK_CANONICAL); ?> 
-	<link rel="icon" href="<?php echo WT_CSS_URL; ?>favicon.png" type="image/png"> 
-	<link rel="stylesheet" type="text/css" href="<?php echo WT_THEME_URL; ?>jquery-ui-1.10.3/jquery-ui-1.10.3.custom.css"> 
-	<link rel="stylesheet" type="text/css" href="<?php echo WT_CSS_URL; ?>style.css"> 
-	<!--[if IE]> 
-	<link rel="stylesheet" type="text/css" href="<?php echo WT_CSS_URL; ?>msie.css"> 
-	<![endif]--> 
+<html <?php echo WT_I18N::html_markup(); ?>>
+<head>
+	<meta charset="UTF-8">
+	<title><?php echo WT_Filter::escapeHtml($title); ?></title>
+	<?php echo header_links($META_DESCRIPTION, $META_ROBOTS, $META_GENERATOR, $LINK_CANONICAL); ?>
+	<link rel="icon" href="<?php echo WT_CSS_URL; ?>favicon.png" type="image/png">
+	<link rel="stylesheet" type="text/css" href="<?php echo WT_THEME_URL; ?>jquery-ui-1.10.3/jquery-ui-1.10.3.custom.css">
+	<link rel="stylesheet" type="text/css" href="<?php echo WT_CSS_URL; ?>style.css">
+	<!--[if IE]>
+	<link rel="stylesheet" type="text/css" href="<?php echo WT_CSS_URL; ?>msie.css">
+	<![endif]-->
 	<?php if (WT_USE_LIGHTBOX) { ?>
 	<link rel="stylesheet" type="text/css" href="<?php echo WT_STATIC_URL, WT_MODULES_DIR; ?>lightbox/css/album_page.css">
+	<?php } ?>
+	<?php if (array_key_exists('GEDFact_assistant', WT_Module::getActiveModules())) { ?>
+	<link rel="stylesheet" type="text/css" href="<?php echo WT_STATIC_URL, WT_MODULES_DIR; ?>GEDFact_assistant/css/cens_style.css">
 	<?php } ?>
 </head>
 <body id="body">

--- a/themes/xenea/header.php
+++ b/themes/xenea/header.php
@@ -31,7 +31,7 @@ $this
 	->addExternalJavascript(WT_JQUERY_COLORBOX_URL)
 	->addExternalJavascript(WT_JQUERY_WHEELZOOM_URL)
 	->addInlineJavascript('activate_colorbox();')
-	->addInlineJavascript('jQuery.extend(jQuery.colorbox.settings, {width:"70%", height:"70%", transition:"none", slideshowStart:"'. WT_I18N::translate('Play').'", slideshowStop:"'. WT_I18N::translate('Stop').'"});') 
+	->addInlineJavascript('jQuery.extend(jQuery.colorbox.settings, {width:"70%", height:"70%", transition:"none", slideshowStart:"'. WT_I18N::translate('Play').'", slideshowStop:"'. WT_I18N::translate('Stop').'"});')
 	->addInlineJavascript('
 		jQuery.extend(jQuery.colorbox.settings, {
 			title:	function(){
@@ -61,17 +61,19 @@ case 'msie':
 if (WT_USE_LIGHTBOX) {
 		echo '<link rel="stylesheet" type="text/css" href="', WT_STATIC_URL, WT_MODULES_DIR, 'lightbox/css/album_page.css" media="screen">';
 }
-
+if (array_key_exists('GEDFact_assistant', WT_Module::getActiveModules())) {
+	echo '<link rel="stylesheet" type="text/css" href="', WT_STATIC_URL, WT_MODULES_DIR, 'GEDFact_assistant/css/cens_style.css">';
+}
 echo
 	'</head>',
 	'<body id="body">';
 
 if ($view!='simple') { // Use "simple" headers for popup windows
-	echo 
+	echo
 	'<div id="header">',
 		'<span class="title" dir="auto">', WT_TREE_TITLE, '</span>',
 		'<div class="hsearch">';
-	echo 
+	echo
 			'<form action="search.php" method="post">',
 			'<input type="hidden" name="action" value="general">',
 			'<input type="hidden" name="ged" value="', WT_GEDCOM, '">',
@@ -111,7 +113,7 @@ if ($view!='simple') { // Use "simple" headers for popup windows
 				} else {
 					echo '<li>', login_link(), '</li> ';
 				}
-	echo	
+	echo
 			'</ul>',
 		'</div>';
 	echo
@@ -121,11 +123,11 @@ if ($view!='simple') { // Use "simple" headers for popup windows
 				if ($menu) {
 					echo $menu->getMenuAsList();
 				}
-	echo 
+	echo
 			'</ul>',
 		'</div>',
 	'</div>';
-// Menu 
+// Menu
 		$menu_items=array(
 			WT_MenuBar::getGedcomMenu(),
 			WT_MenuBar::getMyPageMenu(),


### PR DESCRIPTION
Shifted loading of GEDFact_assistant/css/cens_style.css from function formatCensusNote() to the theme header.php as the note css is required in a number of places. Also took opportunity to amend code in function print_note_record() to remove need for a < br > in the note text to act as a marker for when the header line is to be turned into a link (so display is consistent everywhere) also picked up potential logic error (call getNote() for a null WT_Note) and corrected display of shared notes created outside census assistant

Of course a simpler solution to the css loading may be to put the relevant lines (.note_*) into each theme css file
