### PR TITLE
Combine gedcom_news & user_blog modules

### DIFF
--- a/modules_v3/blog/db_schema/db_schema_0_1.php
+++ b/modules_v3/blog/db_schema/db_schema_0_1.php
@@ -1,0 +1,52 @@
+<?php
+// Update the news/blog module database schema from version 0 to version 1
+//
+// Version 0: empty database
+// Version 1: create the tables, as per PGV 4.2.1
+//
+// The script should assume that it can be interrupted at
+// any point, and be able to continue by re-running the script.
+// Fatal errors, however, should be allowed to throw exceptions,
+// which will be caught by the framework.
+// It shouldn't do anything that might take more than a few
+// seconds, for systems with low timeout values.
+//
+// webtrees: Web based Family History software
+// Copyright (C) 2013 webtrees development team.
+//
+// Derived from PhpGedView
+// Copyright (C) 2009 Greg Roach
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+if (!defined('WT_WEBTREES')) {
+	header('HTTP/1.0 403 Forbidden');
+	exit;
+}
+
+WT_DB::exec(
+	"CREATE TABLE IF NOT EXISTS `##news` (".
+	" n_id       INTEGER AUTO_INCREMENT NOT NULL,".
+	" n_username VARCHAR(100)           NOT NULL,".
+	" n_date     INTEGER                NOT NULL,".
+	" n_title    VARCHAR(255)           NOT NULL,".
+	" n_text     TEXT                   NOT NULL,".
+	" PRIMARY KEY     (n_id),".
+	"         KEY ix1 (n_username)".
+	") COLLATE utf8_unicode_ci ENGINE=InnoDB"
+);
+
+// Update the version to indicate success
+WT_Site::preference($schema_name, $next_version);

--- a/modules_v3/blog/db_schema/db_schema_1_2.php
+++ b/modules_v3/blog/db_schema/db_schema_1_2.php
@@ -1,0 +1,82 @@
+<?php
+// Update the news/blog module database schema from version 1 to version 2
+//
+// The script should assume that it can be interrupted at
+// any point, and be able to continue by re-running the script.
+// Fatal errors, however, should be allowed to throw exceptions,
+// which will be caught by the framework.
+// It shouldn't do anything that might take more than a few
+// seconds, for systems with low timeout values.
+//
+// webtrees: Web based Family History software
+// Copyright (C) 2013 webtrees development team.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+if (!defined('WT_WEBTREES')) {
+	header('HTTP/1.0 403 Forbidden');
+	exit;
+}
+
+// Add new columns
+try {
+	WT_DB::exec(
+		"ALTER TABLE `##news`".
+		" ADD user_id INTEGER NULL AFTER n_id,".
+		" ADD gedcom_id INTEGER NULL AFTER user_id,".
+		" ADD updated TIMESTAMP ON UPDATE CURRENT_TIMESTAMP DEFAULT CURRENT_TIMESTAMP,".
+		" ADD KEY news_ix1 (user_id, updated),".
+		" ADD KEY news_ix2 (gedcom_id, updated)"
+	);
+} catch (PDOException $ex) {
+	// Already updated?
+}
+
+// Migrate data from the old columns to the new ones
+try {
+	WT_DB::exec(
+		"UPDATE `##news` n".
+		" LEFT JOIN `##gedcom` g ON (n.n_username=g.gedcom_name)".
+		" LEFT JOIN `##user` u ON (n.n_username=u.user_name)".
+		" SET n.gedcom_id=g.gedcom_id, n.user_id=u.user_id, updated=FROM_UNIXTIME(n_date)"
+	);
+} catch (PDOException $ex) {
+	// Already updated?
+}
+
+// Delete orphaned rows
+try {
+	WT_DB::exec(
+		"DELETE FROM `##news` WHERE user_id IS NULL AND gedcom_id IS NULL"
+	);
+} catch (PDOException $ex) {
+	// Already updated?
+}
+
+// Delete/rename old columns
+try {
+	WT_DB::exec(
+		"ALTER TABLE `##news`".
+		" DROP n_username, DROP n_date,".
+		" CHANGE n_id news_id INTEGER NOT NULL AUTO_INCREMENT,".
+		" CHANGE n_title subject VARCHAR(255) COLLATE utf8_unicode_ci,".
+		" CHANGE n_text body TEXT COLLATE utf8_unicode_ci"
+	);
+} catch (PDOException $ex) {
+	// Already updated?
+}
+
+// Update the version to indicate success
+WT_Site::preference($schema_name, $next_version);

