### PR TITLE
#1269075 - Names containing an apostrophe (') are displayed as Name (Nam...

### DIFF
--- a/library/WT/Controller/Individual.php
+++ b/library/WT/Controller/Individual.php
@@ -179,10 +179,11 @@ class WT_Controller_Individual extends WT_Controller_GedcomRecord {
 							case 'SURN':
 								// The SURN field is not necessarily the surname.
 								// Where it is not a substring of the real surname, show it after the real surname.
-								if (strpos($primary_name['surname'], str_replace(',', ' ', $name))!==false) {
-									echo $primary_name['surname'];
+								$surname = WT_Filter::escapeHtml($primary_name['surname']);
+								if (strpos($surname, str_replace(',', ' ', $name))!==false) {
+									echo $surname;
 								} else {
-									echo WT_I18N::translate('%1$s (%2$s)', $primary_name['surname'], $name);
+									echo WT_I18N::translate('%1$s (%2$s)', $surname, $name);
 								}
 								break;
 							default:


### PR DESCRIPTION
Bug #1269075
The `$name` variable is compared to the surname extracted for the individual, to decide whether or not to display the potential different surname in brackets.
However; `$name` goes through the `WT_Filter::escapeHtml` filter whereas `$primary_name['surname']` does not, which is a problem when comparing a special character with its equivalent HTML (for instance the quote ')
