### PR TITLE
Fix colors theme CSS overrides

### DIFF
--- a/themes/clouds/header.php
+++ b/themes/clouds/header.php
@@ -44,20 +44,6 @@ $this
 			}
 		});
 	');
-
-$menu_items = array(
-	WT_MenuBar::getGedcomMenu(),
-	WT_MenuBar::getMyPageMenu(),
-	WT_MenuBar::getChartsMenu(),
-	WT_MenuBar::getListsMenu(),
-	WT_MenuBar::getCalendarMenu(),
-	WT_MenuBar::getReportsMenu(),
-	WT_MenuBar::getSearchMenu(),
-);
-foreach (WT_MenuBar::getModuleMenus() as $menu) {
-	$menu_items[] = $menu;
-}
-
 ?>
 <!DOCTYPE html>
 <html <?php echo WT_I18N::html_markup(); ?>>
@@ -73,6 +59,20 @@ foreach (WT_MenuBar::getModuleMenus() as $menu) {
 	<!--[if IE 8]>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
 	<![endif]-->
+<?php
+$menu_items = array(
+	WT_MenuBar::getGedcomMenu(),
+	WT_MenuBar::getMyPageMenu(),
+	WT_MenuBar::getChartsMenu(),
+	WT_MenuBar::getListsMenu(),
+	WT_MenuBar::getCalendarMenu(),
+	WT_MenuBar::getReportsMenu(),
+	WT_MenuBar::getSearchMenu(),
+);
+foreach (WT_MenuBar::getModuleMenus() as $menu) {
+	$menu_items[] = $menu;
+}
+?>
 </head>
 <body id="body">
 	<?php if ($view !== 'simple') { ?>

--- a/themes/colors/header.php
+++ b/themes/colors/header.php
@@ -50,21 +50,6 @@ $this->addInlineJavaScript(
 	'if (jQuery("#menu-tree ul li").length == 2) jQuery("#menu-tree ul li:last-child").remove();'
 );
 
-
-
-$menu_items = array(
-	WT_MenuBar::getGedcomMenu(),
-	WT_MenuBar::getMyPageMenu(),
-	WT_MenuBar::getChartsMenu(),
-	WT_MenuBar::getListsMenu(),
-	WT_MenuBar::getCalendarMenu(),
-	WT_MenuBar::getReportsMenu(),
-	WT_MenuBar::getSearchMenu(),
-);
-foreach (WT_MenuBar::getModuleMenus() as $menu) {
-	$menu_items[] = $menu;
-}
-
 ?>
 <!DOCTYPE html>
 <html <?php echo WT_I18N::html_markup(); ?>>
@@ -84,6 +69,20 @@ foreach (WT_MenuBar::getModuleMenus() as $menu) {
 	<!--[if IE 8]>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.8.3/modernizr.min.js"></script>
 	<![endif]-->
+<?php
+	$menu_items = array(
+	WT_MenuBar::getGedcomMenu(),
+	WT_MenuBar::getMyPageMenu(),
+	WT_MenuBar::getChartsMenu(),
+	WT_MenuBar::getListsMenu(),
+	WT_MenuBar::getCalendarMenu(),
+	WT_MenuBar::getReportsMenu(),
+	WT_MenuBar::getSearchMenu(),
+);
+foreach (WT_MenuBar::getModuleMenus() as $menu) {
+	$menu_items[] = $menu;
+}
+?>
 </head>
 <body id="body">
 	<?php if ($view !== 'simple') { ?>


### PR DESCRIPTION
Custom module menu's may insert links to own CSS files before main CSS
is loaded and thus wrong entries can be chosen. This updates makes
colors theme more consistent with other themes