### PR TITLE
CSS only solution for sidebar and Name box

### DIFF
--- a/individual.php
+++ b/individual.php
@@ -95,7 +95,6 @@ $linkToID=$controller->record->getXref(); // -- Tell addmedia.php what to link t
 
 $controller->addInlineJavascript('
 	jQuery("#tabs").tabs({
-		spinner: \'<i class="icon-loading-small"></i>\',
 		active:   jQuery.cookie("indi-tab"),
 		activate: function(event, ui) {
 			jQuery.cookie("indi-tab", jQuery("#tabs").tabs("option", "active"));
@@ -106,6 +105,7 @@ $controller->addInlineJavascript('
 				event.preventDefault();
 				return;
 			}
+			jQuery(ui.panel.selector).append(\'<div class="loading-image"></div>\');
 			ui.jqXHR.success(function() {
 				ui.tab.data("loaded", true);
 			});
@@ -114,45 +114,25 @@ $controller->addInlineJavascript('
 
 	// sidebar settings
 	// Variables
-	var objMain			= jQuery("#main");
-	var objTabs			= jQuery("#indi_left");
-	var objBar			= jQuery("#sidebar");
-	var objSeparator	= jQuery("#separator");
-	// Adjust header dimensions
-	function adjHeader(){
-		var indi_header_div = document.getElementById("indi_header").offsetWidth - 20;
-		var indi_mainimage_div = document.getElementById("indi_mainimage").offsetWidth +20;
-		var header_accordion_div = document.getElementById("header_accordion1");
-		header_accordion_div.style.width = indi_header_div - indi_mainimage_div +"px";
+	var objMain	= jQuery("#main");
 
-		jQuery(window).bind("resize", function(){
-			var indi_header_div = document.getElementById("indi_header").offsetWidth - 20;
-			var indi_mainimage_div = document.getElementById("indi_mainimage").offsetWidth +20;
-			var header_accordion_div = document.getElementById("header_accordion1");
-			header_accordion_div.style.width = indi_header_div - indi_mainimage_div +"px";
-		 });
-	}
 	// Show sidebar
 	function showSidebar(){
 		objMain.addClass("use-sidebar");
-		objSeparator.css("height", objBar.outerHeight() + "px");
 		jQuery.cookie("hide-sb", null);
 	}
 	// Hide sidebar
 	function hideSidebar(){
 		objMain.removeClass("use-sidebar");
-		objSeparator.css("height", objTabs.outerHeight() + "px");
 		jQuery.cookie("hide-sb", "1");
 	}
 	// Sidebar separator
-	objSeparator.click(function(e){
+	jQuery("#separator").click(function(e){
 		e.preventDefault();
 		if ( objMain.hasClass("use-sidebar") ){
 			hideSidebar();
-			adjHeader();
 		} else {
 			showSidebar();
-			adjHeader();
 		}
 	});
 	// Load preference
@@ -161,8 +141,6 @@ $controller->addInlineJavascript('
 	} else {
 		showSidebar();
 	}
-	adjHeader();
-	jQuery("#main").css("visibility", "visible");
 
 	function show_gedcom_record() {
 		var recwin=window.open("gedrecord.php?pid='. $controller->record->getXref(). '", "_blank", edit_window_specs);
@@ -178,7 +156,7 @@ $controller->addInlineJavascript('
 
 // ===================================== header area
 echo
-	'<div id="main" class="use-sidebar sidebar-at-right" style="visibility:hidden;">', //overall page container
+	'<div id="main" class="use-sidebar">', //overall page container
 	'<div id="indi_left">',
 	'<div id="indi_header">';
 if ($controller->record->canShow()) {
@@ -265,4 +243,4 @@ echo
 	'</div>', //close indi_left
 	$sidebar_html,
 	'<a href="#" id="separator" title="', WT_I18N::translate('Click here to open or close the sidebar'), '"></a>',//clickable element to open/close sidebar
-	'<div style="clear:both;">&nbsp;</div></div>'; // close #main
+	'</div>'; // close #main

--- a/themes/clouds/css-1.5.3/style.css
+++ b/themes/clouds/css-1.5.3/style.css
@@ -3079,7 +3079,6 @@ span.link_text {
 	float: right;
 }
 
-#header_accordion1,
 #sex,
 dd .editlink,
 dd .deletelink {
@@ -3088,10 +3087,9 @@ dd .deletelink {
 
 #indi_header {
 	border-radius: 3px;
-	float: left;
-	margin: 5px 0;
-	padding: 10px;
-	width: 98%;
+	overflow: hidden;
+	margin: 0 0 5px 0;
+	width: 100%;
 }
 
 #indi_header a {
@@ -3110,6 +3108,8 @@ dd .deletelink {
 	margin: 0;
 	padding: 0 10px 0 30px;
 	text-align: left;
+	overflow: hidden;
+	position: relative;
 }
 
 #indi_header h3 .details1 {
@@ -3127,10 +3127,8 @@ dd .deletelink {
 	display: inline;
 }
 
-#indi_header h3.name_one {
+#indi_header .name_one {
 	font-size: 1.5em;
-	overflow: hidden;
-	position: relative;
 }
 
 #indi_header h3.person_box,
@@ -3142,11 +3140,12 @@ dd .deletelink {
 
 #indi_mainimage {
 	float: left;
+	width: 120px;
 }
 
-#indi_mainimage a img {
-	float: left;
-	padding: 0;
+#indi_mainimage img {
+	display: block;
+	margin: auto;
 }
 
 .indi_name_details {
@@ -3241,10 +3240,6 @@ dd .deletelink {
 
 [dir=rtl] dd .editlink,
 [dir=rtl] dd .deletelink {
-	float: left;
-}
-
-[dir=rtl] #header_accordion1 {
 	float: left;
 }
 
@@ -3797,81 +3792,67 @@ span.link_text {
 #main {
 	min-width: 600px;
 	width: 100%;
-}
-
-#separator {
-	background: #acf url(images/general_sprite.png) no-repeat -26px 100px;
-	border: 1px solid #8fbcff;
-	border-top-left-radius: 3px;
-	border-top-right-radius: 3px;
-	display: block;
-	float: right;
-	margin-top: 5px;
-	max-width: 10px;
-	min-width: 6px;
-	width: 0.75%;
-}
-
-#sidebar {
-	border-color: #8fbcff;
-	display: none;
-	height: auto;
-	margin: 5px 2px 0 0;
+	overflow: hidden;
+	padding: 5px 2px 0 2px;
 }
 
 #tabs {
 	background-color: #fff;
 	border-color: #8fbcff;
-	float: left;
 	overflow: visible;
 	width: 100%;
-}
-
-.sidebar-at-right #sidebar {
-	width: 20%;
-}
-
-.use-sidebar #indi_left {
-	width: 77%;
-}
-
-.use-sidebar #separator {
-	background: #acf url(images/general_sprite.png) no-repeat -1px 100px;
-}
-
-.use-sidebar #sidebar {
-	display: block;
-}
-
-.use-sidebar.sidebar-at-right #sidebar,
-.sidebar-at-right #separator {
-	float: right;
 }
 
 [dir=rtl] #indi_left {
 	float: right;
 }
 
-[dir=rtl] #sidebar {
-	margin: 5px 0 0 2px;
-}
-
 [dir=rtl] #tabs {
 	float: right;
 }
 
