### PR TITLE
target="blank" should be target="_blank"

### DIFF
--- a/library/WT/Filter.php
+++ b/library/WT/Filter.php
@@ -85,7 +85,7 @@ class WT_Filter {
 			'/' . addcslashes('(?!>)' . self::URL_REGEX . '(?!</a>)', '/') . '/i',
 			create_function( // Insert soft hyphens into the replaced string
 				'$m',
-				'return "<a href=\"" . $m[0] . "\" target=\"blank\">" . preg_replace("/\b/", "&shy;", $m[0]) . "</a>";'
+				'return "<a href=\"" . $m[0] . "\" target=\"_blank\">" . preg_replace("/\b/", "&shy;", $m[0]) . "</a>";'
 			),
 			WT_Filter::escapeHtml($text)
 		);


### PR DESCRIPTION
I noticed external links entered as citation details to a source were opened in the same window in stead of in a new one. This is caused by the expandUrls function in WT_Filter. Target="blank" should be target="_blank". Also according to the html5 specs: http://www.w3.org/TR/2010/WD-html5-20100624/browsers.html#valid-browsing-context-name-or-keyword
