### PR TITLE
Fix for indi_header width with normal sized main images. Checked for LTR...

### DIFF
--- a/themes/clouds/css-1.5.3/style.css
+++ b/themes/clouds/css-1.5.3/style.css
@@ -3089,6 +3089,7 @@ dd .deletelink {
 	border-radius: 3px;
 	overflow: hidden;
 	margin: 0 0 5px 0;
+	width: 100%;
 }
 
 #indi_header a {

--- a/themes/colors/css-1.5.3/css/colors.css
+++ b/themes/colors/css-1.5.3/css/colors.css
@@ -2916,6 +2916,7 @@ span.link_text {
 	border-radius: 3px;
 	overflow: hidden;
 	margin: 0 0 5px;
+	width: 100%;
 }
 
 #indi_header a {

--- a/themes/fab/css-1.5.3/style.css
+++ b/themes/fab/css-1.5.3/style.css
@@ -1751,8 +1751,8 @@ span.link_text {
 #indi_header {
 	overflow: hidden;
 	border-radius: 4px;
-	margin: 0 0 5px;
-	padding: 0 10px;
+	margin: 0 4px 5px;
+	width: 98%;
 }
 
 #indi_header h3 {
@@ -1785,6 +1785,10 @@ span.link_text {
 	display: block;
 	margin: auto;
 	padding: 0 0 0 5px;
+}
+
+#header_accordion1 {
+	padding: 0 10px
 }
 
 #header_accordion1 .indi_name_details {

--- a/themes/minimal/css-1.5.3/style.css
+++ b/themes/minimal/css-1.5.3/style.css
@@ -2046,7 +2046,8 @@ span.link_text:hover {
 #indi_header {
 	overflow:hidden;
 	margin: 0 0 5px;
-	padding: 0 10px 0 0;
+	padding: 0 0.2em;
+	width: 98%;
 }
 
 #indi_header h3 {
@@ -2099,6 +2100,10 @@ span.link_text:hover {
 	font-size: 2em;
 	margin: 10px;
 	font-weight: bold;
+}
+
+#header_accordion1 {
+	padding: 0 10px;
 }
 
 #header_accordion1 .indi_name_details {

--- a/themes/webtrees/css-1.5.3/style.css
+++ b/themes/webtrees/css-1.5.3/style.css
@@ -34,7 +34,7 @@ body {
 	background-color: #fff;
 	font: 12px tahoma, arial, helvetica, sans-serif;
 	margin: 1px;
-	padding-left: 5px;
+	padding: 0 5px;
 }
 
 fieldset {
@@ -3101,9 +3101,13 @@ delete links ==================== */
 	border-radius: 3px;
 	border: 1px solid #b2c7d7;
 	margin: 0 0 5px;
-	padding: 10px;
+	padding: 10px 0;
+	width: 100%;
 }
 
+#header_accordion1 {
+	padding: 0 10px;
+}
 #indi_header h3 {
 	font-size: 90%;
 	font-weight: bold;
@@ -3624,6 +3628,14 @@ dd .deletelink {
 
 [dir=rtl] #indi_left {
 	float: right;
+}
+
+#indi_left .ui-tabs-panel {
+	padding: 0;
+}
+
+#indi_left .ui-tabs-nav {
+	margin: 0 2px;
 }
 
 #tabs {

--- a/themes/xenea/css-1.5.3/style.css
+++ b/themes/xenea/css-1.5.3/style.css
@@ -3001,12 +3001,13 @@ span.link_text {
 
 /* =========== Indi header ================== */
 #indi_header {
+	width: 100%;
 	overflow: hidden;
 	border-radius: 3px;
 /*	background: url(../jquery-ui-1.10.3/images/ui-bg_highlight-soft_100_e7eef3_1x100.png) repeat-x scroll 50% 50% #fff;*/
 	border: 1px solid #b2c7d7;
 	margin: 0 0 5px;
-	padding: 10px;
+	padding: 10px 0;
 	background: #e8f5f8; /* Old browsers */
 	background: -moz-linear-gradient(top,  #e8f5f8 0%, #f5fafb 60%, #fefefe 100%); /* FF3.6+ */
 	background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#e8f5f8), color-stop(60%,#f5fafb), color-stop(100%,#fefefe)); /* Chrome,Safari4+ */
@@ -3077,6 +3078,10 @@ span.link_text {
 	font-size: 2em;
 	margin: 10px;
 	font-weight: bold;
+}
+
+#header_accordion1 {
+	padding: 0 10px;
 }
 
 #header_accordion1 .indi_name_details {


### PR DESCRIPTION
... & RTL on firefox, chrome , ie 8, 9, 10 & 11.

Fix is to add a width to #indi_header. All the other stuff is to get the display as close to v1.5.3 as possible