--- a/modules_v3/blog/db_schema/db_schema_2_3.php
+++ b/modules_v3/blog/db_schema/db_schema_2_3.php
@@ -1,0 +1,53 @@
+<?php
+// Update the news/blog module database schema from version 2 to 3
+// - add foreign key constraints
+//
+// The script should assume that it can be interrupted at
+// any point, and be able to continue by re-running the script.
+// Fatal errors, however, should be allowed to throw exceptions,
+// which will be caught by the framework.
+// It shouldn't do anything that might take more than a few
+// seconds, for systems with low timeout values.
+//
+// webtrees: Web based Family History software
+// Copyright (C) 2013 webtrees development team.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+if (!defined('WT_WEBTREES')) {
+	header('HTTP/1.0 403 Forbidden');
+	exit;
+}
+
+// Delete any data that might violate the new constraints
+WT_DB::exec(
+	"DELETE FROM `##news`".
+	" WHERE user_id   NOT IN (SELECT user_id   FROM `##user`  )".
+	" OR    gedcom_id NOT IN (SELECT gedcom_id FROM `##gedcom`)"
+);
+
+// Add the new constraints
+try {
+	WT_DB::exec(
+		"ALTER TABLE `##news`".
+		" ADD FOREIGN KEY news_fk1 (user_id  ) REFERENCES `##user`   (user_id)   ON DELETE CASCADE,".
+		" ADD FOREIGN KEY news_fk2 (gedcom_id) REFERENCES `##gedcom` (gedcom_id) ON DELETE CASCADE"
+	);
+} catch (PDOException $ex) {
+	// Already updated?
+}
+
+// Update the version to indicate success
+WT_Site::preference($schema_name, $next_version);

