### PR TITLE
Fix weird bug on windows php

### DIFF
--- a/library/WT/Controller/Branches.php
+++ b/library/WT/Controller/Branches.php
@@ -97,7 +97,7 @@ class WT_Controller_Branches extends WT_Controller_Page {
 
 	private function loadAncestors(WT_Individual $ancestor, $sosa) {
 		if ($ancestor) {
-			$this->ancestors[$sosa] = $ancestor;
+			$this->ancestors[$sosa] = $ancestor->getXref();
 			foreach ($ancestor->getChildFamilies() as $family) {
 				foreach ($family->getSpouses() as $parent) {
 					$this->loadAncestors($parent, $sosa * 2 + ($parent->getSex() == 'F'));
@@ -148,7 +148,7 @@ class WT_Controller_Branches extends WT_Controller_Page {
 		}
 
 		// Is this individual one of our ancestors?
-		$sosa = array_search($individual, $this->ancestors);
+		$sosa = array_search($individual->getXref(), $this->ancestors);
 		if ($sosa) {
 			$sosa_class = 'search_hit';
 			$sosa_html  = ' <a class="details1 ' . $individual->getBoxStyle() . '" title="' . WT_I18N::translate('Sosa') . '" href="relationship.php?pid2=' . WT_USER_ROOT_ID . '&amp;pid1=' . $individual->getXref() . '">' . $sosa . '</a>' . self::sosaGeneration($sosa);
@@ -183,7 +183,7 @@ class WT_Controller_Branches extends WT_Controller_Page {
 
 				$spouse = $family->getSpouse($individual);
 				if ($spouse) {
-					$sosa = array_search($spouse, $this->ancestors);
+					$sosa = array_search($spouse->getXref(), $this->ancestors);
 					if ($sosa) {
 						$sosa_class = 'search_hit';
 						$sosa_html  = ' <a class="details1 ' . $spouse->getBoxStyle() . '" title="' . WT_I18N::translate('Sosa') . '" href="relationship.php?pid2=' . WT_USER_ROOT_ID . '&amp;pid1=' . $spouse->getXref() . '"> '.$sosa.' </a>' . self::sosaGeneration($sosa);


### PR DESCRIPTION
On menu Lists/branches
The original code works perfectly on linux but when run on windows, one surname (that I've found) in my data produces the following error "Fatal error: Nesting level too deep - recursive dependency? in <path>\library\WT\Controller\Branches.php on line 151".

I couldn't see anything wrong - the recursion level wasn't particularly deep - but I did notice the $ancestors array was holding a huge amount of data - a complete WT_Individual record for each entry - I figured that as we're only looking for something unique the Xref would do and by making this change the code now runs in windows as well. 

Weird or what?

PS I even increased the php memory to 512M but it still didn't work!!
