### PR TITLE
Various CSS fixs for RTL languages

### DIFF
--- a/pedigree.php
+++ b/pedigree.php
@@ -252,6 +252,7 @@ echo '</div>'; //close #pedigree-page
 
 // Expand <div id="content"> to include the absolutely-positioned elements.
 $controller->addInlineJavascript('
+	jQuery("html").css("overflow","visible"); // workaround for chrome v37 canvas bugs
 	content_div = document.getElementById("content");
 	if (content_div) {
 		content_div.style.height="'.($maxyoffset+30).'px";

--- a/themes/colors/css-1.5.3/css/colors.css
+++ b/themes/colors/css-1.5.3/css/colors.css
@@ -369,8 +369,8 @@ span.title {
 	width: 100%;
 }
 
-[dir=rtl] #main-menu {
-	padding-right: 16px;
+[dir=rtl] #main-menu > li {
+	margin: 4px 16px 0 0;
 }
 
 [dir=rtl] #main-menu li {

--- a/themes/fab/css-1.5.3/style.css
+++ b/themes/fab/css-1.5.3/style.css
@@ -579,7 +579,7 @@ div.fact_SHARED_NOTE {
 /*-- pedigree chart rtl specific stylesheets --*/
 [dir=rtl] #pedigree_chart {
 	left: auto;
-	right: 10px;
+	right: 0;
 }
 
 /* Printer friendliness */

--- a/themes/webtrees/css-1.5.3/style.css
+++ b/themes/webtrees/css-1.5.3/style.css
@@ -34,7 +34,7 @@ body {
 	background-color: #fff;
 	font: 12px tahoma, arial, helvetica, sans-serif;
 	margin: 1px;
-	padding-left: 5px;
+	padding: 0 5px;
 }
 
 fieldset {
@@ -665,12 +665,16 @@ a:hover .nameZoom {
 	text-align: center;
 }
 
+#my-page h1 {
+	margin: 0.25em auto 0.6em;
+}
+
 #relationship-page h3 {
 	margin: 20px 0 0 20px;
 }
 
 #relationship_chart {
-	margin: 0 20px 0;
+	margin: 0 6px;
 }
 
 .tdtop {
@@ -711,7 +715,7 @@ a:hover .nameZoom {
 
 [dir=rtl] #pedigree_chart {
 	left: auto;
-	right: 10px;
+	right: 0;
 }
 
 #pedigree_canvas {
@@ -895,6 +899,7 @@ a:hover .nameZoom {
 	font-size: 20px;
 	float: left;
 	padding-left: 10px;
+	margin-bottom: 5px;
 }
 
 [dir=rtl] .title {
@@ -2135,31 +2140,29 @@ div.faq_body {
 #topMenu {
 	border-top: 2px solid #81a9cb;
 	border-bottom: 2px solid #81a9cb;
-	float: left;
 	margin: 5px auto;
 	padding: 5px 0;
 	position: relative;
-	width: 100%;
-}
-
-#main-menu {
 	clear: both;
-	position: relative;
-	float: right;
-	right: 50%;
 }
 
 #main-menu,
 #main-menu ul {
-	padding: 0;
 	margin: 0;
 	list-style-type: none;
 }
 
+
+
+#main-menu {
+	margin: 0 auto;
+	display: table;
+}
+
+
 #main-menu li {
 	float: left;
 	position: relative;
-	left: 50%;
 }
 
 #main-menu li li {
@@ -2230,9 +2233,6 @@ div.faq_body {
 }
 
 /* Reverse left and right on RTL pages */
-[dir=rtl] #topMenu {
-	float: right;
-}
 
 [dir=rtl] #main-menu li {
 	float: right;
@@ -2627,6 +2627,14 @@ div.faq_body {
 
 [dir=rtl] #menu-indi-del {
 	background-position: right -840px;
+}
+
+#menu-indi-orderfam {
+	background-position: left 0;
+}
+
+[dir=rtl] #menu-indi-orderfam {
+	background-position: right 0;
 }
 
 #menu-indi-editraw {

--- a/themes/xenea/css-1.5.3/style.css
+++ b/themes/xenea/css-1.5.3/style.css
@@ -307,19 +307,17 @@ textarea:required:invalid {
 #topMenu {
 	border-bottom: 2px solid #0073cf;
 	float: left;
-	height: 45px;
-	margin-bottom: 10px;
-	padding: 5px 0 10px 0;
+	height: 40px;
+	margin-bottom: 14px;
+	padding: 10px 0;
 	position: relative;
 	width: 100%;
+	clear: both;
 }
 
 #main-menu {
-	clear: both;
-	position: relative;
-	float: right;
-	right: 50%;
-	margin-top: 5px;
+	margin: 0 auto;
+	display: table;
 }
 
 #main-menu,
@@ -331,7 +329,6 @@ textarea:required:invalid {
 #main-menu li {
 	float: left;
 	position: relative;
-	left: 50%;
 }
 
 #main-menu li li {
@@ -405,10 +402,6 @@ textarea:required:invalid {
 }
 
 /* Reverse left and right on RTL pages */
-[dir=rtl] #topMenu {
-	float: right;
-}
-
 [dir=rtl] #main-menu li {
 	float: right;
 }
@@ -955,6 +948,14 @@ textarea:required:invalid {
 
 [dir=rtl] #menu-indi-del {
 	background-position: right -713px;
+}
+
+#menu-indi-orderfam {
+	background-position: left 0;
+}
+
+[dir=rtl] #menu-indi-orderfam {
+	background-position: right 0;
 }
 
 #menu-indi-addfav {


### PR DESCRIPTION
colors theme - minor css fix for topmenu to remove horizonal scrollbars
webtrees & xenia redo css for topmenu to remove horizonal scrollbars
webtrees & xenia add css to correctly position icon on 're-order families' menu option
fab & webtrees remove horizontal scrollbars on pedigree chart
pedigree.php temporary fix to remove duplicate scrollbars on chrome, pending proper fix by Google

probably best to apply #201 first