--- a/modules_v3/blog/module.php
+++ b/modules_v3/blog/module.php
@@ -1,0 +1,280 @@
+<?php
+// Classes and libraries for module system
+//
+// webtrees: Web based Family History software
+// Copyright (C) 2013 webtrees development team.
+//
+// Derived from PhpGedView
+// Copyright (C) 2010 John Finlay
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+if (!defined('WT_WEBTREES')) {
+	header('HTTP/1.0 403 Forbidden');
+	exit;
+}
+
+// Create tables, if not already present
+try {
+	WT_DB::updateSchema(WT_ROOT . WT_MODULES_DIR . 'gedcom_news/db_schema/', 'NB_SCHEMA_VERSION', 3);
+} catch (PDOException $ex) {
+	// The schema update scripts should never fail.  If they do, there is no clean recovery.
+	die($ex);
+}
+
+class blog_WT_Module extends WT_Module implements WT_Module_Block {
+
+	CONST LIMIT_NONE = 0;
+	CONST LIMIT_BY_AGE = 1;
+	CONST LIMIT_BY_NUMBER = 2;
+	CONST LIMIT_BY_SCROLLBAR = 3;
+
+	// Extend class WT_Module
+	public function getTitle() {
+		return WT_I18N::translate('News and Journal');
+	}
+
+	// Extend class WT_Module
+	public function getDescription() {
+		return WT_I18N::translate('Site or personal journal');
+	}
+
+	public function modAction($mod_action) {
+		$ctype				= WT_Filter::get('ctype');
+		$isgedcom			= ($ctype === 'gedcom');
+		$news['gedcom_id']	= $isgedcom ? WT_GED_ID : null;
+		$news['user_id']	= $isgedcom ? null : WT_USER_ID;
+		$news['id']			= WT_Filter::getInteger('news_id');
+		$news['title']		= WT_Filter::post('title', null, '');
+		$news['date']		= WT_Filter::postInteger('date', 0, PHP_INT_MAX, WT_TIMESTAMP);
+		$news['text']		= WT_Filter::post('text', null, '');
+
+		switch ($mod_action) {
+			case 'add':
+				$this->editForm($news);
+				break;
+			case 'edit':
+				$this->editForm(getNewsItem($news['id']));
+				break;
+			case 'save':
+				if (WT_Filter::checkCsrf()) {
+					if (!$news['id']) {
+						unset($news['id']);
+					}
+					addNews($news);
+				}
+				break;
+// Because of csrf implementation, delete is a two stage function:
+// firstly the user clicks the delete link, this pops up the confirmation form
+// then on clicking the delete button on the form the deleteitem function is run
+			case 'deleteform':
+				$this->deleteForm(getNewsItem($news['id']));
+				break;
+			case 'deleteitem':
+				if (WT_Filter::checkCsrf()) {
+					deleteNews($news['id']);
+				}
+				header('Location: index.php?ctype=' . $ctype);
+				break;
+		}
+	}
+
+	// Implement class WT_Module_Block
+	public function getBlock($block_id, $template = true, $cfg = null) {
+		global $ctype;
+
+		define('SECS_PER_DAY', 60 * 60 * 24);
+		define('ISGEDCOM', $ctype === 'gedcom');
+		define('SHOWCONTROLS', (ISGEDCOM && WT_USER_GEDCOM_ADMIN) || (!ISGEDCOM && WT_USER_ID));
+
+		// sort out the configuration parameters
+		if ($cfg) {
+			foreach (array('limit', 'flag') as $name) {
+				$$name = array_key_exists($name, $cfg) ? $cfg[$name] : null;
+			}
+		} elseif (WT_Filter::getBool('archive')) {
+			$flag = 0;
+			$limit = self::LIMIT_NONE;
+		} else {
+			$flag  = (int) get_block_setting($block_id, "flag", 0);
+			$limit = (int) get_block_setting($block_id, "limit", self::LIMIT_NONE);
+		}
+
+		if (SHOWCONTROLS) {
+			$title = '<span class="icon-admin" title="' . WT_I18N::translate('Configure') . '" onclick="modalDialog(\'block_edit.php?block_id=' . $block_id . '\', \'' . $this->getTitle() . '\');"></span>';
+		} else {
+			$title = '';
+		}
+		$title .= $this->getTitle();
+
+		$content = '';
+		$hitlimit = false;
+		$usernews = ISGEDCOM ? getGedcomNews(WT_GED_ID) : getUserNews(WT_USER_ID); // should have one getNews function
+
+		if (count($usernews) == 0) {
+			$content .= "<div class='news_box'>" .
+				"<div class='news_title'>" .
+				WT_I18N::translate('There are no articles available') .
+				"</div>" .
+				"</div>";
+		} else {
+			$c = 0;
+			foreach ($usernews as $news) {
+				if (($limit === self::LIMIT_BY_NUMBER && ++$c > $flag) ||
+					($limit === self::LIMIT_BY_AGE && (int) ((WT_TIMESTAMP - $news['date']) / SECS_PER_DAY) > $flag)) {
+					$hitlimit = true;
+					break;
+				}
+				if ($news["text"] == strip_tags($news["text"])) {
+					$news["text"] = nl2br($news["text"], false);
+				}
+				$content .= "<div class='news_box'>" .
+					"<div class='news_title'>" .
+					WT_Filter::escapeHtml($news['title']) .
+					"</div>" .
+					"<div class='news_date'>" .
+					format_timestamp($news['date']) .
+					"</div>" .
+					$news["text"];
+
+				// Print Admin options for this News item
+				if (SHOWCONTROLS) {
+					$content .= '<hr>' .
+						"<a href='index.php?ctype={$ctype}' onclick=\"modalDialog('module.php?mod=" . $this->getName() . "&amp;mod_action=edit&amp;news_id={$news['id']}&amp;ctype={$ctype}','" . WT_I18N::translate('Edit article') . "');return false;\">" . WT_I18N::translate('Edit') . "</a> | " .
+						"<a href='index.php?ctype={$ctype}' onclick=\"modalDialog('module.php?mod=" . $this->getName() . "&amp;mod_action=deleteform&amp;news_id={$news['id']}','" . WT_I18N::translate('Delete article') . "');return false;\">" . WT_I18N::translate('Delete') . "</a>";
+//						"<a href=\"module.php?mod=" . $this->getName() . "&amp;mod_action=delete&amp;news_id={$news['id']}&amp;ctype={$ctype}\" onclick=\"return confirm('" . WT_I18N::translate('Are you sure you want to delete this News entry?') . "');\">" . WT_I18N::translate('Delete') . "</a>";
+				}
+				$content .= "</div>";
+			}
+		}
+		if (SHOWCONTROLS) {
+			$content .= "<a href='index.php?ctype={$ctype}' onclick=\"modalDialog('module.php?mod=" . $this->getName() . "&amp;mod_action=add&amp;ctype={$ctype}','" . WT_I18N::translate('Add article') . "');return false;\">" . WT_I18N::translate('Add a new article') . "</a>";
+			if ($hitlimit) {
+				$content .= " | ";
+			}
+		}
+		if ($hitlimit) {
+			$content .= "<a href=\"index.php?archive=true&amp;ctype={$ctype}\">" . WT_I18N::translate('View archive') . "</a>";
+			$content .= help_link('gedcom_news_archive');
+		}
+
+		if ($template) {
+			// $id, $class, $title & $content are needed by the template
+			$id = $this->getName() . $block_id;
+			$class = $this->getName() . '_block';
+			if ($limit === self::LIMIT_BY_SCROLLBAR) {
+				require WT_THEME_DIR . 'templates/block_small_temp.php';
+			} else {
+				require WT_THEME_DIR . 'templates/block_main_temp.php';
+			}
+		} else {
+			return $content;
+		}
+	}
+
+	// Implement class WT_Module_Block
+	public function loadAjax() {
+		return false;
+	}
+
+	// Implement class WT_Module_Block
+	public function isUserBlock() {
+		return true;
+	}
+
+	// Implement class WT_Module_Block
+	public function isGedcomBlock() {
+		return true;
+	}
+
+	// Implement class WT_Module_Block
+	public function configureBlock($block_id) {
+		if (WT_Filter::postBool('save')) {
+			set_block_setting($block_id, 'limit', WT_Filter::postInteger('limit'));
+			set_block_setting($block_id, 'flag', WT_Filter::postInteger('flag'));
+			exit;
+		}
+
+		$limit = get_block_setting($block_id, 'limit', self::LIMIT_NONE);
+		$flag = get_block_setting($block_id, 'flag', 0);
+		?>
+		<td class="descriptionbox wrap width33">
+			<?php echo WT_I18N::translate('Limit display by:') . help_link('gedcom_news_limit'); ?>
+		</td>
+		<td class="optionbox">
+			<select name="limit">
+				<option value='<?php echo self::LIMIT_NONE ?>' <?php echo $limit == self::LIMIT_NONE ? 'selected="selected"' : ''; ?>><?php echo WT_I18N::translate('No limit'); ?></option>
+				<option value='<?php echo self::LIMIT_BY_AGE ?>' <?php echo $limit == self::LIMIT_BY_AGE ? 'selected="selected"' : ''; ?>><?php echo WT_I18N::translate('Age of item'); ?></option>
+				<option value='<?php echo self::LIMIT_BY_NUMBER ?>' <?php echo $limit == self::LIMIT_BY_NUMBER ? 'selected="selected"' : ''; ?>><?php echo WT_I18N::translate('Number of items'); ?></option>
+				<option value='<?php echo self::LIMIT_BY_SCROLLBAR ?>' <?php echo $limit == self::LIMIT_BY_SCROLLBAR ? 'selected="selected"' : ''; ?>><?php echo WT_I18N::translate('Add a scrollbar when block contents grow'); ?></option>
+			</select>
+		</td>
+		</tr>
+		<tr>
+			<td class="descriptionbox wrap width33">
+				<?php echo WT_I18N::translate('Limit:') . help_link('gedcom_news_flag'); ?>
+			</td>
+			<td class="optionbox">
+				<input type="text" name="flag" size="4" maxlength="4" value="<?php echo $flag; ?>">
+			</td>
+		</tr>
+		<?php
+	}
+
+	private function editForm($news) {
+		$controller = new WT_Controller_Base();
+		$controller
+			->pageHeader();
+
+		if (array_key_exists('ckeditor', WT_Module::getActiveModules())) {
+			ckeditor_WT_Module::enableEditor($controller);
+		}
+		$ctype = $news['gedcom_id'] != null ? 'gedcom' : 'user';
+		?>
+		<form name="messageform" method="post" action="module.php?mod=<?php echo $this->getName(); ?>&amp;mod_action=save&amp;news_id=<?php echo $news['id']; ?>&amp;ctype=<?php echo $ctype; ?>" onsubmit="return modalDialogSubmitAjax(this);">
+			<div class='givn-list'>
+				<?php echo WT_Filter::getCsrf(); ?>
+				<input type="hidden" name="date" value="<?php echo $news['date']; ?>">
+				<label for="title" class="news_title"><?php echo WT_I18N::translate('Title'); ?>:</label>
+				<input type="text" id="title" name="title" size="50" dir="auto" autofocus value="<?php echo $news['title']; ?>">
+				<label for="text" class="news_title" style="display:block; padding:5px 0"><?php echo WT_I18N::translate('Entry Text:'); ?></label>
+				<textarea id="text" name="text" class="html-edit" cols="80" rows="10" dir="auto"><?php echo WT_Filter::escapeHtml($news['text']); ?></textarea>
+			</div>
+			<input type="submit" value="<?php echo WT_I18N::translate('save'); ?>">
+		</form>
+		<?php
+	}
+
+	private function deleteForm($news) {
+		Zend_Session::writeClose();
+		$ctype = $news['gedcom_id'] != null ? 'gedcom' : 'user';
+		?>
+		<form name="msgdeleteform" method="post" action="module.php?mod=<?php echo $this->getName(); ?>&amp;mod_action=deleteitem&amp;news_id=<?php echo $news['id']; ?>&amp;ctype=<?php echo $ctype; ?>" onsubmit="return modalDialogSubmitAjax(this);">
+			<?php echo WT_Filter::getCsrf(); ?>
+			<fieldset>
+				<div class='news_title'>
+					<?php echo WT_I18N::translate('Are you sure you want to delete this article?'); ?>
+				</div>
+				<div>
+					"<?php echo $news['title']?>"
+				</div>
+			</fieldset>
+			<button type="submit" value="submit"><?php echo WT_I18N::translate('Delete'); ?></button>
+		</form>
+		<?php
+	}
+
+
+}


