### PR TITLE
Updated foreign key names to be unique

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -541,7 +541,7 @@ try {
 		" body       TEXT                   NOT NULL,".
 		" created    TIMESTAMP              NOT NULL DEFAULT CURRENT_TIMESTAMP,".
 		" PRIMARY KEY     (message_id),".
-		" FOREIGN KEY ##mesage_fk1 (user_id)   REFERENCES `##user` (user_id) /* ON DELETE RESTRICT */".
+		" FOREIGN KEY ##message_fk1 (user_id)   REFERENCES `##user` (user_id) /* ON DELETE RESTRICT */".
 		") COLLATE utf8_unicode_ci ENGINE=InnoDB"
 	);
 	WT_DB::exec(


### PR DESCRIPTION
This fixes a bug with MariaDB 10, where webtrees setup fails with the following error:

SQLSTATE[HY000]: General error: 1005 Can't create table `<DATABASE>`.`wt_user_setting` (errno: 121 "Duplicate key on write or update")

This bug is reported in the following places:
https://bugs.launchpad.net/webtrees/+bug/1320605
http://www.webtrees.net/index.php/en/forum/help-for-ver-1-5-3/29283-error-on-install
