### PR TITLE
Default meta description contents contained HTML

### DIFF
--- a/library/WT/Controller/Page.php
+++ b/library/WT/Controller/Page.php
@@ -137,7 +137,7 @@ class WT_Controller_Page extends WT_Controller_Base {
 		$META_ROBOTS      = $this->meta_robots;
 		$META_DESCRIPTION = WT_GED_ID ? get_gedcom_setting(WT_GED_ID, 'META_DESCRIPTION') : '';
 		if (!$META_DESCRIPTION) {
-			$META_DESCRIPTION = WT_TREE_TITLE;
+			$META_DESCRIPTION = WT_Filter::unescapeHTML(WT_TREE_TITLE);
 		}
 		$META_GENERATOR = WT_WEBTREES . ' ' . WT_VERSION . ' - ' . WT_WEBTREES_URL;
 		$META_TITLE     = WT_GED_ID ? get_gedcom_setting(WT_GED_ID, 'META_TITLE') : '';


### PR DESCRIPTION
`<span dir="auto">` was included in the default meta description attribute.

Reported at http://www.webtrees.net/index.php/en/forum/4-customising/28726-facebook-login-link-from-webtrees-site
