### PR TITLE
Fix for flags not showing on google maps tab.

### DIFF
--- a/modules_v3/googlemap/googlemap.php
+++ b/modules_v3/googlemap/googlemap.php
@@ -559,7 +559,7 @@ function build_indiv_map(WT_Individual $indi, $indifacts, $famids) {
 					"place":        "<?php echo WT_Filter::escapeJs($gmark['place']       ); ?>",
 					"tooltip":      "<?php echo WT_Filter::escapeJs($gmark['tooltip']     ); ?>",
 					"image":        "<?php echo WT_Filter::escapeJs($gmark['image']       ); ?>",
-					"icon":         "<?php echo WT_Filter::escapeJs($gmark['pl_icon']     ); ?>",
+					"pl_icon":      "<?php echo WT_Filter::escapeJs($gmark['pl_icon']     ); ?>",
 					"sv_lati":      "<?php echo WT_Filter::escapeJs($gmark['sv_lati']     ); ?>",
 					"sv_long":      "<?php echo WT_Filter::escapeJs($gmark['sv_long']     ); ?>",
 					"sv_bearing":   "<?php echo WT_Filter::escapeJs($gmark['sv_bearing']  ); ?>",


### PR DESCRIPTION
I noticed the google map flags didn't show up anymore on the map at the indi pages. I figured out this is caused by a wrongly named variable. Just a little change to fix this.
