### PR TITLE
Consistently use WT_ROOT in the require/require_once statements

### DIFF
--- a/includes/session.php
+++ b/includes/session.php
@@ -134,7 +134,7 @@ if (!function_exists('password_hash')) {
 	// in PHP5.3.7 and *some* earlier/patched versions.
 	$hash = '$2y$04$usesomesillystringfore7hnbRJHxXVLeakoG8K30oukPsA.ztMG';
 	if (crypt("password", $hash) === $hash) {
-		require 'library/ircmaxell/password-compat/lib/password.php';
+		require WT_ROOT.'library/ircmaxell/password-compat/lib/password.php';
 	} else {
 		// For older/unpatched versions of PHP, use the default crypt behaviour.
 		function password_hash($password) {
@@ -176,7 +176,7 @@ if (version_compare(PHP_VERSION, '5.4', '<') && get_magic_quotes_gpc()) {
 	unset($process);
 }
 
-require 'library/autoload.php';
+require WT_ROOT.'library/autoload.php';
 
 // PHP requires a time zone to be set in php.ini
 if (!ini_get('date.timezone')) {

--- a/modules_v3/faq/module.php
+++ b/modules_v3/faq/module.php
@@ -320,7 +320,7 @@ class faq_WT_Module extends WT_Module implements WT_Module_Menu, WT_Module_Block
 	}
 
 	private function config() {
-		require_once 'includes/functions/functions_edit.php';
+		require_once WT_ROOT.'includes/functions/functions_edit.php';
 
 		$controller=new WT_Controller_Page();
 		$controller

--- a/modules_v3/stories/module.php
+++ b/modules_v3/stories/module.php
@@ -288,7 +288,7 @@ class stories_WT_Module extends WT_Module implements WT_Module_Block, WT_Module_
 	}
 
 	private function config() {
-		require_once 'includes/functions/functions_edit.php';
+		require_once WT_ROOT.'includes/functions/functions_edit.php';
 		if (WT_USER_GEDCOM_ADMIN) {
 
 			$controller=new WT_Controller_Page();


### PR DESCRIPTION
The recently introduced autoloader and password-compat library are called through a simple relative path, which is not consistent with the use of the WT_ROOT constant to include files in the rest of the application.