-[dir=rtl] #separator {
-	float: left;
+.use-sidebar #indi_left {
+	width: 77%;
+}
+
+#sidebar {
+	float:right;
+	border: 1px solid #8fbcff;
+	display: none;
+	width: 20%;
+}
+
+#separator {
+	float: right;
+	background: #acf url(images/general_sprite.png) no-repeat -26px 100px;
+	border: 1px solid #8fbcff;
+	border-top-left-radius: 3px;
+	border-top-right-radius: 3px;
+	width: 2%;
+	max-width: 10px;
+	margin: 0 auto -99999px auto;
+	padding-bottom: 99999px;
+}
+
+.use-sidebar #sidebar {
+	display: block;
+}
+
+.use-sidebar #separator {
 	background: #acf url(images/general_sprite.png) no-repeat -1px 100px;
+}
+
+[dir=rtl] .use-sidebar #sidebar {
+	float: left;
+}
+
+[dir=rtl] #separator {
+	background: #acf url(images/general_sprite.png) no-repeat -1px 100px;
+	float: left;
 }
 
 [dir=rtl] .use-sidebar #separator {
 	background: #acf url(images/general_sprite.png) no-repeat -26px 100px;
-}
-
-[dir=rtl] .use-sidebar.sidebar-at-right #sidebar,
-[dir=rtl] .sidebar-at-right #separator {
-	float: left;
 }
 
 /* ==== Sidebar content items ==== */

