### PR TITLE
Fix error with abbreviated weekdays names for French calendar

### DIFF
--- a/library/WT/Date/Calendar.php
+++ b/library/WT/Date/Calendar.php
@@ -40,7 +40,7 @@ class WT_Date_Calendar {
 	static $MONTH_ABBREV = array('' => 0, 'JAN' => 1, 'FEB' => 2, 'MAR' => 3, 'APR' => 4, 'MAY' => 5, 'JUN' => 6, 'JUL' => 7, 'AUG' => 8, 'SEP' => 9, 'OCT' => 10, 'NOV' => 11, 'DEC' => 12);
 
 	/** @var string[] Convert numbers to/from roman numerals */
-	private static $roman_numerals = array(1000 => 'M', 900 => 'CM', 500 => 'D', 400 => 'CD', 100 => 'C', 90 => 'XC', 50 => 'L', 40 => 'XL', 10 => 'X', 9 => 'IX', 5 => 'V', 4 => 'IV', 1 => 'I');
+	protected static $roman_numerals = array(1000 => 'M', 900 => 'CM', 500 => 'D', 400 => 'CD', 100 => 'C', 90 => 'XC', 50 => 'L', 40 => 'XL', 10 => 'X', 9 => 'IX', 5 => 'V', 4 => 'IV', 1 => 'I');
 
 	/** @var CalendarInterface The calendar system used to represent this date */
 	protected $calendar;
@@ -397,7 +397,7 @@ class WT_Date_Calendar {
 	 *
 	 * @return string
 	 */
-	private static function dayNamesAbbreviated($day_number) {
+	protected static function dayNamesAbbreviated($day_number) {
 		switch ($day_number) {
 		case 0:
 			return WT_I18N::translate('Mon');

--- a/library/WT/Date/Jewish.php
+++ b/library/WT/Date/Jewish.php
@@ -276,7 +276,7 @@ class WT_Date_Jewish extends WT_Date_Calendar {
 	 *
 	 * @return string
 	 */
-	private static function numberToHebrewNumerals($num) {
+	protected static function numberToHebrewNumerals($num) {
 		$DISPLAY_JEWISH_THOUSANDS = false;
 
 		static $jHundreds = array("", "ק", "ר", "ש", "ת", "תק", "תר", "תש", "תת", "תתק");


### PR DESCRIPTION
**Issue example**:
- Configure a tree to use French calendar conversion
- Create a custom translation to display the weekday name in the dates (e.g. `'%j %F %Y' => '%D %j %F %Y'`)
- Open the calendar to date 13/01/1794 which is Nonidi 24 Nivôse II

**Error displayed / Stacktrace**:
`InvalidArgumentException: 8 in [...]\library\WT\Date\Calendar.php on line 417`

| Function | Location |
| --- | --- |
| `WT_Date->display( $url = ???, $date_format = ???, $convert_calendars = ??? )` | ..\calendar.php:141 |
| `WT_Date_Calendar->format( $format = '%D %j %F %Y', $qualifier = NULL )` | ..\Date.php:218 |
| `WT_Date_Calendar->formatShortWeekday( )` | ..\Calendar.php:649 |
| `WT_Date_Calendar::dayNamesAbbreviated( $day_number = 8 )` | ..\Calendar.php:743` |

**Cause**: 
The underlying cause is the 10-days weeks in the French Calendar, hence the expression `$this->minJD % static::DAYS_IN_WEEK`(line 743 of Calendar.php) can return a number superior to 6 (up to 9).
The problem  is the use of the `private` modifier in the base class that prevents the method `dayNamesAbbreviated` from being inherited/overriden by the `WT_Date_French' subclass implementation of the same method.

A change of the modifier from `private` to `protected` fix the issue. I have as well modified the other uses of the `private`modifier in the Calendar classes, just in case they need to be overriden by subclasses
