### PR TITLE
Fixes #5 - Remove deprecated captureEvents (used for old Gecko/Netscape)

### DIFF
--- a/lifespan.php
+++ b/lifespan.php
@@ -125,7 +125,6 @@ $controller
 		}
 
 		var IE = document.all?true:false;
-		if (!IE) document.captureEvents(Event.MOUSEMOVE | Event.MOUSEUP)
 		document.onmousemove = getMouseXY;
 		document.onmouseup = releaseimage;
 ');

--- a/timeline.php
+++ b/timeline.php
@@ -214,10 +214,6 @@ function MU() {
 	oldx=0;
 }
 
-if (N) {
-	document.captureEvents(Event.MOUSEDOWN | Event.MOUSEMOVE | Event.MOUSEUP);
-	//document.onmousedown = MD;
-}
 document.onmousemove = MM;
 document.onmouseup = MU;
 </script>


### PR DESCRIPTION
This method has been a no-op for years.
