### PR TITLE
Remove embedded styling from FamNav module

### DIFF
--- a/modules_v3/family_nav/module.php
+++ b/modules_v3/family_nav/module.php
@@ -52,55 +52,69 @@ class family_nav_WT_Module extends WT_Module implements WT_Module_Sidebar {
 	// Implement WT_Module_Sidebar
 	public function getSidebarContent() {
 		global $controller;
-		global $spouselinks, $parentlinks;
 
 		ob_start();
 
-		echo '<div id="sb_family_nav_content"><table class="nav_content">';
+		?>
+		<div id="sb_family_nav_content">
+			<table class="nav_content">
+
+		<?php
 
 		//-- parent families -------------------------------------------------------------
-		foreach ($controller->record->getChildFamilies() as $family) {
-			echo '<tr><td style="padding-bottom:4px;" class="center" colspan="2">';
-			echo '<a class="famnav_link" href="' . $family->getHtmlUrl() . '">';
-			echo '<b>' . $controller->record->getChildFamilyLabel($family) . '</b>';
-			echo '</a>';
-			echo '</td></tr>';
+		foreach ($controller->record->getChildFamilies() as $family) { ?>
+				<tr>
+					<td class="center" colspan="2">
+						<a class="famnav_title" href="<?php echo $family->getHtmlUrl(); ?>">
+							<?php echo $controller->record->getChildFamilyLabel($family); ?>
+						</a>
+					</td>
+				</tr>
+			<?php
 			$this->drawFamily($controller->record, $family);
 		}
 
 		//-- step parents ----------------------------------------------------------------
-		foreach ($controller->record->getChildStepFamilies() as $family) {
-			echo '<tr><td><br></td><td></td></tr>';
-			echo '<tr><td style="padding-bottom: 4px;" class="center" colspan="2">';
-			echo '<a class="famnav_link" href="' . $family->getHtmlUrl() . '">';
-			echo '<b>' . $controller->record->getStepFamilyLabel($family) . '</b>';
-			echo '</a>';
-			echo '</td></tr>';
+		foreach ($controller->record->getChildStepFamilies() as $family) { ?>
+				<tr>
+					<td class="center" colspan="2">
+						<a class="famnav_title" href="<?php echo $family->getHtmlUrl(); ?>">
+							<?php echo $controller->record->getStepFamilyLabel($family); ?>
+						</a>
+					</td>
+				</tr>
+			<?php
 			$this->drawFamily($controller->record, $family);
 		}
 
 		//-- spouse and children --------------------------------------------------
-		foreach ($controller->record->getSpouseFamilies() as $family) {
-			echo '<tr><td><br></td><td></td></tr>';
-			echo '<tr><td style="padding-bottom: 4px;" class="center" colspan="2">';
-			echo '<a class="famnav_link" href="' . $family->getHtmlUrl() . '">';
-			echo '<b>' . WT_I18N::translate('Immediate Family') . '</b>';
-			echo '</a>';
-			echo '</td></tr>';
+		foreach ($controller->record->getSpouseFamilies() as $family) { ?>
+				<tr>
+					<td class="center" colspan="2">
+						<a class="famnav_title" href="<?php echo $family->getHtmlUrl(); ?>">
+							<?php echo WT_I18N::translate('Immediate Family'); ?>
+						</a>
+					</td>
+				</tr>
+			<?php
 			$this->drawFamily($controller->record, $family);
 		}
 		//-- step children ----------------------------------------------------------------
-		foreach ($controller->record->getSpouseStepFamilies() as $family) {
-			echo '<tr><td><br></td><td></td></tr>';
-			echo '<tr><td style="padding-bottom: 4px;" class="center" colspan="2">';
-			echo '<a class="famnav_link" href="' . $family->getHtmlUrl() . '">';
-			echo '<b>' . $family->getFullName() . '</b>';
-			echo '</a>';
-			echo '</td></tr>';
+		foreach ($controller->record->getSpouseStepFamilies() as $family) { ?>
+				<tr>
+					<td class="center" colspan="2">
+						<a class="famnav_title" href="<?php echo $family->getHtmlUrl(); ?>">
+							<?php echo $family->getFullName(); ?>
+						</a>
+					</td>
+				</tr>
+			<?php
 			$this->drawFamily($controller->record, $family);
 		}
-
-		echo '</table></div>';
+		?>
+			</table>
+		</div>
+		<?php
 
 		return ob_get_clean();
 	}
@@ -123,12 +137,21 @@ class family_nav_WT_Module extends WT_Module implements WT_Module_Sidebar {
 				$menu->addClass('', 'submenu flyout2');
 				$submenu = new WT_Menu($this->print_pedigree_person_nav($spouse) . $parentlinks);
 				$menu->addSubMenu($submenu);
-				echo '<tr><td class="facts_label" style="width:75px;">', $menu->getMenu(), '</td><td class="center ', $controller->getPersonStyle($spouse), ' nam">';
-				echo '<a class="famnav_link" href="' . $spouse->getHtmlUrl() . '">';
-				echo $spouse->getFullName();
-				echo '</a>';
-				echo '<div class="font9">' . $spouse->getLifeSpan() . '</div>';
-				echo '</td></tr>';
+				?>
+				<tr>
+					<td class="facts_label">
+						<?php echo $menu->getMenu(); ?>
+					</td>
+					<td class="center <?php echo $controller->getPersonStyle($spouse); ?> nam">
+						<a class="famnav_link" href="<?php echo $spouse->getHtmlUrl(); ?>">
+							<?php echo $spouse->getFullName(); ?>
+						</a>
+						<div class="font9">
+							<?php echo $spouse->getLifeSpan(); ?>
+						</div>
+					</td>
+				</tr>
+				<?php
 			}
 		}
 
@@ -139,12 +162,21 @@ class family_nav_WT_Module extends WT_Module implements WT_Module_Sidebar {
 				$menu->addClass('', 'submenu flyout2');
 				$submenu = new WT_Menu($this->print_pedigree_person_nav($spouse) . $parentlinks);
 				$menu->addSubMenu($submenu);
-				echo '<tr><td class="facts_label" style="width:75px;">', $menu->getMenu(), '</td><td class="center ', $controller->getPersonStyle($spouse), ' nam">';
-				echo '<a class="famnav_link" href="' . $spouse->getHtmlUrl() . '">';
-				echo $spouse->getFullName();
-				echo '</a>';
-				echo '<div class="font9">' . $spouse->getLifeSpan() . '</div>';
-				echo '</td></tr>';
+				?>
+				<tr>
+					<td class="facts_label">
+						<?php echo $menu->getMenu(); ?>
+					</td>
+					<td class="center <?php echo $controller->getPersonStyle($spouse); ?> nam">
+						<a class="famnav_link" href="<?php echo $spouse->getHtmlUrl(); ?>">
+							<?php echo $spouse->getFullName(); ?>
+						</a>
+						<div class="font9">
+							<?php echo $spouse->getLifeSpan(); ?>
+						</div>
+					</td>
+				</tr>
+				<?php
 			}
 		}
 
@@ -155,14 +187,21 @@ class family_nav_WT_Module extends WT_Module implements WT_Module_Sidebar {
 				$menu->addClass('', 'submenu flyout2');
 				$submenu = new WT_Menu($this->print_pedigree_person_nav($child) . $spouselinks);
 				$menu->addSubMenu($submenu);
-				echo '<tr><td class="facts_label" style="width:75px;">';
-				echo $menu->getMenu();
-				echo '</td><td class="center ', $controller->getPersonStyle($child), ' nam">';
-				echo '<a class="famnav_link" href="' . $child->getHtmlUrl() . '">';
-				echo $child->getFullName();
-				echo '</a>';
-				echo '<div class="font9">' . $child->getLifeSpan() . '</div>';
-				echo '</td></tr>';
+				?>
+				<tr>
+					<td class="facts_label">
+						<?php echo $menu->getMenu(); ?>
+					</td>
+					<td class="center <?php echo $controller->getPersonStyle($child); ?> nam">
+						<a class="famnav_link" href="<?php echo $child->getHtmlUrl(); ?>">
+							<?php echo $child->getFullName(); ?>
+						</a>
+						<div class="font9">
+							<?php echo $child->getLifeSpan(); ?>
+						</div>
+					</td>
+				</tr>
+				<?php
 			}
 		}
 	}
@@ -173,31 +212,23 @@ class family_nav_WT_Module extends WT_Module implements WT_Module_Sidebar {
 	}
 
 	function print_pedigree_person_nav($person) {
-		global $SEARCH_SPIDER;
+		global $SEARCH_SPIDER, $spouselinks, $parentlinks, $step_parentlinks;
 
-		global $spouselinks, $parentlinks, $step_parentlinks;
+		$persons		= false;
+		$person_step	= false;
+		$person_parent	= false;
+		$natdad			= false;
+		$natmom			= false;
 
-		$persons = '';
-		$person_step = '';
-		$person_parent = '';
-		$natdad = '';
-		$natmom = '';
-
-		$tmp = array('M'=>'','F'=>'F', 'U'=>'NN');
-		$isF = $tmp[$person->getSex()];
 		$spouselinks      = '';
 		$parentlinks      = '';
 		$step_parentlinks = '';
 
 		if ($person->canShowName() && !$SEARCH_SPIDER) {
 			//-- draw a box for the family flyout
-			$parentlinks      .= '<div class="flyout4"><b>' . WT_I18N::translate('Parents') . '</b></div>';
-			$step_parentlinks .= '<div class="flyout4"><b>' . WT_I18N::translate('Parents') . '</b></div>';
-			$spouselinks      .= '<div class="flyout4"><b>' . WT_I18N::translate('Family' ) . '</b></div>';
-
-			$persons       = '';
-			$person_parent = '';
-			$person_step   = '';
+			$parentlinks      .= '<div class="flyout4">' . WT_I18N::translate('Parents') . '</div>';
+			$step_parentlinks .= '<div class="flyout4">' . WT_I18N::translate('Parents') . '</div>';
+			$spouselinks      .= '<div class="flyout4">' . WT_I18N::translate('Family' ) . '</div>';
 
 			//-- parent families --------------------------------------
 			$fams = $person->getChildFamilies();
@@ -211,24 +242,24 @@ class family_nav_WT_Module extends WT_Module implements WT_Module_Sidebar {
 					// Husband ------------------------------
 					if ($husb || $children) {
 						if ($husb) {
-							$person_parent = 'Yes';
-							$parentlinks .= '<a class="flyout3" href="' . $husb->getHtmlUrl() . '">';
-							$parentlinks .= $husb->getFullName();
-							$parentlinks .= '</a>';
-							$parentlinks .= '<br>';
-							$natdad = 'yes';
+							$person_parent = true;
+							$parentlinks .=
+								'<a class="flyout3" href="' . $husb->getHtmlUrl() . '">' .
+									$husb->getFullName() .
+								'</a>';
+							$natdad = true;
 						}
 					}
 
 					// Wife ------------------------------
 					if ($wife || $children) {
 						if ($wife) {
-							$person_parent = 'Yes';
-							$parentlinks .= '<a class="flyout3" href="' . $wife->getHtmlUrl() . '">';
-							$parentlinks .= $wife->getFullName();
-							$parentlinks .= '</a>';
-							$parentlinks .= '<br>';
-							$natmom = 'yes';
+							$person_parent = true;
+							$parentlinks .=
+								'<a class="flyout3" href="' . $wife->getHtmlUrl() . '">' .
+									$wife->getFullName() .
+								'</a>';
+							$natmom = true;
 						}
 					}
 				}
@@ -242,28 +273,28 @@ class family_nav_WT_Module extends WT_Module implements WT_Module_Sidebar {
 					$wife = $family->getWife($person);
 					$children = $family->getChildren();
 
-					if ($natdad != 'yes') {
+					if (!$natdad) {
 						// Husband -----------------------
 						if ($husb || $children) {
 							if ($husb) {
-								$person_step = 'Yes';
-								$parentlinks .= '<a class="flyout3" href="' . $husb->getHtmlUrl() . '">';
-								$parentlinks .= $husb->getFullName();
-								$parentlinks .= '</a>';
-								$parentlinks .= '<br>';
+								$person_step = true;
+								$parentlinks .=
+									'<a class="flyout3" href="' . $husb->getHtmlUrl() . '">' .
+										$husb->getFullName() .
+									'</a>';
 							}
 						}
 					}
 
-					if ($natmom != 'yes') {
+					if (!$natmom) {
 						// Wife ----------------------------
 						if ($wife || $children) {
 							if ($wife) {
-								$person_step='Yes';
-								$parentlinks .= '<a class="flyout3" href="' . $wife->getHtmlUrl() . '">';
-								$parentlinks .= $wife->getFullName();
-								$parentlinks .= '</a>';
-								$parentlinks .= '<br>';
+								$person_step=true;
+								$parentlinks .=
+									'<a class="flyout3" href="' . $wife->getHtmlUrl() . '">' .
+										$wife->getFullName() .
+									'</a>';
 							}
 						}
 					}
@@ -276,35 +307,36 @@ class family_nav_WT_Module extends WT_Module implements WT_Module_Sidebar {
 				// Spouse ------------------------------
 				$spouse = $family->getSpouse($person);
 				if ($spouse) {
-					$spouselinks .= '<a class="flyout3" href="' . $spouse->getHtmlUrl() . '">';
-					$spouselinks .= $spouse->getFullName();
-					$spouselinks .= '</a>';
-					$spouselinks .= '<br>';
-					if ($spouse->getFullName() != '') {
-						$persons = 'Yes';
-					}
+					$persons = true;
+					$spouselinks .=
+						'<a class="flyout3" href="' . $spouse->getHtmlUrl() . '">' .
+							$spouse->getFullName() .
+						'</a>';
 				}
 
 				// Children ------------------------------   @var $child Person
 				$children = $family->getChildren();
-				foreach ($children as $child) {
-					$persons='Yes';
+				if ($children) {
+					$persons=true;
 					$spouselinks .= '<ul class="clist">';
-					$spouselinks .= '<li class="flyout3">';
-					$spouselinks .= '<a href="' . $child->getHtmlUrl() . '">';
-					$spouselinks .= $child->getFullName();
-					$spouselinks .= '</a>';
-					$spouselinks .= '</li>';
+					foreach ($children as $child) {
+						$spouselinks .=
+							'<li>' .
+								'<a class="flyout3" href="' . $child->getHtmlUrl() . '">' .
+									$child->getFullName() .
+								'</a>' .
+							'</li>';
+					}
 					$spouselinks .= '</ul>';
 				}
 			}
-			if ($persons != 'Yes') {
+			if (!$persons) {
 				$spouselinks .= '(' . WT_I18N::translate('none') . ')';
 			}
-			if ($person_parent != 'Yes') {
+			if (!$person_parent) {
 				$parentlinks .= '(' . WT_I18N::translate_c('unknown family', 'unknown') . ')';
 			}
-			if ($person_step != 'Yes') {
+			if (!$person_step) {
 				$step_parentlinks .= '(' . WT_I18N::translate_c('unknown family', 'unknown') . ')';
 			}
 		}

--- a/themes/clouds/css-1.5.2/style.css
+++ b/themes/clouds/css-1.5.2/style.css
@@ -2568,7 +2568,8 @@ color:#2f416f;
 text-decoration:underline !important;
 }
 
-.flyout3,.flyout3 a {
+.flyout3 {
+display:block;
 background:none;
 border:none;
 left:0;
@@ -2584,6 +2585,7 @@ margin-left:0;
 margin-top:0;
 padding:3px;
 text-align:left;
+font-weight: bold;
 }
 
 .nam a:hover {
@@ -2594,7 +2596,14 @@ color:red;
 padding:0;
 width:100%;
 }
-
+.nav_content .facts_label {
+	width:75px;
+}
+.famnav_title{
+	font-weight: bold;
+	display: block;
+	padding: 5px 0;
+}
 html[dir=rtl] .flyout3 {text-align:right;}
 html[dir=rtl] .flyout {text-align:right;left:210px;}
 html[dir=rtl] .flyout2 {text-align:right;right:40px;}

--- a/themes/colors/css-1.5.2/css/colors.css
+++ b/themes/colors/css-1.5.2/css/colors.css
@@ -907,12 +907,13 @@ html[dir=rtl] .use-sidebar.sidebar-at-right #sidebar,html[dir=rtl] .sidebar-at-r
 /* Family navigator */
 #sb_content_family_nav {padding:0;}
 #sb_family_nav_content {margin-top:8px;}
-
+.nav_content .facts_label {width:75px;}
+.famnav_title{font-weight: bold;display: block;padding: 5px 0;}
 .flyout {color:#000000;margin-top:-20px;padding:3px;right:210px;text-align:left;}
 .flyout2 {background:#ffffff;border:1px solid #cccccc;color:#000000;left:40px;margin-top:-2px;padding:3px;text-align:left;}
 .flyout2 a:hover {color:#2f416f;text-decoration:underline !important;}
-.flyout3,.flyout3 a {background:none;border:none;left:0;margin-top:0;padding:0;text-align:left;text-decoration:none;}
-.flyout4 {color:#000000;margin-left:0;margin-top:0;padding:3px;text-align:left;}
+.flyout3 {display:block;background:none;border:none;left:0;margin-top:0;padding:0;text-align:left;text-decoration:none;}
+.flyout4 {font-weight:bold;color:#000000;margin-left:0;margin-top:0;padding:3px;text-align:left;}
 
 html[dir=rtl] .flyout3 {text-align:right;}
 html[dir=rtl] .flyout {text-align:right;left:210px;}

--- a/themes/fab/css-1.5.2/style.css
+++ b/themes/fab/css-1.5.2/style.css
@@ -81,8 +81,8 @@ img.block {
 	vertical-align: middle;
 }
 
-.line1, 
-.line2, 
+.line1,
+.line2,
 .line3 {
 	vertical-align: middle;
 }
@@ -2224,6 +2224,14 @@ html[dir=rtl] .use-sidebar #separator {
 	width: 100%;
 	padding: 10px 0;
 }
+.nav_content .facts_label {
+	width:75px;
+}
+.famnav_title{
+	font-weight: bold;
+	display: block;
+	padding: 5px 0;
+}
 .flyout {
 	color: #000;
 	text-align: left;
@@ -2239,14 +2247,15 @@ html[dir=rtl] .use-sidebar #separator {
 	padding: 3px;
 }
 .flyout4 {
+	font-weight: bold;
 	color: #000;
 	text-align: left;
 	margin-top: 0;
 	margin-left: 0;
 	padding: 3px;
 }
-.flyout3,
-.flyout3 a {
+.flyout3 {
+	display:block;
 	background: none;
 	border: none;
 	text-decoration: none;

--- a/themes/minimal/css-1.5.2/style.css
+++ b/themes/minimal/css-1.5.2/style.css
@@ -1543,11 +1543,13 @@ html[dir=rtl] .use-sidebar #separator {background:#dddddd url(images/indi_sprite
 #sb_family_nav_content {margin-top:2px;}
 .nam a:hover {color:#555555;}
 .nav_content {width:100%;padding:10px 0 0 0;}
+.nav_content .facts_label {width:75px;}
+.famnav_title{font-weight: bold;display: block;padding: 5px 0;}
 .flyout {color:#000000;text-align:left;margin-top:-20px;right:210px;padding:3px;}
 .flyout2 {color:#000000;text-align:left;margin-top:-2px;left:40px;padding:3px;}
 .flyout2 a:hover {color:#555555;}
-.flyout4 {color:#000000;text-align:left;margin-top:0;margin-left:0;padding:3px;}
-.flyout3, .flyout3 a {background:none;border:none;text-decoration:none;text-align:left;margin-top:0;left:0;padding:0;}
+.flyout4 {font-weight: bold;color:#000000;text-align:left;margin-top:0;margin-left:0;padding:3px;}
+.flyout3 {display:block;background:none;border:none;text-decoration:none;text-align:left;margin-top:0;left:0;padding:0;}
 .famnav_link {font-size:12px;padding:0;width:100%;}
 
 html[dir=rtl] .flyout {text-align:right;left:210px;}

--- a/themes/webtrees/css-1.5.2/style.css
+++ b/themes/webtrees/css-1.5.2/style.css
@@ -846,11 +846,13 @@ html[dir=rtl] .use-sidebar #separator {background:#99c2ff url(images/general_spr
 #sb_family_nav_content {margin-top:8px;}
 .nam a:hover {color:#ff0000;}
 .nav_content {width:100%;padding:0;}
+.nav_content .facts_label{width:75px;}
+.famnav_title{font-weight:bold;display:block;padding:5px 0;}
 .flyout {text-align:left;margin-top:-20px;right:210px;padding:3px;}
 .flyout2 {text-align:left;margin-top:-2px;left:40px;padding:3px;}
 .flyout2 a:hover {color:#ff0000;}
-.flyout4 {text-align:left;margin-top:0;margin-left:0;padding:3px;}
-.flyout3, .flyout3 a {background:none;border:none;text-decoration:none;text-align:left;margin-top:0;left:0;padding:0;}
+.flyout4 {text-align:left;margin-top:0;margin-left:0;padding:3px;font-weight:bold}
+.flyout3 {display:block;background:none;border:none;text-decoration:none;text-align:left;margin-top:0;left:0;padding:0;}
 
 html[dir=rtl] .flyout {text-align:right;left:210px;}
 html[dir=rtl] .flyout2 {text-align:right;right:40px;}

--- a/themes/xenea/css-1.5.2/style.css
+++ b/themes/xenea/css-1.5.2/style.css
@@ -1855,11 +1855,13 @@ html[dir=rtl] .use-sidebar #separator {background:#c3dfff url(images/indi_sprite
 #sb_family_nav_content {margin-top:2px;}
 .nam a:hover {color:#ff0000;}
 .nav_content {width:100%;padding:10px 0;}
+.nav_content .facts_label {width:75px;}
+.famnav_title{font-weight: bold;display: block;padding: 5px 0;}
 .flyout {color:#000000;text-align:left;margin-top:-20px;right:210px;padding:3px;}
 .flyout2 {color:#000000;text-align:left;margin-top:-2px;left:40px;padding:3px;}
 .flyout2 a:hover {color:#ff0000;}
-.flyout4 {color:#000000;text-align:left;margin-top:0;margin-left:0;padding:3px;}
-.flyout3, .flyout3 a {background:none;border:none;text-decoration:none;text-align:left;margin-top:0;left:0;padding:0;}
+.flyout4 {font-weight: bold;color:#000000;text-align:left;margin-top:0;margin-left:0;padding:3px;}
+.flyout3 {display:block;background:none;border:none;text-decoration:none;text-align:left;margin-top:0;left:0;padding:0;}
 .famnav_link {font-size:12px;padding:0;width:100%;}
 
 html[dir=rtl] .flyout {text-align:right;left:210px;}


### PR DESCRIPTION
Issues addressed: extra table rows just to force a newline, embedded
styles, embedded bold, error where ul is placed within a foreach so
each item is a new list (about line 320).

The following style information restores the stock theme display:
new styles .famnav_title & ".nav_content .facts_label"
add font-weight: bold; to flyout 4
add display:block; to flyout3 (and remove .flyout3 a)
