### PR TITLE
Animate open/close sidebar

### DIFF
--- a/themes/clouds/css-1.5.4/style.css
+++ b/themes/clouds/css-1.5.4/style.css
@@ -3768,8 +3768,7 @@ span.link_text {
 
 /* ==== Sidebar ===== */
 #indi_left {
-	float: left;
-	width: 98%;
+	display: table-cell;
 }
 
 #main {
@@ -3777,6 +3776,8 @@ span.link_text {
 	width: 100%;
 	overflow: hidden;
 	padding: 5px 2px 0 2px;
+	display: table;
+	table-layout: fixed;
 }
 
 #tabs {
@@ -3786,57 +3787,50 @@ span.link_text {
 	width: 100%;
 }
 
-[dir=rtl] #indi_left {
-	float: right;
-}
-
 [dir=rtl] #tabs {
 	float: right;
 }
 
-.use-sidebar #indi_left {
-	width: 77.5%;
-}
-
 #sidebar {
-	float:right;
-	border: 1px solid #8fbcff;
-	display: none;
-	width: 20%;
-	margin: 0 1px;
+	border:         1px solid #8fbcff;
+	width:          20%;
+	display:        table-cell;
+	vertical-align: top;
 }
 
 #separator {
-	float: right;
-	background: #acf url(images/general_sprite.png) no-repeat -26px 100px;
-	border: 1px solid #8fbcff;
-	border-top-left-radius: 3px;
+	display:          table-cell;
+	width:            2.5em;
+	position:         relative;
+	background-color: transparent;
+}
+
+#separator:after {
+	position:                absolute;
+	top:                     0;
+	left:                    auto;
+	right:                   0;
+	width:                   10px;
+	height:                  99999px;
+	content:                 "";
+	border:                  1px solid #8fbcff;
+	border-top-left-radius:  3px;
 	border-top-right-radius: 3px;
-	width: 2%;
-	max-width: 10px;
-	margin: 0 auto -99999px auto;
-	padding-bottom: 99999px;
 }
 
-.use-sidebar #sidebar {
-	display: block;
+[dir=rtl] #separator:after {
+	left:  0;
+	right: auto;
 }
 
-.use-sidebar #separator {
-	background: #acf url(images/general_sprite.png) no-repeat -1px 100px;
+.separator-hidden:after,
+[dir=rtl] .separator-visible:after {
+	background: #aaccff url(images/general_sprite.png) no-repeat -26px 100px;
 }
 
-[dir=rtl] .use-sidebar #sidebar {
-	float: left;
-}
-
-[dir=rtl] #separator {
-	background: #acf url(images/general_sprite.png) no-repeat -1px 100px;
-	float: left;
-}
-
-[dir=rtl] .use-sidebar #separator {
-	background: #acf url(images/general_sprite.png) no-repeat -26px 100px;
+.separator-visible:after,
+[dir=rtl] .separator-hidden:after {
+	background: #aaccff url(images/general_sprite.png) no-repeat -1px 100px;
 }
 
 /* ==== Sidebar content items ==== */

--- a/themes/colors/css-1.5.4/css/aquamarine.css
+++ b/themes/colors/css-1.5.4/css/aquamarine.css
@@ -41,7 +41,7 @@
 .facts_label, .facts_label a, .facts_label h2, .facts_label .date,
 .list_label, .list_label a, #search-page-table, #edituser-table,
 #lightbox_content span a, #lightbox_content span a:hover,
