### PR TITLE
bug 1076873 - sitemap.xml contains empty <urlset> tag

### DIFF
--- a/modules_v3/sitemap/module.php
+++ b/modules_v3/sitemap/module.php
@@ -120,7 +120,8 @@ class sitemap_WT_Module extends WT_Module implements WT_Module_Config {
 		if ($timestamp > WT_TIMESTAMP - self::CACHE_LIFE) {
 			$data=get_module_setting($this->getName(), 'sitemap-'.$ged_id.'-'.$rec_type.'-'.$volume.'.xml');
 		} else {
-			$data='';
+			$tree=WT_Tree::get($ged_id);
+			$data='<url><loc>'.WT_SERVER_NAME.WT_SCRIPT_PATH.'index.php?ctype=gedcom&amp;ged='.$tree->tree_name_url.'</loc></url>'.PHP_EOL;
 			$records=array();
 			switch ($rec_type) {
 			case 'i':


### PR DESCRIPTION
add a link to the tree's home page as the first entry in every sitemap.  This solves two problems:
1) the home page will be added to the sitemap
2) none of the sitemaps will be empty
