### PR TITLE
Remove the need for the <main> element to have an ID

### DIFF
--- a/pedigree.php
+++ b/pedigree.php
@@ -249,11 +249,11 @@ echo '<canvas id="pedigree_canvas" width="' . (int)($canvaswidth) . '" height="'
 echo '</div>'; //close #pedigree_chart
 echo '</div>'; //close #pedigree-page
 
-// Expand <div id="content"> to include the absolutely-positioned elements.
+// Expand <div id="#pedigree-page"> to include the absolutely-positioned elements.
 $controller->addInlineJavascript('
 	var WT_PEDIGREE_CHART = (function() {
 	jQuery("html").css("overflow","visible"); // workaround for chrome v37 canvas bugs
-	jQuery("#content").css("height", "' . ($maxyoffset + 30) . '");
+	jQuery("#pedigree-page").css("height", "' . ($maxyoffset + 30) . '");
 
 	// Draw joining lines in <canvas>
 	// Set variables

--- a/themes/clouds/css-1.6.2/style.css
+++ b/themes/clouds/css-1.6.2/style.css
@@ -4263,7 +4263,7 @@ span.link_text {
 }
 
 @media print {
-	#content {
+	main {
 		padding: 0;
 	}
 

--- a/themes/clouds/header.php
+++ b/themes/clouds/header.php
@@ -120,4 +120,4 @@ foreach (WT_MenuBar::getModuleMenus() as $menu) {
 	</header>
 	<?php } ?>
 	<?php echo WT_FlashMessages::getHtmlMessages(); ?>
-	<main id="content">
+	<main>

--- a/themes/colors/header.php
+++ b/themes/colors/header.php
@@ -130,4 +130,4 @@ foreach (WT_MenuBar::getModuleMenus() as $menu) {
 	</header>
 	<?php } ?>
 	<?php echo WT_FlashMessages::getHtmlMessages(); ?>
-	<main id="content">
+	<main>

--- a/themes/fab/css-1.6.2/style.css
+++ b/themes/fab/css-1.6.2/style.css
@@ -195,7 +195,7 @@ header h1 {
 	float: right;
 }
 
-#content {
+main {
 	margin-top: 12px;
 	margin-bottom: 12px;
 }

--- a/themes/fab/header.php
+++ b/themes/fab/header.php
@@ -102,4 +102,4 @@ $this
 	</header>
 	<?php } ?>
 	<?php echo WT_FlashMessages::getHtmlMessages(); ?>
-	<main id="content">
+	<main>

--- a/themes/minimal/css-1.6.2/style.css
+++ b/themes/minimal/css-1.6.2/style.css
@@ -705,7 +705,7 @@ a .name1:hover {
 	clear: both;
 }
 
-#content {
+main {
 	clear: both;
 	margin-left: 1px;
 }

--- a/themes/minimal/header.php
+++ b/themes/minimal/header.php
@@ -102,4 +102,4 @@ $this
 	</header>
 	<?php } ?>
 	<?php echo WT_FlashMessages::getHtmlMessages(); ?>
-	<main id="content">
+	<main>

--- a/themes/webtrees/header.php
+++ b/themes/webtrees/header.php
@@ -99,4 +99,4 @@ $this
 	</header>
 	<?php } ?>
 	<?php echo WT_FlashMessages::getHtmlMessages(); ?>
-	<main id="content">
+	<main>

--- a/themes/xenea/css-1.6.2/style.css
+++ b/themes/xenea/css-1.6.2/style.css
@@ -1579,7 +1579,7 @@ a:hover .nameZoom {
 	clear: both;
 }
 
-#content {
+main {
 	clear: both;
 	margin-left: 1px;
 }

--- a/themes/xenea/header.php
+++ b/themes/xenea/header.php
@@ -119,4 +119,4 @@ $this
 	</header>
 	<?php } ?>
 	<?php echo WT_FlashMessages::getHtmlMessages(); ?>
-	<main id="content">
+	<main>


### PR DESCRIPTION
Also fixes bug on IE11 whereby the footer ends up between the options form and the actual chart. Even with this fix for IE11 the footer sometimes very briefly appears in the wrong position before correctly relocating. This only seems to happen with an "F5" page refresh