-#separator, .use-sidebar #separator, #family_nav,
+#separator:after, #family_nav,
 .ui-state-active a:link, .ui-state-active a:visited {
 	background-color: #00a9c7;
 	color: #fff;

--- a/themes/colors/css-1.5.4/css/ash.css
+++ b/themes/colors/css-1.5.4/css/ash.css
@@ -41,7 +41,7 @@
 .facts_label, .facts_label a, .facts_label h2, .facts_label .date,
 .list_label, .list_label a, #search-page-table, #edituser-table,
 #lightbox_content span a, #lightbox_content span a:hover,
-#separator, .use-sidebar #separator, #family_nav,
+#separator:after, #family_nav,
 .ui-state-active a:link, .ui-state-active a:visited {
 	background-color: #9da5b4;
 	color: #fff;

--- a/themes/colors/css-1.5.4/css/belgianchocolate.css
+++ b/themes/colors/css-1.5.4/css/belgianchocolate.css
@@ -41,7 +41,7 @@
 .facts_label, .facts_label a, .facts_label h2, .facts_label .date,
 .list_label, .list_label a, #search-page-table, #edituser-table,
 #lightbox_content span a, #lightbox_content span a:hover,
-#separator, .use-sidebar #separator, #family_nav,
+#separator:after, #family_nav,
 .ui-state-active a:link, .ui-state-active a:visited {
 	background-color: #af2604;
 	color: #fff;

--- a/themes/colors/css-1.5.4/css/bluelagoon.css
+++ b/themes/colors/css-1.5.4/css/bluelagoon.css
@@ -41,7 +41,7 @@
 .facts_label, .facts_label a, .facts_label h2, .facts_label .date,
 .list_label, .list_label a, #search-page-table, #edituser-table,
 #lightbox_content span a, #lightbox_content span a:hover,
-#separator, .use-sidebar #separator, #family_nav,
+#separator:after, #family_nav,
 .ui-state-active a:link, .ui-state-active a:visited {
 	background-color: #5ab5ee;
 	color: #fff;

--- a/themes/colors/css-1.5.4/css/bluemarine.css
+++ b/themes/colors/css-1.5.4/css/bluemarine.css
@@ -41,7 +41,7 @@
 .facts_label, .facts_label a, .facts_label h2, .facts_label .date,
 .list_label, .list_label a, #search-page-table, #edituser-table,
 #lightbox_content span a, #lightbox_content span a:hover,
-#separator, .use-sidebar #separator, #family_nav,
+#separator:after, #family_nav,
 .ui-state-active a:link, .ui-state-active a:visited {
 	background-color: #6598cb;
 	color: #fff;

--- a/themes/colors/css-1.5.4/css/coffeeandcream.css
+++ b/themes/colors/css-1.5.4/css/coffeeandcream.css
@@ -41,7 +41,7 @@
 .facts_label, .facts_label a, .facts_label h2, .facts_label .date,
 .list_label, .list_label a, #search-page-table, #edituser-table,
 #lightbox_content span a, #lightbox_content span a:hover,
-#separator, .use-sidebar #separator, #family_nav,
+#separator:after, #family_nav,
 .ui-state-active a:link, .ui-state-active a:visited {
 	background-color: #93724f;
 	color: #fff;

--- a/themes/colors/css-1.5.4/css/coldday.css
+++ b/themes/colors/css-1.5.4/css/coldday.css
@@ -41,7 +41,7 @@
 .facts_label, .facts_label a, .facts_label h2, .facts_label .date,
 .list_label, .list_label a, #search-page-table, #edituser-table,
 #lightbox_content span a, #lightbox_content span a:hover,
-#separator, .use-sidebar #separator, #family_nav,
+#separator:after, #family_nav,
 .ui-state-active a:link, .ui-state-active a:visited {
 	background-color: #5997e3;
 	color: #fff;

--- a/themes/colors/css-1.5.4/css/colors.css
+++ b/themes/colors/css-1.5.4/css/colors.css
@@ -3623,8 +3623,7 @@ span.link_text {
 
 /* Sidebar */
 #indi_left {
-	float: left;
-	width: 98%;
+	display: table-cell;
 }
 
 #main {
@@ -3632,6 +3631,8 @@ span.link_text {
 	width: 100%;
 	overflow: hidden;
 	padding: 5px 2px 0 2px;
+	display: table;
+	table-layout: fixed;
 }
 
 #tabs {
@@ -3641,61 +3642,53 @@ span.link_text {
 	border-color: #ddd;
 }
 
-[dir=rtl] #indi_left,
 [dir=rtl] #tabs {
 	float: right;
 }
 
-.use-sidebar #indi_left {
-	width: 77.5%;
-}
-
 #sidebar {
-	float:right;
 	border-color: #ddd;
-	display: none;
 	width: 20%;
-	margin: 0 1px;
+	display: table-cell;
+	vertical-align: top;
 }
 
 #separator {
-	float: right;
-	background-image: url(../images/general_sprite.png);
-	background-position: -26px 100px;
-	background-repeat: no-repeat;
+	display:          table-cell;
+	width:            2.5em;
+	position:         relative;
+	background-color: transparent;
+}
+
+#separator:after {
+	position:                absolute;
+	top:                     0;
+	left:                    auto;
+	right:                   0;
+	width:                   10px;
+	height:                  99999px;
+	content:                 "";
 	border: 1px solid #999;
 	border-top-left-radius: 3px;
 	border-top-right-radius: 3px;
-	width: 2%;
-	max-width: 10px;
-	margin: 0 auto -99999px auto;
-	padding-bottom: 99999px;
 }
 
-.use-sidebar #sidebar {
-	display: block;
+[dir=rtl] #separator:after {
+	left:  0;
+	right: auto;
 }
 
-.use-sidebar #separator {
-	background-image: url(../images/general_sprite.png);
-	background-position: -1px 100px;
-	background-repeat: no-repeat;
-}
-
-[dir=rtl] .use-sidebar #sidebar {
-	float: left;
-}
-
-[dir=rtl] #separator {
-	background-image: url(../images/general_sprite.png);
-	background-position: -1px 100px;
-	background-repeat: no-repeat;
-	float: left;
-}
-
-[dir=rtl] .use-sidebar #separator {
+.separator-hidden:after,
+[dir=rtl] .separator-visible:after {
 	background-image: url(../images/general_sprite.png);
 	background-position: -26px 100px;
+	background-repeat: no-repeat;
+}
+
+.separator-visible:after,
+[dir=rtl] .separator-hidden:after {
+	background-image: url(../images/general_sprite.png);
+	background-position: -1px 100px;
 	background-repeat: no-repeat;
 }
 

