### PR TITLE
Fix inconsistent language string

### DIFF
--- a/admin_trees_renumber.php
+++ b/admin_trees_renumber.php
@@ -257,7 +257,7 @@ if (WT_Filter::get('go')) {
 
 	}
 } else {
-	echo '<p>', WT_I18N::translate('In a family tree, each record has an internal reference number (called an “XREF”), such as “F123” or “R14”.') ,'</p>';
+	echo '<p>', WT_I18N::translate('In a family tree, each record has an internal reference number (called an “XREF”) such as “F123” or “R14”.') ,'</p>';
 	echo '<p>', WT_I18N::translate('You can renumber the records in a family tree, so that these internal reference numbers are not duplicated in any other family tree.') ,'</p>';
 }
 


### PR DESCRIPTION
This string had an additional comma that was preventing it from being translated properly