--- a/themes/colors/css-1.5.3/css/colors.css
+++ b/themes/colors/css-1.5.3/css/colors.css
@@ -2914,10 +2914,9 @@ span.link_text {
 
 #indi_header {
 	border-radius: 3px;
-	float: left;
-	margin: 5px 0;
-	padding: 10px;
-	width: 98%;
+	overflow: hidden;
+	margin: 0 0 5px;
+	width: 100%;
 }
 
 #indi_header a {
@@ -2948,16 +2947,16 @@ span.link_text {
 	margin: 0;
 	padding: 0 10px 0 30px;
 	text-align: left;
+	overflow: hidden;
+	position: relative;
 }
 
 #indi_header h3 a {
 	display: inline;
 }
 
-#indi_header h3.name_one {
+#indi_header .name_one {
 	font-size: 1.5em;
-	overflow: hidden;
-	position: relative;
 }
 
 #indi_header h3.person_box,
@@ -3041,7 +3040,6 @@ span.link_text {
 	margin: 12px 0;
 }
 
-#header_accordion1,
 #sex,
 dd .editlink,
 dd .deletelink {
@@ -3075,10 +3073,6 @@ dd .deletelink {
 
 [dir=rtl] dd .editlink,
 [dir=rtl] dd .deletelink {
-	float: left;
-}
-
-[dir=rtl] #header_accordion1 {
 	float: left;
 }
 
@@ -3662,41 +3656,51 @@ span.link_text {
 #main {
 	min-width: 600px;
 	width: 100%;
+	overflow: hidden;
+	padding: 5px 2px 0 2px;
+}
+
+#tabs {
+	background-color: #fff;
+	overflow: visible;
+	width: 100%;
+	border-color: #ddd;
+}
+
+[dir=rtl] #indi_left,
+[dir=rtl] #tabs {
+	float: right;
+}
+
+.use-sidebar #indi_left {
+	width: 77%;
+}
+
+#sidebar {
+	float:right;
+	border-color: #ddd;
+	display: none;
+	width: 20%;
+	margin: 0 0 -99999px 0;
+	padding-bottom: 99999px;
 }
 
 #separator {
+	float: right;
 	background-image: url(../images/general_sprite.png);
 	background-position: -26px 100px;
 	background-repeat: no-repeat;
 	border: 1px solid #999;
 	border-top-left-radius: 3px;
 	border-top-right-radius: 3px;
-	display: block;
-	float: right;
-	margin-top: 5px;
+	width: 2%;
 	max-width: 10px;
-	min-width: 6px;
-	width: 0.75%;
+	margin: 0 auto -99999px auto;
+	padding-bottom: 99999px;
 }
 
-#sidebar {
-	display: none;
-	height: auto;
-	border-radius: 3px;
-	border-color: #ddd;
-	margin: 5px 2px 0 0;
-}
-
-#tabs {
-	background-color: #fff;
-	float: left;
-	overflow: visible;
-	width: 100%;
-	border-color: #ddd;
-}
-
-.sidebar-at-right #sidebar {
-	width: 20%;
+.use-sidebar #sidebar {
+	display: block;
 }
 
 .use-sidebar #separator {
@@ -3705,43 +3709,21 @@ span.link_text {
 	background-repeat: no-repeat;
 }
 
-.use-sidebar #indi_left {
-	width: 77%;
-}
-
-.use-sidebar #sidebar {
-	display: block;
-}
-
-.use-sidebar.sidebar-at-right #sidebar,
-.sidebar-at-right #separator {
-	float: right;
-}
-
-[dir=rtl] #indi_left,
-[dir=rtl] #tabs {
-	float: right;
-}
-
-[dir=rtl] #sidebar {
-	margin: 5px 0 0 2px;
+[dir=rtl] .use-sidebar #sidebar {
+	float: left;
 }
 
 [dir=rtl] #separator {
 	background-image: url(../images/general_sprite.png);
-	background-repeat: no-repeat;
 	background-position: -1px 100px;
+	background-repeat: no-repeat;
+	float: left;
 }
 
 [dir=rtl] .use-sidebar #separator {
 	background-image: url(../images/general_sprite.png);
-	background-repeat: no-repeat;
 	background-position: -26px 100px;
-}
-
-[dir=rtl] .use-sidebar.sidebar-at-right #sidebar,
-[dir=rtl] .sidebar-at-right #separator {
-	float: left;
+	background-repeat: no-repeat;
 }
 
 /* Sidebar content items */
