### PR TITLE
Bug fix & html tidy

### DIFF
--- a/themes/clouds/css-1.5.3/style.css
+++ b/themes/clouds/css-1.5.3/style.css
@@ -3884,46 +3884,53 @@ span.link_text {
 	margin-top: 8px;
 }
 
+.nav_content .facts_label {
+	width: 75px;
+}
+.famnav_title{
+	font-weight: bold;
+	display: block;
+	padding: 5px 0;
+}
+
 .flyout {
-	color: #000;
-	margin-top: -20px;
-	padding: 3px;
-	right: 210px;
-	text-align: left;
-}
-
-.flyout2 {
-	background: #fff;
-	border: 1px solid #ccc;
-	color: #000;
 	left: 40px;
-	margin-top: -2px;
 	padding: 3px;
-	text-align: left;
+	background-color: #ECF5FF;
+	border: 1px solid #cccccc;
 }
 
-.flyout2 a:hover {
-	color: #2f416f;
-	text-decoration: underline !important;
-}
-
-.flyout3,
-.flyout3 a {
-	background: none;
-	border: none;
-	left: 0;
-	margin-top: 0;
-	padding: 0;
-	text-align: left;
+.flyout a, .flyout a:hover {
+	color: #000000;
+    cursor: default;
 	text-decoration: none;
 }
 
-.flyout4 {
-	color: #000;
-	margin-left: 0;
-	margin-top: 0;
-	padding: 3px;
-	text-align: left;
+.flyout2 {
+	font-weight: 700;
+}
+
+.flyout3 {
+    color: #003399;
+}
+
+.flyout3:hover {
+	cursor: pointer;
+    color: #FF0000;
+}
+
+[dir=rtl] .flyout {
+	text-align: right;
+	right: 40px;
+}
+
+[dir=rtl] .flyout2 {
+	text-align: right;
+	left: 210px;
+}
+
+[dir=rtl] .flyout3 {
+	text-align: right;
 }
 
 .nam a:hover {
@@ -3933,20 +3940,6 @@ span.link_text {
 .nav_content {
 	padding: 0;
 	width: 100%;
-}
-
-[dir=rtl] .flyout3 {
-	text-align: right;
-}
-
-[dir=rtl] .flyout {
-	text-align: right;
-	left: 210px;
-}
-
-[dir=rtl] .flyout2 {
-	text-align: right;
-	right: 40px;
 }
 
 /* Descendancy */

--- a/themes/colors/css-1.5.3/css/colors.css
+++ b/themes/colors/css-1.5.3/css/colors.css
@@ -3753,60 +3753,50 @@ span.link_text {
 	margin-top: 8px;
 }
 
+.nav_content .facts_label {
+	width: 75px;
+}
+
+.famnav_title{
+	font-weight: bold;
+	display: block;
+	padding: 5px 0;
+}
+
 .flyout {
-	color: #000;
-	margin-top: -20px;
-	padding: 3px;
-	right: 210px;
-	text-align: left;
-}
-
-.flyout2 {
-	background: #fff;
-	border: 1px solid #ccc;
-	color: #000;
 	left: 40px;
-	margin-top: -2px;
 	padding: 3px;
-	text-align: left;
+	background-color: #FFFFFF;
+	border: 1px solid #CCCCCC;
 }
 
-.flyout2 a:hover {
-	color: #2f416f;
-	text-decoration: underline !important;
-}
-
-.flyout3,
-.flyout3 a {
-	background: none;
-	border: none;
-	left: 0;
-	margin-top: 0;
-	padding: 0;
-	text-align: left;
+.flyout a, .flyout a:hover {
+	color: #000000;
+    cursor: default;
 	text-decoration: none;
 }
 
-.flyout4 {
-	color: #000;
-	margin-left: 0;
-	margin-top: 0;
-	padding: 3px;
-	text-align: left;
-}
+.flyout2 {
+	font-weight: 700;
+ }
 
-[dir=rtl] .flyout3 {
-	text-align: right;
+.flyout3:hover {
+	cursor: pointer;
+	text-decoration: underline;
 }
 
 [dir=rtl] .flyout {
 	text-align: right;
-	left: 210px;
+	right: 40px;
 }
 
 [dir=rtl] .flyout2 {
 	text-align: right;
-	right: 40px;
+	left: 210px;
+}
+
+[dir=rtl] .flyout3 {
+	text-align: right;
 }
 
 #sb_desc_content {

--- a/themes/fab/css-1.5.3/style.css
+++ b/themes/fab/css-1.5.3/style.css
@@ -2473,54 +2473,53 @@ dd .deletelink {
 	padding: 10px 0;
 }
 
-.flyout {
-	color: #000;
-	text-align: left;
-	margin-top: -20px;
-	right: 210px;
-	padding: 3px;
-}
-
-.flyout2 {
-	color: #000;
-	text-align: left;
-	margin-top: -2px;
-	left: 40px;
-	padding: 3px;
-}
-
-.flyout4 {
-	color: #000;
-	text-align: left;
-	margin-top: 0;
-	margin-left: 0;
-	padding: 3px;
-}
-
-.flyout3,
-.flyout3 a {
-	background: none;
-	border: none;
-	text-decoration: none;
-	text-align: left;
-	margin-top: 0;
-	left: 0;
-	padding: 0;
-}
-
 .famnav_link div {
 	padding: 0;
 	width: 100%;
 }
 
+.nav_content .facts_label {
+	width: 75px;
+}
+
+.famnav_title{
+	font-weight: bold;
+	display: block;
+	padding: 5px 0;
+}
+
+.flyout {
+	left: 40px;
+	padding: 3px;
+}
+
+.flyout a, .flyout a:hover {
+	color: #000000;
+    cursor: default;
+	text-decoration: none;
+}
+
+.flyout2 {
+	font-weight: 700;
+}
+
+.flyout3 {
+	color: #336699;
+}
+
+.flyout3:hover {
+	cursor: pointer;
+	text-decoration: underline;
+}
+
 [dir=rtl] .flyout {
 	text-align: right;
-	left: 210px;
+	right: 40px;
 }
 
 [dir=rtl] .flyout2 {
 	text-align: right;
-	right: 40px;
+	left: 210px;
 }
 
 [dir=rtl] .flyout3 {

--- a/themes/minimal/css-1.5.3/style.css
+++ b/themes/minimal/css-1.5.3/style.css
@@ -1404,25 +1404,6 @@ a.showit:hover > span {
 
 /* End of Autocomplete styles*/
 
-/* Flyout menu Styles */
-.flyout {
-	color: #000;
-	text-align: left;
-	margin-top: -20px;
-	right: 210px;
-	padding: 3px;
-}
-
-.flyoutrtl {
-	color: #000;
-	text-align: right;
-	margin-top: -20px;
-	left: 210px;
-	padding: 3px;
-}
-
-/* End of Flyout Menu styles*/
-
 .nowrap {
 	white-space: nowrap;
 }
@@ -2928,59 +2909,50 @@ dd .deletelink {
 	padding: 10px 0 0 0;
 }
 
-.flyout {
-	color: #000;
-	text-align: left;
-	margin-top: -20px;
-	right: 210px;
-	padding: 3px;
-}
-
-.flyout2 {
-	color: #000;
-	text-align: left;
-	margin-top: -2px;
-	left: 40px;
-	padding: 3px;
-}
-
-.flyout2 a:hover {
-	color: #555;
-}
-
-.flyout4 {
-	color: #000;
-	text-align: left;
-	margin-top: 0;
-	margin-left: 0;
-	padding: 3px;
-}
-
-.flyout3,
-.flyout3 a {
-	background: none;
-	border: none;
-	text-decoration: none;
-	text-align: left;
-	margin-top: 0;
-	left: 0;
-	padding: 0;
-}
-
 .famnav_link {
 	font-size: 12px;
 	padding: 0;
 	width: 100%;
 }
 
+.nav_content .facts_label {
+	width: 75px;
+}
+
+.famnav_title{
+	font-weight: bold;
+	display: block;
+	padding: 5px 0;
+}
+
+.flyout {
+    left: 40px;
+    padding: 3px;
+}
+
+.flyout a, .flyout a:hover{
+	color: #000000;
+    cursor: default;
+	text-decoration: none;
+}
+
+.flyout2 {
+	font-weight: 700;
+}
+
+.flyout3:hover {
+	cursor: pointer;
+	text-decoration: underline;
+}
+
 [dir=rtl] .flyout {
 	text-align: right;
-	left: 210px;
+	right: 40px;
 }
 
 [dir=rtl] .flyout2 {
 	text-align: right;
-	right: 40px;
+	left: 210px;
 }
 
 [dir=rtl] .flyout3 {

--- a/themes/webtrees/css-1.5.3/style.css
+++ b/themes/webtrees/css-1.5.3/style.css
@@ -1188,12 +1188,6 @@ a.showit:hover > span {
 	white-space: normal;
 }
 
-ul.clist {
-	list-style-image: none;
-	text-decoration: none;
-	margin: 0;
-}
-
 .statistics-page {
 	text-align: center;
 }
@@ -3724,50 +3718,51 @@ dd .deletelink {
 	padding: 0;
 }
 
+.nav_content .facts_label{
+	width: 75px;
+}
+
+#sb_family_nav_content .clist {
+	margin: 0;
+}
+
+.famnav_title{
+	font-weight: bold;
+	display: block;
+	padding: 5px 0;
+}
+
 .flyout {
-	text-align: left;
-	margin-top: -20px;
-	right: 210px;
-	padding: 3px;
+    left: 40px;
+}
+
+.flyout a, .flyout a:hover {
+	color: #000000;
+    cursor: default;
+	text-decoration: none;
 }
 
 .flyout2 {
-	text-align: left;
-	margin-top: -2px;
-	left: 40px;
-	padding: 3px;
+    font-weight: 700;
+ }
+
+.flyout3 {
+    color: #362B36;
 }
 
-.flyout2 a:hover {
-	color: #f00;
-}
-
-.flyout4 {
-	text-align: left;
-	margin-top: 0;
-	margin-left: 0;
-	padding: 3px;
-}
-
-.flyout3,
-.flyout3 a {
-	background: none;
-	border: none;
-	text-decoration: none;
-	text-align: left;
-	margin-top: 0;
-	left: 0;
-	padding: 0;
+.flyout3:hover {
+	cursor: pointer;
+    color: #FF0000;
 }
 
 [dir=rtl] .flyout {
 	text-align: right;
-	left: 210px;
+	right: 40px;
 }
 
 [dir=rtl] .flyout2 {
 	text-align: right;
-	right: 40px;
+	left: 210px;
 }
 
 [dir=rtl] .flyout3 {

--- a/themes/xenea/css-1.5.3/style.css
+++ b/themes/xenea/css-1.5.3/style.css
@@ -3889,43 +3889,8 @@ dd .deletelink {
 	padding: 10px 0;
 }
 
-.flyout {
-	color: #000;
-	text-align: left;
-	margin-top: -20px;
-	right: 210px;
-	padding: 3px;
-}
-
-.flyout2 {
-	color: #000;
-	text-align: left;
-	margin-top: -2px;
-	left: 40px;
-	padding: 3px;
-}
-
-.flyout2 a:hover {
-	color: #f00;
-}
-
-.flyout4 {
-	color: #000;
-	text-align: left;
-	margin-top: 0;
-	margin-left: 0;
-	padding: 3px;
-}
-
-.flyout3,
-.flyout3 a {
-	background: none;
-	border: none;
-	text-decoration: none;
-	text-align: left;
-	margin-top: 0;
-	left: 0;
-	padding: 0;
+.nav_content .facts_label {
+	width: 75px;
 }
 
 .famnav_link {
@@ -3934,14 +3899,44 @@ dd .deletelink {
 	width: 100%;
 }
 
+.famnav_title{
+	font-weight: bold;
+	display: block;
+	padding: 5px 0;
+}
+
+.flyout {
+	left: 40px;
+	padding: 3px;
+}
+
+.flyout a, .flyout a:hover {
+	color: #000000;
+    cursor: default;
+	text-decoration: none;
+}
+
+.flyout2 {
+	font-weight: 700;
+}
+
+.flyout3 {
+	cursor: pointer;
+	color: #362B36;
+}
+
+.flyout3:hover {
+	color: #FF0000;
+}
+
 [dir=rtl] .flyout {
 	text-align: right;
-	left: 210px;
+	right: 40px;
 }
 
 [dir=rtl] .flyout2 {
 	text-align: right;
-	right: 40px;
+	left: 210px;
 }
 
 [dir=rtl] .flyout3 {


### PR DESCRIPTION
This is virtually a complete rewrite of the module

Changes.
1. Generated code passes HTML5 validation (bug #1236995)
2. All styling done in themes CSS
3. Only items that are 'real' links look like links and respond to mouse clicks
4. Step mother/father are identified as such in the 'Parents' menu

The validation problem with the original code was that nested `<a..>` elements were generated in function print_pedigree_person_nav. I originally looked at using cascaded WT_Menus but although the result validated, the appearance wasn't very nice. Using getMenuAsList()  restored the look but reintroduced the validation problems.

The solution adopted here is to replace the nested `<a..>` elements with `<div>`'s styled to look like links and to use a bit of javascript to provide the onclick functionality.

The module has been restructured to replace the huge print_pedigree_person_nav() function with getParents() & getFamily(). In my view this provides a more logical structure whilst eliminating some global (within the module) variables.
