### PR TITLE
Bug #1222698 fix and other note styling fixes

### DIFF
--- a/modules_v3/GEDFact_assistant/css/cens_style.css
+++ b/modules_v3/GEDFact_assistant/css/cens_style.css
@@ -21,7 +21,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
  */
- 
+
 .cens_header {text-align:left; margin:5px; height:40px;}
 .cens_container {float:left; width:575px; margin:5px 0; padding:0;}
 .cens_container span {margin:0 3px;}
@@ -54,9 +54,13 @@ textarea#NOTE {font-size: 12px;height:250px; width:98.5%; overflow:auto;}
 .rtlnav {position:absolute; top:-15px; right:40px;}
 .headimg {margin-top:-4px; border:0;}
 .headimg2 {height:17px;	border-style:none;margin:-3px;margin-left:0px;}
-.note1 {font-weight: bold;}
-.note2 {font-weight: bold;}
-.notecell {white-space: nowrap;}
+
+/* The following styles shifted to the themes
+.note_body{margin:10px 0;font-size:11px;}
+.note_body th{text-align:left;font-weight: bold;}
+.note_body td{padding:0 2px;}
+.note_text{white-space:normal;display:block;}*/
+
 #edit_interface-page input#personid {width:160px;}
 
 html[dir='rtl'] .cens_header {text-align:right;}

--- a/modules_v3/GEDFact_assistant/module.php
+++ b/modules_v3/GEDFact_assistant/module.php
@@ -269,11 +269,11 @@ class GEDFact_assistant_WT_Module extends WT_Module {
 
 		if (preg_match('/(.*)((?:\n.*)*)\n\.start_formatted_area\.\n(.*)((?:\n.*)*)\n.end_formatted_area\.\n(.*(?:\n.*)*)/', $note->getNote(), $match)) {
 			// This looks like a census-assistant shared note
-			$title     = WT_Filter::escapeHtml($match[1]);
-			$preamble  = WT_Filter::escapeHtml($match[2]);
-			$header    = WT_Filter::escapeHtml($match[3]);
-			$data      = WT_Filter::escapeHtml($match[4]);
-			$postamble = WT_Filter::escapeHtml($match[5]);
+			$title     = trim(WT_Filter::escapeHtml($match[1]));
+			$preamble  = trim(WT_Filter::escapeHtml($match[2]));
+			$header    = trim(WT_Filter::escapeHtml($match[3]));
+			$data      = trim(WT_Filter::escapeHtml($match[4]));
+			$postamble = trim(WT_Filter::escapeHtml($match[5]));
 
 			$fmt_headers = array();
 			foreach ($headers as $key=>$value) {
@@ -293,21 +293,14 @@ class GEDFact_assistant_WT_Module extends WT_Module {
 				$tbody .= '</tr>';
 			}
 
-			// TODO: why doesn't this work?  Why do we need to add the javascript inline?
-			//$controller->addInlineJavascript(
-			//	'jQuery("head").append(\'<link rel="stylesheet" href="' . WT_STATIC_URL . WT_MODULES_DIR . 'GEDFact_assistant/css/cens_style.css" type="text/css">\');'
-			//);
-
 			return
-				'<script>jQuery("head").append(\'<link rel="stylesheet" href="' . WT_STATIC_URL . WT_MODULES_DIR . 'GEDFact_assistant/css/cens_style.css" type="text/css">\');</script>' .
-				'<span class="note1">' . $title . '</span>' .
-				'<br>' . // Needed to allow the first line to be converted to a link
-				'<span class="note1">' . $preamble . '</span>' .
-				'<table class="note2">' .
+				'<span class="note_title">' . $title . '</span>' .
+				'<span class="note_text">' . $preamble . '</span>' .
+				'<table class="note_body">' .
 				'<thead>' .  $thead .  '</thead>' .
 				'<tbody>' .  $tbody .  '</tbody>' .
 				'</table>' .
-				'<span class="note1">' . $postamble . '</span>';
+				'<span class="note_text">' . $postamble . '</span>';
 		} else {
 			// Not a census-assistant shared note - apply default formatting
 			return WT_Filter::expandUrls($note->getNote());

--- a/themes/clouds/css-1.5.0/style.css
+++ b/themes/clouds/css-1.5.0/style.css
@@ -3091,3 +3091,20 @@ html[dir=rtl] #cboxSlideshow {right:57px;left:0; }
 #stories p {
 	padding-top: 8px;
 }
+
+/* Shared Note */
+.note_body{
+	margin:10px 0;
+	font-size:11px;
+}
+.note_body th{
+	text-align:left;
+	font-weight: bold;
+}
+.note_body td{
+	padding:0 2px;
+}
+.note_text{
+	white-space:normal;
+	display:block;
+}

--- a/themes/colors/css-1.5.0/css/colors.css
+++ b/themes/colors/css-1.5.0/css/colors.css
@@ -1228,3 +1228,20 @@ html[dir=rtl] #cboxSlideshow {right:57px;left:0; }
 #stories p {
 	padding-top: 8px;
 }
+
+/* Shared Note */
+.note_body{
+	margin:10px 0;
+	font-size:11px;
+}
+.note_body th{
+	text-align:left;
+	font-weight: bold;
+}
+.note_body td{
+	padding:0 2px;
+}
+.note_text{
+	white-space:normal;
+	display:block;
+}

--- a/themes/fab/css-1.5.0/style.css
+++ b/themes/fab/css-1.5.0/style.css
@@ -3491,3 +3491,20 @@ html[dir=rtl] #cboxSlideshow {
 #stories p {
 	padding-top: 8px;
 }