@@ -4845,7 +4827,13 @@ a.icon-uarrow:hover {
 
 /* Silhouettes on individual pages */
 #indi_mainimage {
-	min-width: 100px;
+	float: left;
+	width: 120px;
+}
+
+#indi_mainimage img {
+	display: block;
+	margin: auto;
 }
 
 #indi_mainimage .icon-silhouette-F {

--- a/themes/fab/css-1.5.3/style.css
+++ b/themes/fab/css-1.5.3/style.css
@@ -1749,10 +1749,10 @@ span.link_text {
 /* =========== Indi header ================== */
 
 #indi_header {
-	float: left;
+	overflow: hidden;
 	width: 98%;
 	border-radius: 4px;
-	margin: 5px 0;
+	margin: 0 0 5px;
 	padding: 0 10px;
 }
 
@@ -1762,11 +1762,11 @@ span.link_text {
 	margin: 0;
 	padding: 0 10px 0 30px;
 	text-align: left;
-}
-
-#indi_header h3.name_one {
 	overflow: hidden;
 	position: relative;
+}
+
+#indi_header .name_one {
 	font-size: larger;
 }
 
@@ -1779,11 +1779,12 @@ span.link_text {
 
 #indi_mainimage {
 	float: right;
+	width: 120px;
 }
 
-#indi_mainimage a img {
-	float: right;
-	padding: 0;
+#indi_mainimage img {
+	display: block;
+	margin: auto;
 }
 
 .indi_name_details {
@@ -1829,10 +1830,6 @@ span.link_text {
 	padding: 3px;
 }
 
-#header_accordion1 {
-	float: left;
-}
-
 .indi_table {
 	clear: left;
 }
@@ -1873,17 +1870,14 @@ dd .deletelink {
 	float: left;
 }
 
+/*
 [dir=rtl] #indi_mainimage a img {
 	float: left;
 }
-
+*/
 [dir=rtl] #indi_note .fact_NOTE {
 	float: right;
 	margin: 0 0 0 10px;
-}
-
-[dir=rtl] #header_accordion1 {
-	float: right;
 }
 
 [dir=rtl] .indi_table {
@@ -2378,6 +2372,8 @@ dd .deletelink {
 #main {
 	min-width: 600px;
 	width: 100%;
+	padding: 3px 0 0 0;
+	overflow: hidden;
 }
 
 #indi_left {
@@ -2386,25 +2382,68 @@ dd .deletelink {
 }
 
 #tabs {
-	float: left;
 	width: 98%;
 	overflow: visible;
+	padding-bottom: 0;
+	margin-bottom: 0;
 }
 
+[dir=rtl] #indi_left {
+	float: right;
+}
+
+[dir=rtl] #tabs {
+	float: right;
+}
+
+.use-sidebar #indi_left {
+	width: 77%;
+}
+
+#sidebar {
+	float:right;
+	display: none;
+	width: 20%;
+}
+
+#separator {
+	float: right;
+	background: #ccc url(images/indi_sprite.png) no-repeat -26px 100px;
+	border: 1px solid #aaa;
+	border-top-left-radius: 4px;
+	border-top-right-radius: 4px;
+	width: 2%;
+	max-width: 10px;
+	margin: 0 auto -99999px auto;
+	padding-bottom: 99999px;
+}
+
+.use-sidebar #sidebar {
+	display: block;
+}
+
+.use-sidebar #separator {
+	background: #ccc url(images/indi_sprite.png) no-repeat -1px 100px;
+}
+
+[dir=rtl] .use-sidebar #sidebar {
+	float: left;
+}
+
+[dir=rtl] #separator {
+	background: #ccc url(images/indi_sprite.png) no-repeat -1px 100px;
+	float: left;
+}
+
+[dir=rtl] .use-sidebar #separator {
+	background: #ccc url(images/indi_sprite.png) no-repeat -26px 100px;
+}
+
+/*
 #sidebar {
 	display: none;
 	margin: 5px 2px 0 0;
 	height: auto;
-}
-
-#sidebarAccordion,
-#sidebarAccordion2 {
-	width: auto;
-}
-
-#sidebarAccordion h3,
-#sidebarAccordion2 h3 {
-	text-align: center;
 }
 
 .use-sidebar #indi_left {
@@ -2441,14 +2480,6 @@ dd .deletelink {
 	background: #ccc url(images/indi_sprite.png) no-repeat -1px 100px;
 }
 
-[dir=rtl] #indi_left {
-	float: right;
-}
-
-[dir=rtl] #tabs {
-	float: right;
-}
-
 [dir=rtl] #sidebar {
 	margin: 5px 0 0 2px;
 }
@@ -2465,6 +2496,17 @@ dd .deletelink {
 
 [dir=rtl] .use-sidebar #separator {
 	background: #ccc url(images/indi_sprite.png) no-repeat -26px 100px;
+}
+*/
+
+#sidebarAccordion,
+#sidebarAccordion2 {
+	width: auto;
+}
+
+#sidebarAccordion h3,
+#sidebarAccordion2 h3 {
+	text-align: center;
 }
 
 /* ============== Sidebar content items ============== */

