### PR TITLE
Fix display corruption on IE

### DIFF
--- a/individual.php
+++ b/individual.php
@@ -108,7 +108,7 @@ var WT_INDIVIDUAL = (function () {
 		jQuery ("#tabs").tabs ({
 			// If url has a hash (e.g #stories) then don\'t set an active tab - it overrides the hash
 			// otherwise use cookie
-			active: document.location.hash ? null : jQuery.cookie ("indi-tab"),
+			active: location.hash ? null : jQuery.cookie ("indi-tab"),
 			activate: function (event, ui) {
 				jQuery.cookie ("indi-tab", jQuery ("#tabs").tabs ("option", "active"));
 			},

--- a/themes/clouds/css-1.5.4/style.css
+++ b/themes/clouds/css-1.5.4/style.css
@@ -3774,7 +3774,6 @@ span.link_text {
 #main {
 	min-width: 600px;
 	width: 100%;
-	overflow: hidden;
 	padding: 5px 2px 0 2px;
 	display: table;
 	table-layout: fixed;
@@ -3792,10 +3791,13 @@ span.link_text {
 }
 
 #sidebar {
-	border:         1px solid #8fbcff;
 	width:          20%;
 	display:        table-cell;
 	vertical-align: top;
+}
+
+#sidebarAccordion {
+	border: 1px solid #8fbcff;
 }
 
 #separator {
@@ -3803,6 +3805,7 @@ span.link_text {
 	width:            2.5em;
 	position:         relative;
 	background-color: transparent;
+	overflow: hidden;
 }
 
 #separator:after {

--- a/themes/colors/css-1.5.4/css/colors.css
+++ b/themes/colors/css-1.5.4/css/colors.css
@@ -3629,7 +3629,6 @@ span.link_text {
 #main {
 	min-width: 600px;
 	width: 100%;
-	overflow: hidden;
 	padding: 5px 2px 0 2px;
 	display: table;
 	table-layout: fixed;
@@ -3647,7 +3646,6 @@ span.link_text {
 }
 
 #sidebar {
-	border-color: #ddd;
 	width: 20%;
 	display: table-cell;
 	vertical-align: top;
@@ -3658,6 +3656,7 @@ span.link_text {
 	width:            2.5em;
 	position:         relative;
 	background-color: transparent;
+	overflow: hidden;
 }
 
 #separator:after {

--- a/themes/fab/css-1.5.4/style.css
+++ b/themes/fab/css-1.5.4/style.css
@@ -2367,7 +2367,6 @@ dd .deletelink {
 	min-width: 600px;
 	width: 100%;
 	padding: 3px 0 0 0;
-	overflow: hidden;
 	display: table;
 	table-layout: fixed;
 }
@@ -2398,6 +2397,7 @@ dd .deletelink {
 	width:            2.5em;
 	position:         relative;
 	background-color: transparent;
+	overflow: hidden;
 }
 
 #separator:after {
@@ -2428,13 +2428,11 @@ dd .deletelink {
 	background: #ccc url(images/indi_sprite.png) no-repeat -1px 100px;
 }
 
-#sidebarAccordion,
-#sidebarAccordion2 {
+#sidebarAccordion {
 	width: auto;
 }
 
-#sidebarAccordion h3,
-#sidebarAccordion2 h3 {
+#sidebarAccordion h3 {
 	text-align: center;
 }
 

--- a/themes/minimal/css-1.5.4/style.css
+++ b/themes/minimal/css-1.5.4/style.css
@@ -2768,7 +2768,6 @@ dd .deletelink {
 #main {
 	min-width: 600px;
 	width: 100%;
-	overflow: hidden;
 	padding-top: 0px;
 	display: table;
 	table-layout: fixed;
@@ -2785,13 +2784,11 @@ dd .deletelink {
 	overflow: auto;
 }
 
-#sidebarAccordion,
-#sidebarAccordion2 {
+#sidebarAccordion {
 	width: auto;
 }
 
-#sidebarAccordion h3,
-#sidebarAccordion2 h3 {
+#sidebarAccordion h3 {
 	height: 30px;
 	text-align: center;
 	background: #ddd;
@@ -2799,7 +2796,6 @@ dd .deletelink {
 }
 
 #sidebar {
-	border-color: #ddd;
 	width: 20%;
 	display: table-cell;
 	vertical-align: top;
@@ -2810,6 +2806,7 @@ dd .deletelink {
 	width:            2.5em;
 	position:         relative;
 	background-color: transparent;
+	overflow: hidden;
 }
 
 #separator:after {
@@ -2820,8 +2817,8 @@ dd .deletelink {
 	width:                   10px;
 	height:                  99999px;
 	content:                 "";
-	border: 1px solid #81a9cb;
-	border-top-left-radius: 3px;
+	border:                  1px solid #888;
+	border-top-left-radius:  3px;
 	border-top-right-radius: 3px;
 }
 

--- a/themes/webtrees/css-1.5.4/style.css
+++ b/themes/webtrees/css-1.5.4/style.css
@@ -3585,7 +3585,6 @@ dd .deletelink {
 #main {
 	min-width: 600px;
 	width: 100%;
-	overflow: hidden;
 	display: table;
 	table-layout: fixed;
 }
@@ -3615,7 +3614,6 @@ dd .deletelink {
 
 /* sidebar */
 #sidebar {
-	border-color:   #dddddd;
 	width:          20%;
 	display:        table-cell;
 	vertical-align: top;
@@ -3626,6 +3624,7 @@ dd .deletelink {
 	width:            2.5em;
 	position:         relative;
 	background-color: transparent;
+	overflow: hidden;
 }
 
 #separator:after {

--- a/themes/xenea/css-1.5.4/style.css
+++ b/themes/xenea/css-1.5.4/style.css
@@ -3748,7 +3748,6 @@ dd .deletelink {
 #main {
 	min-width: 600px;
 	width: 100%;
-	overflow: hidden;
 	display: table;
 	table-layout: fixed;
 }
@@ -3768,20 +3767,17 @@ dd .deletelink {
 	float: right;
 }
 
-#sidebarAccordion,
-#sidebarAccordion2 {
+#sidebarAccordion {
 	width: auto;
 }
 
-#sidebarAccordion h3,
-#sidebarAccordion2 h3 {
+#sidebarAccordion h3 {
 	height: 30px;
 	text-align: center;
 	border-color: #999;
 }
 
 #sidebar {
-	border-color: #ddd;
 	width: 20%;
 	display: table-cell;
 	vertical-align: top;
@@ -3792,6 +3788,7 @@ dd .deletelink {
 	width:            2.5em;
 	position:         relative;
 	background-color: transparent;
+	overflow: hidden;
 }
 
 #separator:after {
@@ -3802,8 +3799,8 @@ dd .deletelink {
 	width:                   10px;
 	height:                  99999px;
 	content:                 "";
-	border: 1px solid #81a9cb;
-	border-top-left-radius: 3px;
+	border:                  1px solid #81a9cb;
+	border-top-left-radius:  3px;
 	border-top-right-radius: 3px;
 }
 


### PR DESCRIPTION
My recent submission (#223) resulted in a corrupt display on Internet explorer when displaying a story which was selected from the main menu. It was caused by having to set an explicit (and overly long) height on the "#separator:after" element which seems to confuse IEs positioning calculation when a hash is present on the URL. Setting overflow:hidden on the #separator element fixes it. 

![screenshot](https://cloud.githubusercontent.com/assets/104515/4009491/29b05b94-29e5-11e4-8e08-e3ef00ca4872.jpg)
