### PR TITLE
Fix: status messages do not show up in pop-up frames on the xenea theme.

### DIFF
--- a/themes/xenea/header.php
+++ b/themes/xenea/header.php
@@ -149,7 +149,9 @@ if ($view!='simple') { // Use "simple" headers for popup windows
 				unset($menu_items, $menu);
 	echo
 		'</ul>',  // <ul id="main-menu">
-		'</div>', // <div id="topMenu">
-		WT_FlashMessages::getHtmlMessages(); // Feedback from asynchronous actions
+		'</div>'; // <div id="topMenu">
 }
-echo $javascript, '<div id="content">';
+echo
+	$javascript,
+	WT_FlashMessages::getHtmlMessages(), // Feedback from asynchronous actions
+	'<div id="content">';


### PR DESCRIPTION
I had the same error in the JustBlack theme which is originally derived from the xenea theme.

In all other themes it works well.
