### PR TITLE
Fixed redirection bug

### DIFF
--- a/includes/session.php
+++ b/includes/session.php
@@ -168,9 +168,12 @@ define('WT_SERVER_NAME',
 	(empty($_SERVER['SERVER_PORT']) || $_SERVER['SERVER_PORT']==80 ? '' : ':'.$_SERVER['SERVER_PORT'])
 );
 
+// REDIRECT_URL should be set in the case of Apache following a RedirectRule
 // SCRIPT_NAME should always be correct, but is not always present.
 // PHP_SELF should always be present, but may have trailing path: /path/to/script.php/FOO/BAR
-if (!empty($_SERVER['SCRIPT_NAME'])) {
+if (!empty($_SERVER['REDIRECT_URL'])) {
+	define('WT_SCRIPT_PATH', substr($_SERVER['REDIRECT_URL'], 0, stripos($_SERVER['REDIRECT_URL'], WT_SCRIPT_NAME)));
+} elseif (!empty($_SERVER['SCRIPT_NAME'])) {
 	define('WT_SCRIPT_PATH', substr($_SERVER['SCRIPT_NAME'], 0, stripos($_SERVER['SCRIPT_NAME'], WT_SCRIPT_NAME)));
 } elseif (!empty($_SERVER['PHP_SELF'])) {
 	define('WT_SCRIPT_PATH', substr($_SERVER['PHP_SELF'], 0, stripos($_SERVER['PHP_SELF'], WT_SCRIPT_NAME)));


### PR DESCRIPTION
In the case of MOD_REWRITE being used on an Apache server to forge the webtrees url,
webtrees would try to redirect to its source directory path and would not respect
the SERVER_URL site setting (causing an infinite redirect loop).

Further explanation:

Suppose the webtrees source is in a folder named `/webtrees` in the document root of the webserver but suppose you want the URL for your site to be something like `http://example.com/familytree`.

Previously webtrees would not handle this situation correctly and set the `WT_SCRIPT_PATH` constant based on its file path (`/webtrees` from `$_SERVER['SCRIPT_NAME']`). This constant however is used in URL generation e.g. `LOGIN_URL`. It should therefore be calculated from the incoming URL.

The result is all links generated which are based on `WT_SCRIPT_PATH` will take the user to a different URL root; moreover trying to set the `SERVER_URL` site setting in the database causes in infinite redirect loop since Apache tries to redirect to the favoured URL and webtrees sees it does not match the file directory and tries to redirect back.

This commit fixes the bug - if only for the Apache redirect case. I believe this is at least better than no fix at all.
