### PR TITLE
Fix broken display when changes pending.

### DIFF
--- a/themes/clouds/css-1.5.4/style.css
+++ b/themes/clouds/css-1.5.4/style.css
@@ -2257,11 +2257,13 @@ form .rtl {
 
 /* Pending edits - TODO perhaps show differently in different contexts? */
 .new {
-	outline: solid blue 1px;
+	border: solid blue 1px;
+	overflow: hidden;
 }
 
 .old {
-	outline: solid red 1px;
+	border: solid red 1px;
+	overflow: hidden
 }
 
 a.showit {

--- a/themes/colors/css-1.5.4/css/colors.css
+++ b/themes/colors/css-1.5.4/css/colors.css
@@ -2087,11 +2087,13 @@ textarea {
 
 /* Pending edits - TODO perhaps show differently in different contexts? */
 .new {
-	outline: solid blue 1px;
+	border: solid blue 1px;
+	overflow: hidden;
 }
 
 .old {
-	outline: solid red 1px;
+	border: solid red 1px;
+	overflow: hidden;
 }
 
 a.showit {

--- a/themes/fab/css-1.5.4/style.css
+++ b/themes/fab/css-1.5.4/style.css
@@ -250,11 +250,13 @@ textarea:required:invalid {
 
 /* Pending edits - TODO perhaps show differently in different contexts? */
 .new {
-	outline: solid #00f 1px;
+	border: solid #00f 1px;
+	overflow: hidden;
 }
 
 .old {
-	outline: solid #f00 1px;
+	border: solid #f00 1px;
+	overflow: hidden;
 }
 
 /* Set stack level for top two header menu rows */

--- a/themes/minimal/css-1.5.4/style.css
+++ b/themes/minimal/css-1.5.4/style.css
@@ -1244,11 +1244,13 @@ img.block {
 
 /* Pending edits - TODO perhaps show differently in different contexts? */
 .new {
-	outline: solid blue 1px;
+	border: solid blue 1px;
+	overflow: hidden;
 }
 
 .old {
-	outline: solid red 1px;
+	border: solid red 1px;
+	overflow: hidden;
 }
 
 a.showit {

--- a/themes/webtrees/css-1.5.4/style.css
+++ b/themes/webtrees/css-1.5.4/style.css
@@ -1011,11 +1011,13 @@ a:hover .nameZoom {
 
 /* Pending edits - TODO perhaps show differently in different contexts? */
 .new {
-	outline: solid blue 1px;
+	border: solid blue 1px;
+	overflow: hidden;
 }
 
 .old {
-	outline: solid red 1px;
+	border: solid red 1px;
+	overflow: hidden;
 }
 
 a.showit {

--- a/themes/xenea/css-1.5.4/style.css
+++ b/themes/xenea/css-1.5.4/style.css
@@ -2157,11 +2157,13 @@ h4 {
 
 /* Pending edits - TODO perhaps show differently in different contexts? */
 .new {
-	outline: solid blue 1px;
+	border: solid blue 1px;
+	overflow: hidden;
 }
 
 .old {
-	outline: solid red 1px;
+	border: solid red 1px;
+	overflow: hidden;
 }
 
 a.showit {


### PR DESCRIPTION
eg. favourites block when pending change is to one of the displayed facts where coloured border overflows the containing element.

Reinstated after branch deleted in error