--- a/themes/minimal/css-1.5.3/style.css
+++ b/themes/minimal/css-1.5.3/style.css
@@ -2044,9 +2044,9 @@ span.link_text:hover {
 /* =========== Indi header ================== */
 
 #indi_header {
-	float: left;
+	overflow:hidden;
 	width: 98%;
-	margin: 5px 0;
+	margin: 0 0 5px;
 	padding: 0 10px 0 0;
 }
 
@@ -2055,11 +2055,11 @@ span.link_text:hover {
 	margin: 0;
 	padding: 0 10px 0 30px;
 	text-align: left;
-}
-
-#indi_header h3.name_one {
 	overflow: hidden;
 	position: relative;
+}
+
+#indi_header .name_one {
 	font-size: 1.5em;
 }
 
@@ -2100,15 +2100,6 @@ span.link_text:hover {
 	font-size: 2em;
 	margin: 10px;
 	font-weight: bold;
-}
-
-#indi_mainimage {
-	float: right;
-}
-
-#indi_mainimage a img {
-	float: right;
-	padding: 0;
 }
 
 .indi_name_details {
@@ -2188,12 +2179,6 @@ span.link_text:hover {
 	padding: 3px;
 }
 
-#header_accordion1 {
-	border: 1px solid #ddd;
-	border-radius: 3px 3px 3px 3px;
-	float: left;
-}
-
 .indi_table {
 	clear: left;
 }
@@ -2238,17 +2223,9 @@ dd .deletelink {
 	float: left;
 }
 
-[dir=rtl] #indi_mainimage a img {
-	float: left;
-}
-
 [dir=rtl] #indi_note .fact_NOTE {
 	float: right;
 	margin: 0 0 0 10px;
-}
-
-[dir=rtl] #header_accordion1 {
-	float: right;
 }
 
 [dir=rtl] .indi_table {
@@ -2806,11 +2783,17 @@ dd .deletelink {
 #main {
 	min-width: 600px;
 	width: 100%;
+	overflow: hidden;
+	padding-top: 5px;
 }
 
 #indi_left {
 	float: left;
 	width: 98%;
+}
+
+[dir=rtl] #indi_left {
+	float: right;
 }
 
 #tabs {
@@ -2833,6 +2816,50 @@ dd .deletelink {
 	border: 1px solid #888;
 }
 
+.use-sidebar #indi_left {
+	width: 77%;
+}
+
+#sidebar {
+	float:right;
+	border-color: #ddd;
+	display: none;
+	width: 20%;
+}
+
+#separator {
+	float: right;
+	background: #ddd url(images/indi_sprite.png) no-repeat -26px 100px;
+	border: 1px solid #81a9cb;
+	border-top-left-radius: 3px;
+	border-top-right-radius: 3px;
+	width: 2%;
+	max-width: 10px;
+	margin: 0 auto -99999px auto;
+	padding-bottom: 99999px;
+}
+
+.use-sidebar #sidebar {
+	display: block;
+}
+
+.use-sidebar #separator {
+	background: #ddd url(images/indi_sprite.png) no-repeat -1px 100px;
+}
+
+[dir=rtl] .use-sidebar #sidebar {
+	float: left;
+}
+
+[dir=rtl] #separator {
+	background: #ddd url(images/indi_sprite.png) no-repeat -1px 100px;
+	float: left;
+}
+
+[dir=rtl] .use-sidebar #separator {
+	background: #ddd url(images/indi_sprite.png) no-repeat -26px 100px;
+}
+/*
 #sidebar {
 	border-color: #ddd;
 	display: none;
@@ -2873,9 +2900,7 @@ dd .deletelink {
 	background: #ddd url(images/indi_sprite.png) no-repeat -1px 100px;
 }
 
-[dir=rtl] #indi_left {
-	float: right;
-}
+
 
 [dir=rtl] #sidebar {
 	margin: 5px 0 0 2px;
@@ -2893,7 +2918,7 @@ dd .deletelink {
 [dir=rtl] .use-sidebar #separator {
 	background: #ddd url(images/indi_sprite.png) no-repeat -26px 100px;
 }
-
+*/
 /* ============== Sidebar content items ============== */
 /* Family navigator */
 #sb_content_family_nav {
