### PR TITLE
Rationalize jQuery dialog usage

### DIFF
--- a/help_text.php
+++ b/help_text.php
@@ -29,8 +29,6 @@
 define('WT_SCRIPT_NAME', 'help_text.php');
 require './includes/session.php';
 
-$controller=new WT_Controller_Ajax();
-
 $help = WT_Filter::get('help');
 switch ($help) {
 	//////////////////////////////////////////////////////////////////////////////
@@ -1509,8 +1507,7 @@ default:
 	}
 	break;
 }
-
-$controller->pageHeader();
-
-echo '<span class="helpheader">', $title, '</span>';
-echo '<div class="helpcontent">', $text,'</div>';
+// This file is called by a getJSON call so return the data
+// in correct format
+header('Content-Type: application/json');
+echo json_encode(array('title'=>$title,'content'=>$text));


### PR DESCRIPTION
Previous submission used a true modal dialog. This caused problems when the content in the dialog box itself opened a dialog e.g CKEditor. 

A non-modal dialog is now created (same as current - mea culpa) but with improved sequencing when there are multiple dialogs open and the overlay is clicked to close (last opened - first closed etc.)

new functions:
displayDialog() - responsible for creating and closing dialogs.
modalConfirm() - a replacement for the native javascript confirm() - usage: modalConfirm(title,text).then(function (reply) {...};

modified functions
modalDialog(), helpDialog() & modalNotes  - each is called in a different way but they
each create a div with a title & html and then call displayDialog()

helpDialog also uses JSON to call help_text.php (only one call now)
