### PR TITLE
Don't include the HTTPS port in WT_SERVER_NAME when it's the default

### DIFF
--- a/includes/session.php
+++ b/includes/session.php
@@ -165,10 +165,11 @@ if (!ini_get('date.timezone')) {
 // TODO: we ought to generate this dynamically, but lots of code currently relies on this global
 $QUERY_STRING=isset($_SERVER['QUERY_STRING']) ? $_SERVER['QUERY_STRING'] : '';
 
+$https = !empty($_SERVER['HTTPS']) && in_array($_SERVER['HTTPS'], array('1', 'on', 'On', 'ON'));
 define('WT_SERVER_NAME',
-	(empty($_SERVER['HTTPS']) || !in_array($_SERVER['HTTPS'], array('1', 'on', 'On', 'ON')) ?  'http://' : 'https://').
+	($https ?  'https://' : 'http://').
 	(empty($_SERVER['SERVER_NAME']) ? '' : $_SERVER['SERVER_NAME']).
-	(empty($_SERVER['SERVER_PORT']) || $_SERVER['SERVER_PORT']==80 ? '' : ':'.$_SERVER['SERVER_PORT'])
+	(empty($_SERVER['SERVER_PORT']) || (!$https && $_SERVER['SERVER_PORT']==80) || ($https && $_SERVER['SERVER_PORT']==443) ? '' : ':'.$_SERVER['SERVER_PORT'])
 );
 
 // SCRIPT_NAME should always be correct, but is not always present.


### PR DESCRIPTION
This also fixes including the port when https is over port 80 (uncommon).

I tested the following 4 combinations:
1. HTTP over port 80
2. HTTPS over port 443
3. HTTP over port 8080
4. HTTPS over port 8081