@@ -3942,7 +3967,13 @@ a.icon-udarrow {
 
 /* Silhouettes on individual pages */
 #indi_mainimage {
-	min-width: 100px;
+	float: right;
+	width: 120px;
+}
+
+#indi_mainimage img {
+	display: block;
+	margin: auto;
 }
 
 #indi_mainimage .icon-silhouette-F {

--- a/themes/webtrees/css-1.5.3/style.css
+++ b/themes/webtrees/css-1.5.3/style.css
@@ -3097,11 +3097,11 @@ delete links ==================== */
 
 /* =========== Indi header ================== */
 #indi_header {
-	float: left;
+	overflow: hidden;
 	width: 98%;
 	border-radius: 3px;
 	border: 1px solid #b2c7d7;
-	margin: 5px 0;
+	margin: 0 0 5px;
 	padding: 10px;
 }
 
@@ -3111,11 +3111,11 @@ delete links ==================== */
 	margin: 0;
 	padding: 0 10px 0 30px;
 	text-align: left;
-}
-
-#indi_header h3.name_one {
 	overflow: hidden;
 	position: relative;
+}
+
+#indi_header .name_one {
 	font-size: 1.5em;
 }
 
@@ -3159,13 +3159,13 @@ delete links ==================== */
 
 #indi_mainimage {
 	float: left;
+	width: 120px;
 }
 
-#indi_mainimage a img {
-	float: left;
-	padding: 0;
+#indi_mainimage img {
+	display: block;
+	margin: auto;
 }
-
 .indi_name_details {
 	margin: 0;
 	overflow: hidden !important;
@@ -3189,10 +3189,6 @@ delete links ==================== */
 
 #indi_note {
 	margin: 0 0 5px 0;
-}
-
-#header_accordion1 {
-	float: right;
 }
 
 .indi_table {
@@ -3271,17 +3267,9 @@ dd .deletelink {
 	float: right;
 }
 
-[dir=rtl] #indi_mainimage a img {
-	float: right;
-}
-
 [dir=rtl] #indi_note .fact_NOTE {
 	float: right;
 	margin: 0 0 0 10px;
-}
-
-[dir=rtl] #header_accordion1 {
-	float: left;
 }
 
 [dir=rtl] .indi_table {
@@ -3620,6 +3608,8 @@ dd .deletelink {
 #main {
 	min-width: 600px;
 	width: 100%;
+	overflow: hidden;
+	padding: 5px 0 0 0;
 }
 
 #indi_left {
@@ -3627,75 +3617,62 @@ dd .deletelink {
 	width: 98%;
 }
 
+[dir=rtl] #indi_left {
+	float: right;
+}
+
 #tabs {
 	background-color: #fff;
 	border-color: #ddd;
-	float: left;
 	width: 100%;
 	overflow: visible;
-}
-
-#sidebar {
-	border-color: #ddd;
-	display: none;
-	margin: 5px 2px 0 0;
-	height: auto;
-}
-
-.use-sidebar #indi_left {
-	width: 77%;
-}
-
-.use-sidebar #sidebar {
-	display: block;
-}
-
-.sidebar-at-right #sidebar {
-	width: 20%;
-}
-
-.use-sidebar.sidebar-at-right #sidebar,
-.sidebar-at-right #separator {
-	float: right;
-}
-
-#separator {
-	float: right;
-	display: block;
-	background: #99c2ff url(images/general_sprite.png) no-repeat -26px 100px;
-	width: 0.75%;
-	min-width: 6px;
-	max-width: 10px;
-	border: 1px solid #81a9cb;
-	border-top-left-radius: 3px;
-	border-top-right-radius: 3px;
-	margin-top: 5px;
-}
-
-.use-sidebar #separator {
-	background: #99c2ff url(images/general_sprite.png) no-repeat -1px 100px;
-}
-
-[dir=rtl] #indi_left {
-	float: right;
 }
 
 [dir=rtl] #tabs {
 	float: right;
 }
 
