### PR TITLE
Googlemaps flags: Countries and States dropdownmenu not working.

### DIFF
--- a/modules_v3/googlemap/module.php
+++ b/modules_v3/googlemap/module.php
@@ -440,8 +440,8 @@ class googlemap_WT_Module extends WT_Module implements WT_Module_Config, WT_Modu
 		$countries = WT_Stats::get_all_countries();
 		$action    = WT_Filter::post('action');
 
-		$countrySelected = WT_Filter::post('countrySelected', null, 'Countries');
-		$stateSelected   = WT_Filter::post('stateSelected',   null, 'States');
+		$countrySelected = WT_Filter::get('countrySelected', null, 'Countries');
+		$stateSelected   = WT_Filter::get('stateSelected',   null, 'States');
 
 		$country = array();
 		$rep = opendir(WT_ROOT.WT_MODULES_DIR.'googlemap/places/flags/');


### PR DESCRIPTION
The dropdown menu for countries and states in the flags popup screen wasn't working since 1.5.0 dev. I got things working by changing the WT_filter::post command to a WT_filter::get command.
