### PR TITLE
Fix: W3C validation error on medialist.php

### DIFF
--- a/medialist.php
+++ b/medialist.php
@@ -298,7 +298,7 @@ if ($search) {
 			}
 			echo '</td></tr></table>';
 			echo '</td>';
-			if ((++$n) % $columns == 0) {
+			if ((++$n) % $columns == 0 && $n < $count) {
 				echo '</tr><tr>';
 			}
 		} // end media loop


### PR DESCRIPTION
Just one more W3C validation error solved at the medialist page. Without this change this error occurs: "Row (n) of a row group established by a tbody element has no cells beginning on it". This is because at the end of <tbody> an empty <tr></tr> is created without <td> tag. This change prevents that.