-[dir=rtl] #sidebar {
-	margin: 5px 0 0 2px;
+/* sidebar */
+.use-sidebar #indi_left {
+	width: 77%;
 }
 
-[dir=rtl] .use-sidebar.sidebar-at-right #sidebar,
-[dir=rtl] .sidebar-at-right #separator {
+#sidebar {
+	float:right;
+	border-color: #ddd;
+	display: none;
+	width: 20%;
+	margin: 0 0 -99999px 0;
+	padding-bottom: 99999px;
+}
+
+#separator {
+	float: right;
+	background: #99c2ff url(images/general_sprite.png) no-repeat -26px 100px;
+	border: 1px solid #81a9cb;
+	border-top-left-radius: 3px;
+	border-top-right-radius: 3px;
+	width: 2%;
+	max-width: 10px;
+	margin: 0 auto -99999px auto;
+	padding-bottom: 99999px;
+}
+
+.use-sidebar #sidebar {
+	display: block;
+}
+
+.use-sidebar #separator {
+	background: #99c2ff url(images/general_sprite.png) no-repeat -1px 100px;
+}
+
+[dir=rtl] .use-sidebar #sidebar {
 	float: left;
 }
 
 [dir=rtl] #separator {
-	float: left;
 	background: #99c2ff url(images/general_sprite.png) no-repeat -1px 100px;
+	float: left;
 }
 
 [dir=rtl] .use-sidebar #separator {
@@ -4748,10 +4725,6 @@ a.icon-udarrow:hover {
 }
 
 /* Silhouettes on individual pages */
-#indi_mainimage {
-	min-width: 100px;
-}
-
 #indi_mainimage .icon-silhouette-F {
 	width: 99px;
 	height: 106px;

--- a/themes/xenea/css-1.5.3/style.css
+++ b/themes/xenea/css-1.5.3/style.css
@@ -3001,13 +3001,21 @@ span.link_text {
 
 /* =========== Indi header ================== */
 #indi_header {
-	float: left;
+	overflow: hidden;
 	width: 98%;
 	border-radius: 3px;
-	background: url(../jquery-ui-1.10.3/images/ui-bg_highlight-soft_100_e7eef3_1x100.png) repeat-x scroll 50% 50% #fff;
+/*	background: url(../jquery-ui-1.10.3/images/ui-bg_highlight-soft_100_e7eef3_1x100.png) repeat-x scroll 50% 50% #fff;*/
 	border: 1px solid #b2c7d7;
-	margin: 5px 0;
+	margin: 0 0 5px;
 	padding: 10px;
+	background: #e8f5f8; /* Old browsers */
+	background: -moz-linear-gradient(top,  #e8f5f8 0%, #f5fafb 60%, #fefefe 100%); /* FF3.6+ */
+	background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#e8f5f8), color-stop(60%,#f5fafb), color-stop(100%,#fefefe)); /* Chrome,Safari4+ */
+	background: -webkit-linear-gradient(top,  #e8f5f8 0%,#f5fafb 60%,#fefefe 100%); /* Chrome10+,Safari5.1+ */
+	background: -o-linear-gradient(top,  #e8f5f8 0%,#f5fafb 60%,#fefefe 100%); /* Opera 11.10+ */
+	background: -ms-linear-gradient(top,  #e8f5f8 0%,#f5fafb 60%,#fefefe 100%); /* IE10+ */
+	background: linear-gradient(to bottom,  #e8f5f8 0%,#f5fafb 60%,#fefefe 100%); /* W3C */
+	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#e8f5f8', endColorstr='#fefefe',GradientType=0 ); /* IE6-9 */
 }
 
 #indi_header h3 {
@@ -3016,11 +3024,11 @@ span.link_text {
 	margin: 0;
 	padding: 0 10px 0 30px;
 	text-align: left;
-}
-
-#indi_header h3.name_one {
 	overflow: hidden;
 	position: relative;
+}
+
+#indi_header .name_one {
 	font-size: 1.5em;
 }
 
@@ -3070,15 +3078,6 @@ span.link_text {
 	font-size: 2em;
 	margin: 10px;
 	font-weight: bold;
-}
-
-#indi_mainimage {
-	float: left;
-}
-
-#indi_mainimage a img {
-	float: left;
-	padding: 0;
 }
 
 .indi_name_details {
@@ -3140,10 +3139,6 @@ span.link_text {
 	padding: 3px;
 }
 
-#header_accordion1 {
-	float: right;
-}
-
 .indi_table {
 	clear: left;
 }
@@ -3184,17 +3179,9 @@ dd .deletelink {
 	float: right;
 }
 
-[dir=rtl] #indi_mainimage a img {
-	float: right;
-}
-
 [dir=rtl] #indi_note .fact_NOTE {
 	float: right;
 	margin: 0 0 0 10px;