--- a/themes/colors/css-1.5.4/css/greenbeam.css
+++ b/themes/colors/css-1.5.4/css/greenbeam.css
@@ -41,7 +41,7 @@
 .facts_label, .facts_label a, .facts_label h2, .facts_label .date,
 .list_label, .list_label a, #search-page-table, #edituser-table,
 #lightbox_content span a, #lightbox_content span a:hover,
-#separator, .use-sidebar #separator, #family_nav,
+#separator:after, #family_nav,
 .ui-state-active a:link, .ui-state-active a:visited {
 	background-color: #04af23;
 	color: #fff;

--- a/themes/colors/css-1.5.4/css/mediterranio.css
+++ b/themes/colors/css-1.5.4/css/mediterranio.css
@@ -41,7 +41,7 @@
 .facts_label, .facts_label a, .facts_label h2, .facts_label .date,
 .list_label, .list_label a, #search-page-table, #edituser-table,
 #lightbox_content span a, #lightbox_content span a:hover,
-#separator, .use-sidebar #separator, #family_nav,
+#separator:after, #family_nav,
 .ui-state-active a:link, .ui-state-active a:visited {
 	background-color: #d23014;
 	color: #fff;

--- a/themes/colors/css-1.5.4/css/mercury.css
+++ b/themes/colors/css-1.5.4/css/mercury.css
@@ -41,7 +41,7 @@
 .facts_label, .facts_label a, .facts_label h2, .facts_label .date,
 .list_label, .list_label a, #search-page-table, #edituser-table,
 #lightbox_content span a, #lightbox_content span a:hover,
-#separator, .use-sidebar #separator, #family_nav,
+#separator:after, #family_nav,
 .ui-state-active a:link, .ui-state-active a:visited {
 	background-color: #c6c8d2;
 	color: #707070;

--- a/themes/colors/css-1.5.4/css/nocturnal.css
+++ b/themes/colors/css-1.5.4/css/nocturnal.css
@@ -41,7 +41,7 @@
 .facts_label, .facts_label a, .facts_label h2, .facts_label .date,
 .list_label, .list_label a, #search-page-table, #edituser-table,
 #lightbox_content span a, #lightbox_content span a:hover,
-#separator, .use-sidebar #separator, #family_nav,
+#separator:after, #family_nav,
 .ui-state-active a:link, .ui-state-active a:visited {
 	background-color: #6a78be;
 	color: #fff;

--- a/themes/colors/css-1.5.4/css/olivia.css
+++ b/themes/colors/css-1.5.4/css/olivia.css
@@ -41,7 +41,7 @@
 .facts_label, .facts_label a, .facts_label h2, .facts_label .date,
 .list_label, .list_label a, #search-page-table, #edituser-table,
 #lightbox_content span a, #lightbox_content span a:hover,
-#separator, .use-sidebar #separator, #family_nav,
+#separator:after, #family_nav,
 .ui-state-active a:link, .ui-state-active a:visited {
 	background-color: #7db323;
 	color: #fff;

--- a/themes/colors/css-1.5.4/css/pinkplastic.css
+++ b/themes/colors/css-1.5.4/css/pinkplastic.css
@@ -41,7 +41,7 @@
 .facts_label, .facts_label a, .facts_label h2, .facts_label .date,
 .list_label, .list_label a, #search-page-table, #edituser-table,
 #lightbox_content span a, #lightbox_content span a:hover,
-#separator, .use-sidebar #separator, #family_nav,
+#separator:after, #family_nav,
 .ui-state-active a:link, .ui-state-active a:visited {
 	background-color: #f75993;
 	color: #fff;

--- a/themes/colors/css-1.5.4/css/sage.css
+++ b/themes/colors/css-1.5.4/css/sage.css
@@ -41,7 +41,7 @@
 .facts_label, .facts_label a, .facts_label h2, .facts_label .date,
 .list_label, .list_label a, #search-page-table, #edituser-table,
 #lightbox_content span a, #lightbox_content span a:hover,
-#separator, .use-sidebar #separator, #family_nav,
+#separator:after, #family_nav,
 .ui-state-active a:link, .ui-state-active a:visited {
 	background-color: #cca;
 	color: #333;

--- a/themes/colors/css-1.5.4/css/shinytomato.css
+++ b/themes/colors/css-1.5.4/css/shinytomato.css
@@ -41,7 +41,7 @@
 .facts_label, .facts_label a, .facts_label h2, .facts_label .date,
 .list_label, .list_label a, #search-page-table, #edituser-table,
 #lightbox_content span a, #lightbox_content span a:hover,
-#separator, .use-sidebar #separator, #family_nav,
+#separator:after, #family_nav,
 .ui-state-active a:link, .ui-state-active a:visited {
 	background-color: #f96058;
 	color: #fff;

--- a/themes/colors/css-1.5.4/css/tealtop.css
+++ b/themes/colors/css-1.5.4/css/tealtop.css
@@ -41,7 +41,7 @@
 .facts_label, .facts_label a, .facts_label h2, .facts_label .date,
 .list_label, .list_label a, #search-page-table, #edituser-table,
 #lightbox_content span a, #lightbox_content span a:hover,
-#separator, .use-sidebar #separator, #family_nav,
+#separator:after, #family_nav,
 .ui-state-active a:link, .ui-state-active a:visited {
 	background-color: #51b389;
 	color: #fff;

--- a/themes/fab/css-1.5.4/style.css
+++ b/themes/fab/css-1.5.4/style.css
@@ -2368,11 +2368,12 @@ dd .deletelink {
 	width: 100%;
 	padding: 3px 0 0 0;
 	overflow: hidden;
+	display: table;
+	table-layout: fixed;
 }
 
 #indi_left {
-	float: left;
-	width: 98%;
+	display: table-cell;
 }
 
 #tabs {
@@ -2382,117 +2383,50 @@ dd .deletelink {
 	margin-bottom: 0;
 }
 
-[dir=rtl] #indi_left {
-	float: right;
-}
-
 [dir=rtl] #tabs {
 	float: right;
 }
 
-.use-sidebar #indi_left {
-	width: 77.5%;
-}
-
 #sidebar {
-	float:right;
-	display: none;
-	width: 20%;
-	margin: 0 1px;
-}
-
-#separator {
-	float: right;
-	background: #ccc url(images/indi_sprite.png) no-repeat -26px 100px;
-	border: 1px solid #aaa;
-	border-top-left-radius: 4px;
-	border-top-right-radius: 4px;
-	width: 2%;
-	max-width: 10px;
-	margin: 0 auto -99999px auto;
-	padding-bottom: 99999px;
-}
-
-.use-sidebar #sidebar {
-	display: block;
-}
-
-.use-sidebar #separator {
-	background: #ccc url(images/indi_sprite.png) no-repeat -1px 100px;
-}
-
-[dir=rtl] .use-sidebar #sidebar {
-	float: left;
-}
-
-[dir=rtl] #separator {
-	background: #ccc url(images/indi_sprite.png) no-repeat -1px 100px;
-	float: left;
-}
-
-[dir=rtl] .use-sidebar #separator {
-	background: #ccc url(images/indi_sprite.png) no-repeat -26px 100px;
-}
-
-/*
-#sidebar {
-	display: none;
-	margin: 5px 2px 0 0;
-	height: auto;
-}
-
-.use-sidebar #indi_left {
-	width: 77%;
-}
-
-.use-sidebar #sidebar {
-	display: block;
-}
-
-.sidebar-at-right #sidebar {
+	display: table-cell;
+	vertical-align: top;
 	width: 20%;
 }
 
-.use-sidebar.sidebar-at-right #sidebar,
-.sidebar-at-right #separator {
-	float: right;
+#separator {
+	display:          table-cell;
+	width:            2.5em;
+	position:         relative;
+	background-color: transparent;
 }
 
-#separator {
-	float: right;
-	display: block;
-	background: #ccc url(images/indi_sprite.png) no-repeat -26px 100px;
-	min-width: 6px;
-	max-width: 10px;
-	width: 0.75%;
+#separator:after {
+	position:                absolute;
+	top:                     0;
+	left:                    auto;
+	right:                   0;
+	width:                   10px;
+	height:                  99999px;
+	content:                 "";
 	border: 1px solid #aaa;
 	border-top-left-radius: 4px;
 	border-top-right-radius: 4px;
-	margin-top: 5px;
 }
 
-.use-sidebar #separator {
-	background: #ccc url(images/indi_sprite.png) no-repeat -1px 100px;
+[dir=rtl] #separator:after {
+	left:  0;
+	right: auto;
 }
 
-[dir=rtl] #sidebar {
-	margin: 5px 0 0 2px;
-}
-
-[dir=rtl] .use-sidebar.sidebar-at-right #sidebar,
-[dir=rtl] .sidebar-at-right #separator {
-	float: left;
-}
-
-[dir=rtl] #separator {
-	float: left;
-	background: #ccc url(images/indi_sprite.png) no-repeat -1px 100px;
-}
-
-[dir=rtl] .use-sidebar #separator {
+.separator-hidden:after,
+[dir=rtl] .separator-visible:after {
 	background: #ccc url(images/indi_sprite.png) no-repeat -26px 100px;
 }
-*/
+
+.separator-visible:after,
+[dir=rtl] .separator-hidden:after {
+	background: #ccc url(images/indi_sprite.png) no-repeat -1px 100px;
+}
 
 #sidebarAccordion,
 #sidebarAccordion2 {