### PR DESCRIPTION
Hi Greg,

When I was looking at fixing the CKEditor problem with editnews.php, I noticed a TODO in there about moving
its functions into the module

So I've done it. The gedcom_news & user_journal modules are both now incorporated in the blog module.

The add/edit form is now a modal dialog and whereas previously the user_journal module had a hard
coded option for deciding what happened if the contents overflowed the window (scroll bar), now both news &
journal have configurable options.

The downside is I've changed the configuration settings that are saved [class constants (integers) instead of
text strings], so if this module is adopted as a replacement either the user will have to redo his preferences
or a migration will be needed. New translations will also be needed.

I also incorporated the csrf stuff for saving or deleting articles and this raised a problem for the delete
function, previously the anchor had an onclick function that popped up a confirm dialog and if accepted just
called the delete routine. To incorporated the csrf stuff I had to create a modal dialog with a form (ugly!)
so that I could post the csrf token. Maybe a need here for a generic confirmation dialog?

Another thing I noticed was the addNews, deleteNews, getUserNews & getGedcomNews functions are in
authentication.php - shouldn't they be in functions_db.php?

The gedcom_news, user_journal & now the blog module call getNewsItem, getUserNews or getGedcomNews as
appropriate - it should be simple to convert these to one function - just tell it the type of id we're giving
it.

Phew, its taken longer writing this that do the coding!