-}
-
-[dir=rtl] #header_accordion1 {
-	float: left;
 }
 
 [dir=rtl] .indi_table {
@@ -3781,6 +3768,7 @@ dd .deletelink {
 #main {
 	min-width: 600px;
 	width: 100%;
+	overflow: hidden;
 }
 
 #indi_left {
@@ -3791,16 +3779,16 @@ dd .deletelink {
 #tabs {
 	background-color: #fff;
 	border-color: #ddd;
-	float: left;
 	width: 100%;
 	overflow: visible;
 }
 
-#sidebar {
-	border-color: #ddd;
-	display: none;
-	margin: 5px 2px 0 0;
-	height: auto;
+[dir=rtl] #indi_left {
+	float: right;
+}
+
+[dir=rtl] #tabs {
+	float: right;
 }
 
 #sidebarAccordion,
@@ -3819,54 +3807,40 @@ dd .deletelink {
 	width: 77%;
 }
 
-.use-sidebar #sidebar {
-	display: block;
-}
-
-.sidebar-at-right #sidebar {
+#sidebar {
+	float:right;
+	border-color: #ddd;
+	display: none;
 	width: 20%;
 }
 
-.use-sidebar.sidebar-at-right #sidebar,
-.sidebar-at-right #separator {
-	float: right;
-}
-
 #separator {
-	display: block;
+	float: right;
 	background: #c3dfff url(images/indi_sprite.png) no-repeat -26px 100px;
-	min-width: 6px;
-	max-width: 10px;
-	width: 0.75%;
-	border: 1px solid #999;
+	border: 1px solid #81a9cb;
 	border-top-left-radius: 3px;
 	border-top-right-radius: 3px;
-	margin-top: 5px;
+	width: 2%;
+	max-width: 10px;
+	margin: 0 auto -99999px auto;
+	padding-bottom: 99999px;
+}
+
+.use-sidebar #sidebar {
+	display: block;
 }
 
 .use-sidebar #separator {
 	background: #c3dfff url(images/indi_sprite.png) no-repeat -1px 100px;
 }
 
-[dir=rtl] #indi_left {
-	float: right;
-}
-
-[dir=rtl] #tabs {
-	float: right;
-}
-
-[dir=rtl] #sidebar {
-	margin: 5px 0 0 2px;
-}
-
-[dir=rtl] .use-sidebar.sidebar-at-right #sidebar,
-[dir=rtl] .sidebar-at-right #separator {
+[dir=rtl] .use-sidebar #sidebar {
 	float: left;
 }
 
 [dir=rtl] #separator {
 	background: #c3dfff url(images/indi_sprite.png) no-repeat -1px 100px;
+	float: left;
 }
 
 [dir=rtl] .use-sidebar #separator {
@@ -5026,7 +5000,13 @@ a.icon-uarrow:hover {
 
 /* Silhouettes on individual pages */
 #indi_mainimage {
-	min-width: 100px;
+	float: left;
+	width: 120px;
+}
+
+#indi_mainimage img {
+	display: block;
+	margin: auto;
 }
 
 #indi_mainimage .icon-silhouette-F {


### PR DESCRIPTION
This submission addresses 3 areas:
1. jQuery UI Tabs spinner option was removed in jQueryUI 1.10 so have provided an alternative solution.
2. Provide CSS only solution to resizing the header accordion - straightforward CSS
3. Provide CSS only solution to resizing the sidebar separator (This uses faux colums as described here: http://css-tricks.com/fluid-width-equal-height-columns/  One True Layout Method). I've made the separator grow to the longest of the sidebar and tabs content. My initial thought was just to make the separator track the sidebar height but when the sidebar is hidden it's height is effectively 0 so an arbitrary height needed to be set. On balance I think the current method provides a better appearance.