+
+/* Shared Note */
+.note_body{
+	margin:10px 0;
+	font-size:11px;
+}
+.note_body th{
+	text-align:left;
+	font-weight: bold;
+}
+.note_body td{
+	padding:0 2px;
+}
+.note_text{
+	white-space:normal;
+	display:block;
+}

--- a/themes/minimal/css-1.5.0/style.css
+++ b/themes/minimal/css-1.5.0/style.css
@@ -1865,3 +1865,19 @@ html[dir=rtl] #cboxSlideshow {right:57px;left:0; }
 #stories p {
 	padding-top: 8px;
 }
+/* Shared Note */
+.note_body{
+	margin:10px 0;
+	font-size:11px;
+}
+.note_body th{
+	text-align:left;
+	font-weight: bold;
+}
+.note_body td{
+	padding:0 2px;
+}
+.note_text{
+	white-space:normal;
+	display:block;
+}

--- a/themes/webtrees/css-1.5.0/style.css
+++ b/themes/webtrees/css-1.5.0/style.css
@@ -1155,3 +1155,19 @@ html[dir=rtl] #cboxSlideshow {right:57px;left:0; }
 .story_edit {
 	padding: 12px;
 }
+/* Shared Note */
+.note_body{
+	margin:10px 0;
+	font-size:11px;
+}
+.note_body th{
+	text-align:left;
+	font-weight: bold;
+}
+.note_body td{
+	padding:0 2px;
+}
+.note_text{
+	white-space:normal;
+	display:block;
+}

--- a/themes/xenea/css-1.5.0/style.css
+++ b/themes/xenea/css-1.5.0/style.css
@@ -2178,3 +2178,19 @@ html[dir=rtl] #cboxSlideshow {right:57px;left:0; }
 #stories p {
 	padding-top: 8px;
 }
+/* Shared Note */
+.note_body{
+	margin:10px 0;
+	font-size:11px;
+}
+.note_body th{
+	text-align:left;
+	font-weight: bold;
+}
+.note_body td{
+	padding:0 2px;
+}
+.note_text{
+	white-space:normal;
+	display:block;
+}


### PR DESCRIPTION
Greg, I sent you an email with a few questions about this. I've adopted the simple approach here.

Shifted note styles from GEDFact_assistant/css/cens_style.css to the themes as they are required in a number of places. Also recoded function print_note_record() to remove need for a < br > in the note text to act as a marker for when the header line is to be turned into a link (allows consistency of display), fixed potential logic error that permitted a call to getNote() with a null record, and replaced "\n" chars with "< br >" for notes that were created outside the census assistant - this identified that the regex in function formatCensusNote() was leaving leading/trailing "\n" chars for preamble, postamble & data sections. Fixed by the simple expedient of trimming them!
