### PR TITLE
Make $translation_adapter public so it can be used by custom modules to add their own translations

### DIFF
--- a/library/WT/I18N.php
+++ b/library/WT/I18N.php
@@ -132,9 +132,6 @@ class WT_I18N {
 		// Load the translation file
 		self::$translation_adapter = new Zend_Translate('gettext', WT_ROOT.'language/'.$locale.'.mo', $locale);
 
-		// Deprecated - some custom modules use this to add translations
-		Zend_Registry::set('Zend_Translate', self::$translation_adapter);
-
 		// Load any local user translations
 		if (is_dir(WT_DATA_DIR.'language')) {
 			if (file_exists(WT_DATA_DIR.'language/'.$locale.'.mo')) {


### PR DESCRIPTION
Since Zend_Registry::get('Zend_Translate') is deprecated, a work around is to use parent::__construct() in the module constructor.

But if you make the WT_I18N variabele $translation_adapter public then this adapter can be used by custom modules to add their own translations and isn't it necessary to keep the deprecated function alive.

A custom translation then can be implemented in the module constructor in this way:

```
WT_I18N::$translation_adapter->addTranslation(
        new Zend_Translate('gettext', WT_MODULES_DIR.$this->getName().'/language/'.WT_LOCALE.'.mo', WT_LOCALE)
);
```
