### PR TITLE
Simplified version of my proposal to reinstate the title display for shared notes on Indi Tab

### DIFF
--- a/includes/functions/functions_print.php
+++ b/includes/functions/functions_print.php
@@ -415,13 +415,8 @@ function print_note_record($text, $nlevel, $nrec, $textOnly=false) {
 			list($ttl, $html) = explode("\n", $html, 2);
 		} else {
 			$html = WT_Filter::formatText($note->getNote(), $WT_TREE);
-			// strip out anything other than whitespace, letters & numbers
-			$tmp = preg_replace("/[^\s|\p{L}|\p{N}]+/u", '', strip_tags($html));
 			// truncate at end of 1st line or TITLE_CUTOFF whichever is the shortest
-			$ttl = current(explode("\n", wordwrap($tmp, TITLE_CUTOFF, "...\n")));
-			// Note the title text, hasn't been removed from $html,
-			// therefore the full markdown result will be displayed
-			// when the the link is expanded
+			$ttl = current(explode("\n", wordwrap(strip_tags($html), TITLE_CUTOFF, "...\n")));
 		}
 		$title = sprintf("<a title='%s' onclick=\"return edit_note('%s');return false;\" href='#'>%s</a>", WT_I18N::translate('Edit'), $note->getXref(), $ttl);
 	} else {


### PR DESCRIPTION
I submit this as a suggestion as a way to reinstate the addition of a 'title' to the Shared Notes display. If the note is formatted by the Census assistant then things are straightforward, If not then I propose the 1st line (or a proportion of it) is then extracted from a 'strip tagged' version of the html and that is used as the title. This leaves the original note contents untouched for when the display option is expanded.

I realize that if the 1st line of the note contained a table or a link for example then the resulting title wouldn't make much sense but users would soon learn!! (maybe with the help of the wiki)

PS Unrelated: The uniqid line has been changed because believe it or not on my windows system I was getting duplicate ids generated when I had two adjacent facts both with notes!
