### PR TITLE
Consolidate css classes

### DIFF
--- a/modules_v3/clippings/module.php
+++ b/modules_v3/clippings/module.php
@@ -192,7 +192,7 @@ class clippings_WT_Module extends WT_Module implements WT_Module_Menu, WT_Module
 
 					<?php if (WT_USER_GEDCOM_ADMIN) {	?>
 						<tr><td class="descriptionbox width50 wrap"><?php echo WT_I18N::translate('Apply privacy settings?'), help_link('apply_privacy'); ?></td>
-						<td class="list_value">
+						<td class="optionbox">
 							<input type="radio" name="privatize_export" value="none" checked="checked"> <?php echo WT_I18N::translate('None'); ?><br>
 							<input type="radio" name="privatize_export" value="gedadmin"> <?php echo WT_I18N::translate('Manager'); ?><br>
 							<input type="radio" name="privatize_export" value="user"> <?php echo WT_I18N::translate('Member'); ?><br>
@@ -200,7 +200,7 @@ class clippings_WT_Module extends WT_Module implements WT_Module_Menu, WT_Module
 						</td></tr>
 					<?php } elseif (WT_USER_CAN_ACCESS) {	?>
 						<tr><td class="descriptionbox width50 wrap"><?php echo WT_I18N::translate('Apply privacy settings?'), help_link('apply_privacy'); ?></td>
-						<td class="list_value">
+						<td class="optionbox">
 							<input type="radio" name="privatize_export" value="user" checked="checked"> <?php echo WT_I18N::translate('Member'); ?><br>
 							<input type="radio" name="privatize_export" value="visitor"> <?php echo WT_I18N::translate('Visitor'); ?>
 						</td></tr>
@@ -210,7 +210,7 @@ class clippings_WT_Module extends WT_Module implements WT_Module_Menu, WT_Module
 					<td class="optionbox"><input type="checkbox" name="convert" value="yes"></td></tr>
 
 					<tr><td class="descriptionbox width50 wrap"><?php echo WT_I18N::translate('Add the GEDCOM media path to filenames'), help_link('GEDCOM_MEDIA_PATH'); ?></td>
-					<td class="list_value">
+					<td class="optionbox">
 						<input type="checkbox" name="conv_path" value="<?php echo WT_Filter::escapeHtml($GEDCOM_MEDIA_PATH); ?>">
 						<span dir="auto"><?php echo WT_Filter::escapeHtml($GEDCOM_MEDIA_PATH); ?></span>
 					</td></tr>


### PR DESCRIPTION
Clippings cart module.

The css classes for the checkboxes and radio buttons on the "File Information" table was a mixture of optionbox & list_value which meant that it was nigh on impossible to vertically align them. This standardises on optionbox.