--- a/themes/minimal/css-1.5.4/style.css
+++ b/themes/minimal/css-1.5.4/style.css
@@ -2769,15 +2769,12 @@ dd .deletelink {
 	width: 100%;
 	overflow: hidden;
 	padding-top: 5px;
+	display: table;
+	table-layout: fixed;
 }
 
 #indi_left {
-	float: left;
-	width: 98%;
-}
-
-[dir=rtl] #indi_left {
-	float: right;
+	display: table-cell;
 }
 
 #tabs {
@@ -2800,110 +2797,48 @@ dd .deletelink {
 	border: 1px solid #888;
 }
 
-.use-sidebar #indi_left {
-	width: 77.5%;
-}
-
 #sidebar {
-	float:right;
 	border-color: #ddd;
-	display: none;
 	width: 20%;
-	margin: 0 1px;
+	display: table-cell;
+	vertical-align: top;
 }
 
 #separator {
-	float: right;
-	background: #ddd url(images/indi_sprite.png) no-repeat -26px 100px;
+	display:          table-cell;
+	width:            2.5em;
+	position:         relative;
+	background-color: transparent;
+}
+
+#separator:after {
+	position:                absolute;
+	top:                     0;
+	left:                    auto;
+	right:                   0;
+	width:                   10px;
+	height:                  99999px;
+	content:                 "";
 	border: 1px solid #81a9cb;
 	border-top-left-radius: 3px;
 	border-top-right-radius: 3px;
