### PR TITLE
Javascript modal dialog changes

### DIFF
--- a/help_text.php
+++ b/help_text.php
@@ -29,8 +29,6 @@
 define('WT_SCRIPT_NAME', 'help_text.php');
 require './includes/session.php';
 
-$controller=new WT_Controller_Ajax();
-
 $help = WT_Filter::get('help');
 switch ($help) {
 	//////////////////////////////////////////////////////////////////////////////
@@ -1509,8 +1507,7 @@ default:
 	}
 	break;
 }
-
-$controller->pageHeader();
-
-echo '<span class="helpheader">', $title, '</span>';
-echo '<div class="helpcontent">', $text,'</div>';
+// This file is called by a getJSON call so return the data
+// in correct format
+header('Content-Type: application/json');
+echo json_encode(array('title'=>$title,'content'=>$text));


### PR DESCRIPTION
Uses JSON to call help_text.php.

The diff display makes it difficult to see what I've done, but I've modified modalDialog(), helpDialog() & modalNotes to use jQuery to create a DIV element with title & html attributes populated by whatever call method is appropriate and then pass that element to a new function displayDialog() which instantiates and displays the dialog and handles clicking on the overlay and tidyup on close (which at least one of the old functions didn't - can't remember which off hand)