-	width: 2%;
-	max-width: 10px;
-	margin: 0 auto -99999px auto;
-	padding-bottom: 99999px;
 }
 
-.use-sidebar #sidebar {
-	display: block;
+[dir=rtl] #separator:after {
+	left:  0;
+	right: auto;
 }
 
-.use-sidebar #separator {
-	background: #ddd url(images/indi_sprite.png) no-repeat -1px 100px;
-}
-
-[dir=rtl] .use-sidebar #sidebar {
-	float: left;
-}
-
-[dir=rtl] #separator {
-	background: #ddd url(images/indi_sprite.png) no-repeat -1px 100px;
-	float: left;
-}
-
-[dir=rtl] .use-sidebar #separator {
+.separator-hidden:after,
+[dir=rtl] .separator-visible:after {
 	background: #ddd url(images/indi_sprite.png) no-repeat -26px 100px;
 }
-/*
-#sidebar {
-	border-color: #ddd;
-	display: none;
-	margin: 5px 2px 0 0;
-	height: auto;
-}
 
-.use-sidebar #indi_left {
-	width: 77%;
-}
-
-.use-sidebar #sidebar {
-	display: block;
-}
-
-.sidebar-at-right #sidebar {
-	width: 20%;
-}
-
-.use-sidebar.sidebar-at-right #sidebar,
-.sidebar-at-right #separator {
-	float: right;
-}
-
-#separator {
-	display: block;
-	background: #ddd url(images/indi_sprite.png) no-repeat -26px 100px;
-	min-width: 6px;
-	max-width: 10px;
-	width: 0.75%;
-	border: 1px solid #888;
-	border-top-left-radius: 3px;
-	border-top-right-radius: 3px;
-	margin-top: 5px;
-}
-
-.use-sidebar #separator {
+.separator-visible:after,
+[dir=rtl] .separator-hidden:after {
 	background: #ddd url(images/indi_sprite.png) no-repeat -1px 100px;
 }
 
-
-
-[dir=rtl] #sidebar {
-	margin: 5px 0 0 2px;
-}
-
-[dir=rtl] .use-sidebar.sidebar-at-right #sidebar,
-[dir=rtl] .sidebar-at-right #separator {
-	float: left;
-}
-
-[dir=rtl] #separator {
-	background: #ddd url(images/indi_sprite.png) no-repeat -1px 100px;
-}
-
-[dir=rtl] .use-sidebar #separator {
-	background: #ddd url(images/indi_sprite.png) no-repeat -26px 100px;
-}
-*/
 /* ============== Sidebar content items ============== */
 /* Family navigator */
 #sb_content_family_nav {

--- a/themes/webtrees/css-1.5.4/style.css
+++ b/themes/webtrees/css-1.5.4/style.css
@@ -2091,7 +2091,7 @@ div.faq_body {
 #topMenu {
 	border-top: 2px solid #81a9cb;
 	border-bottom: 2px solid #81a9cb;
-	margin: 5px auto;
+	margin: 8px auto;
 	padding: 5px 0;
 	position: relative;
 	clear: both;
@@ -3586,16 +3586,12 @@ dd .deletelink {
 	min-width: 600px;
 	width: 100%;
 	overflow: hidden;
-	padding: 5px 0 0 0;
+	display: table;
+	table-layout: fixed;
 }
 
 #indi_left {
-	float: left;
-	width: 98%;
-}
-
-[dir=rtl] #indi_left {
-	float: right;
+	display: table-cell;
 }
 
 #indi_left .ui-tabs-panel {
@@ -3618,49 +3614,46 @@ dd .deletelink {
 }
 
 /* sidebar */
-.use-sidebar #indi_left {
-	width: 77.5%;
-}
-
 #sidebar {
-	float:right;
-	border-color: #ddd;
-	display: none;
-	width: 20%;
-	margin: 0 1px;
+	border-color:   #dddddd;
+	width:          20%;
+	display:        table-cell;
+	vertical-align: top;
 }
 
 #separator {
-	float: right;
-	background: #99c2ff url(images/general_sprite.png) no-repeat -26px 100px;
-	border: 1px solid #81a9cb;
-	border-top-left-radius: 3px;
+	display:          table-cell;
+	width:            2.5em;
+	position:         relative;
+	background-color: transparent;
+}
+
+#separator:after {
+	position:                absolute;
+	top:                     0;
+	right:                   0;
+	left:                    auto;
+	width:                   10px;
+	height:                  99999px;
+	content:                 "";
+	border:                  1px solid #81a9cb;
+	border-top-left-radius:  3px;
 	border-top-right-radius: 3px;
-	width: 2%;
-	max-width: 10px;
-	margin: 0 auto -99999px auto;
-	padding-bottom: 99999px;
 }
 
-.use-sidebar #sidebar {
-	display: block;
+[dir=rtl] #separator:after {
+	right: auto;
+	left:  0;
 }
 
-.use-sidebar #separator {
-	background: #99c2ff url(images/general_sprite.png) no-repeat -1px 100px;
-}
-
-[dir=rtl] .use-sidebar #sidebar {
-	float: left;
-}
-
-[dir=rtl] #separator {
-	background: #99c2ff url(images/general_sprite.png) no-repeat -1px 100px;
-	float: left;
-}
-
-[dir=rtl] .use-sidebar #separator {
+.separator-hidden:after,
+[dir=rtl] .separator-visible:after {
 	background: #99c2ff url(images/general_sprite.png) no-repeat -26px 100px;
+}
+
+.separator-visible:after,
+[dir=rtl] .separator-hidden:after {
+	background: #99c2ff url(images/general_sprite.png) no-repeat -1px 100px;
 }
 
 /* ============== Sidebar content items ============== */

--- a/themes/xenea/css-1.5.4/style.css
+++ b/themes/xenea/css-1.5.4/style.css
@@ -3749,11 +3749,12 @@ dd .deletelink {
 	min-width: 600px;
 	width: 100%;
 	overflow: hidden;
+	display: table;
+	table-layout: fixed;
 }
 
 #indi_left {
-	float: left;
-	width: 98%;
+	display: table-cell;
 }
 
 #tabs {
@@ -3761,10 +3762,6 @@ dd .deletelink {
 	border-color: #ddd;
 	width: 100%;
 	overflow: visible;
-}
-
-[dir=rtl] #indi_left {
-	float: right;
 }
 
 [dir=rtl] #tabs {
@@ -3783,49 +3780,46 @@ dd .deletelink {
 	border-color: #999;
 }
 
-.use-sidebar #indi_left {
-	width: 77.5%;
-}
-
 #sidebar {
-	float:right;
 	border-color: #ddd;
-	display: none;
 	width: 20%;
-	margin: 0 1px;
+	display: table-cell;
+	vertical-align: top;
 }
 
 #separator {
-	float: right;
-	background: #c3dfff url(images/indi_sprite.png) no-repeat -26px 100px;
+	display:          table-cell;
+	width:            2.5em;
+	position:         relative;
+	background-color: transparent;
+}
+
+#separator:after {
+	position:                absolute;
+	top:                     0;
+	left:                    auto;
+	right:                   0;
+	width:                   10px;
+	height:                  99999px;
+	content:                 "";
 	border: 1px solid #81a9cb;
 	border-top-left-radius: 3px;
 	border-top-right-radius: 3px;
-	width: 2%;
-	max-width: 10px;
-	margin: 0 auto -99999px auto;
-	padding-bottom: 99999px;
 }
 
-.use-sidebar #sidebar {
-	display: block;
+[dir=rtl] #separator:after {
+	left:  0;
+	right: auto;
 }
 
-.use-sidebar #separator {
-	background: #c3dfff url(images/indi_sprite.png) no-repeat -1px 100px;
-}
-
-[dir=rtl] .use-sidebar #sidebar {
-	float: left;
-}
-
-[dir=rtl] #separator {
-	background: #c3dfff url(images/indi_sprite.png) no-repeat -1px 100px;
-	float: left;
-}
-
-[dir=rtl] .use-sidebar #separator {
+.separator-hidden:after,
+[dir=rtl] .separator-visible:after {
 	background: #c3dfff url(images/indi_sprite.png) no-repeat -26px 100px;
+}
+
+.separator-visible:after,
+[dir=rtl] .separator-hidden:after {
+	background: #c3dfff url(images/indi_sprite.png) no-repeat -1px 100px;
 }
 
 /* ============== Sidebar content items ============== */


### PR DESCRIPTION
I offer this as an enhancement;

Rather than float the main content and sidebar elements, they are now set as “display: table-cell”, this enables a couple of improvements
1. The spacing between the “columns” can be explicitly set, consequently it doesn’t vary as the browser width changes. I’ve set it to be as close as possible to the current spacing with a reasonable browser width but the padding on the #indi-left & #sidebar elements can be altered to taste.
2. It is now possible to animate the open/close of the sidebar which is in my opinion a visual improvement acting in a similar manner to an accordion open/close.

I also converted the javascript to an object so that the functions could be removed from the global namespace, however as the final solution doesn’t have any functions this may be considered un-necessary, nevertheless I’ve left it in place.
