### PR TITLE
Decouple popup menu css from charts css

### DIFF
--- a/ancestry.php
+++ b/ancestry.php
@@ -142,7 +142,7 @@ switch ($controller->chart_style) {
 case 0:
 	// List
 	$pidarr=array();
-	echo '<ul id="ancestry_chart">';
+	echo '<ul id="ancestry_chart" class="chart_common">';
 	$controller->printChildAscendancy($controller->root, 1, $OLD_PGENS-1);
 	echo '</ul>';
 	echo '<br>';
@@ -150,7 +150,7 @@ case 0:
 case 1:
 	// TODO: this should be a parameter to a function, not a global
 	$show_cousins = $controller->show_cousins;
-	echo '<div id="ancestry_chart">';
+	echo '<div id="ancestry_booklet">';
 	// Booklet
 	// first page : show indi facts
 	print_pedigree_person($controller->root);

--- a/descendancy.php
+++ b/descendancy.php
@@ -96,13 +96,13 @@ if ($controller->error_message) {
 } else {
 	switch ($controller->chart_style) {
 	case 0: // List
-		echo '<ul style="list-style: none; display: block;" id="descendancy_chart">';
+		echo '<ul id="descendancy_chart" class="chart_common">';
 		$controller->printChildDescendancy($controller->root, $controller->generations);
 		echo '</ul>';
 		break;
 	case 1: // Booklet
 		$show_cousins = true;
-		echo '<div id="descendancy_chart">';
+		echo '<div id="descendancy_booklet">';
 		$controller->printChildFamily($controller->root, $controller->generations);
 		echo '</div>';
 		break;

--- a/library/WT/Controller/Ancestry.php
+++ b/library/WT/Controller/Ancestry.php
@@ -103,7 +103,7 @@ class WT_Controller_Ancestry extends WT_Controller_Chart {
 		}
 		// child
 		echo '<li>';
-		echo '<table border="0" cellpadding="0" cellspacing="0"><tr><td><a name="sosa', $sosa, '"></a>';
+		echo '<table><tr><td>';
 		if ($sosa==1) {
 			echo '<img src="', $WT_IMAGES['spacer'], '" height="3" width="', $Dindent, '" alt=""></td><td>';
 		} else {
@@ -136,8 +136,8 @@ class WT_Controller_Ancestry extends WT_Controller_Chart {
 
 		if ($family && $new && $depth>0) {
 			// print marriage info
-			echo '<span class="details1" style="white-space: nowrap;" >';
-			echo '<img src="', $WT_IMAGES['spacer'], '" height="2" width="', $Dindent, '" align="middle" alt=""><a href="#" onclick="return expand_layer(\'sosa_', $sosa, '\');" class="top"><i id="sosa_', $sosa, '_img" class="icon-minus" title="', WT_I18N::translate('View family'), '"></i></a>';
+			echo '<span class="details1">';
+			echo '<img src="', $WT_IMAGES['spacer'], '" height="2" width="', $Dindent, '" alt=""><a href="#" onclick="return expand_layer(\'sosa_', $sosa, '\');" class="top"><i id="sosa_', $sosa, '_img" class="icon-minus" title="', WT_I18N::translate('View family'), '"></i></a>';
 			echo '&nbsp;<span dir="ltr" class="person_box">&nbsp;', ($sosa*2), '&nbsp;</span>&nbsp;', WT_I18N::translate('and');
 			echo '&nbsp;<span dir="ltr" class="person_boxF">&nbsp;', ($sosa*2+1), '&nbsp;</span>&nbsp;';
 			if ($family->canShow()) {
@@ -147,7 +147,7 @@ class WT_Controller_Ancestry extends WT_Controller_Chart {
 			}
 			echo '</span>';
 			// display parents recursively - or show empty boxes
-			echo '<ul style="list-style: none; display: block;" id="sosa_', $sosa, '">';
+			echo '<ul id="sosa_', $sosa, '" class="generation">';
 			$this->printChildAscendancy($family->getHusband(), $sosa*2, $depth-1);
 			$this->printChildAscendancy($family->getWife(), $sosa*2+1, $depth-1);
 			echo '</ul>';

--- a/library/WT/Controller/Descendancy.php
+++ b/library/WT/Controller/Descendancy.php
@@ -133,7 +133,7 @@ class WT_Controller_Descendancy extends WT_Controller_Chart {
 		global $WT_IMAGES, $Dindent;
 
 		echo "<li>";
-		echo "<table border=\"0\" cellpadding=\"0\" cellspacing=\"0\"><tr><td>";
+		echo "<table><tr><td>";
 		if ($depth==$this->generations) echo "<img src=\"".$WT_IMAGES["spacer"]."\" height=\"3\" width=\"$Dindent\" alt=\"\"></td><td>";
 		else {
 			echo "<img src=\"".$WT_IMAGES["spacer"]."\" height=\"3\" width=\"3\" alt=\"\">";
@@ -195,7 +195,7 @@ class WT_Controller_Descendancy extends WT_Controller_Chart {
 		// print marriage info
 		echo '<li>';
 		echo '<img src="', $WT_IMAGES['spacer'], '" height="2" width="', ($Dindent+4), '" alt="">';
-		echo '<span class="details1" style="white-space:nowrap;">';
+		echo '<span class="details1">';
 		echo "<a href=\"#\" onclick=\"expand_layer('".$uid."'); return false;\" class=\"top\"><i id=\"".$uid."_img\" class=\"icon-minus\" title=\"".WT_I18N::translate('View family')."\"></i></a>";
 		if ($family->canShow()) {
 			foreach ($family->getFacts(WT_EVENTS_MARR) as $fact) {
@@ -206,9 +206,9 @@ class WT_Controller_Descendancy extends WT_Controller_Chart {
 
 		// print spouse
 		$spouse=$family->getSpouse($person);
-		echo '<ul style="list-style:none; display:block;" id="'.$uid.'">';
+		echo '<ul id="'.$uid.'" class="generation">';
 		echo '<li>';
-		echo '<table border="0" cellpadding="0" cellspacing="0"><tr><td>';
+		echo '<table><tr><td>';
 		print_pedigree_person($spouse);
 		echo '</td>';
 

--- a/themes/clouds/css-1.6.2/style.css
+++ b/themes/clouds/css-1.6.2/style.css
@@ -1376,81 +1376,61 @@ img.block {
 
 /*-- charts layout --*/
 
-#ancestry_chart table div p {
-	font-size: 90%;
-	margin: 0;
+#compact_chart,
+#fan_chart,
+.chart_common,
+#ancestry_booklet,
+#descendancy_booklet,
+#familybook_chart,
+#hourglass_chart {
+	margin: 20px;
 }
 
-#ancestry_chart span.details1 div[class^="fact_"] {
-	display: inline-block;
-}
-
-#ancestry_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
-	display: block;
+/*-- ancestry and descendancy chart common styles --*/
+.chart_common li {
 	list-style: none;
-	margin: 0 0 0 15px;
-	padding-bottom: 0;
-	padding-right: 0;
-	padding-top: 3px;
 }
 
-#ancestry_chart li {
-	list-style: none;
-	margin: 0 0 2px -13px;
-	padding-bottom: 0;
-	padding-right: 0;
-	padding-top: 0;
+.chart_common .generation {
+	background: transparent url(images/vline.png) left top repeat-y;
+	margin:     0 0 0 15px;
+	padding:    0;
+	display:    block;
 }
 
-#ancestry_chart li table {
+[dir='rtl'] .chart_common .generation {
+	margin:              0 15px 0 0;
+	background-position: right top;
+}
+
+.chart_common .generation > li {
 	margin: 5px 0;
 }
 
-[dir=rtl] #ancestry_chart ul {
-	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
+.chart_common table {
+	padding:         0;
+	border-spacing:  0;
+	border-collapse: collapse;
+	margin:          5px 0;
 }
 
-[dir=rtl] #ancestry_chart li {
-	margin: 0;
-	padding: 0 2px 0 0;
-	left: auto;
+.chart_common td {
+	border:  0;
+	padding: 0;
 }
 
-#descendancy_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
-	list-style: none;
-	margin: 0 0 5px 20px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#descendancy_chart li {
-	list-style: none;
-	margin: 5px 0 0 -15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#descendancy_chart span.details1 div[class^="fact_"] {
+.chart_common span.details1 div[class^="fact_"] {
 	display: inline-block;
 }
 
-#descendancy_chart td.details1 {
-	padding-top: 5px;
+.chart_common span.details1 .date {
+	color: inherit;
 }
 
-[dir=rtl] #descendancy_chart ul {
-	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
+.chart_common li > span.details1 {
+	white-space: nowrap;
 }
+
 
 #familybook_chart {
 	margin-left: 10px;
@@ -1604,14 +1584,6 @@ img.block {
 	position: relative;
 	top: 50px;
 	left: 0;
-}
-
-#compact_chart,
-#fan_chart,
-#ancestry_chart,
-#familybook_chart,
-#hourglass_chart {
-	margin: 20px;
 }
 
 .fan_chart_menu {
@@ -2899,61 +2871,38 @@ dt {
 	margin: 20px auto;
 }
 
-.block .itr,
-#family-table .itr,
-#ancestry_chart .itr,
-#descendancy_chart .itr,
-#familybook_chart .itr,
-#hourglass_chart .itr,
-#relatives_content .itr {
-	position: relative;
-	top: 0;
-}
-
+/* Popup menu used in boxes on charts etc. */
 .itr {
+	position: relative;
 	line-height: 1.5;
-	position: absolute;
-}
-
-.itr:hover .popup {
-	display: block;
-	position: absolute;
-	right: 0;
-	width: 12em;
-	z-index: 9999;
 }
 
 .popup {
 	display: none;
+	position: absolute;
+	top: 20px;
+	right: 0;
+	left: auto;
 }
 
 .popup ul {
-	background-image: none !important;
-	font-size: 9px;
+	white-space: nowrap;
+	font-size: smaller;
 	list-style: none;
 	margin: 0;
 	padding: 0 10px;
 }
 
-.popup li {
-	padding: 1px 5px;
+.popup > ul {
+	padding: 2px 10px;
 }
 
-.popup li span {
+.popup li .NAME {
 	padding: 0 5px;
-}
-
-.popup li ul,
-.popup li ul li,
-.popup li span span {
-	padding: 0;
 }
 
 .itr:hover .popup {
 	display: block;
-	position: absolute;
-	width: 12em;
-	right: 0;
 	z-index: 9999;
 }
 

--- a/themes/colors/css-1.6.2/style.css
+++ b/themes/colors/css-1.6.2/style.css
@@ -1314,93 +1314,61 @@ ul {
 }
 
 /* chart styles */
-#ancestry_chart {
-	margin-left: 10px;
-}
-
-#ancestry_chart span.details1 div[class^="fact_"] {
-	display: inline-block;
-}
-
-#ancestry_chart table div p {
-	font-size: 90%;
-	margin: 0;
-}
-
-#ancestry_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
-	display: block;
-	list-style: none;
-	margin: 0 0 0 15px;
-	padding-bottom: 0;
-	padding-right: 0;
-	padding-top: 3px;
-}
-
-#ancestry_chart li {
-	list-style: none;
-	margin: 0 0 2px -13px;
-	padding-bottom: 0;
-	padding-right: 0;
-	padding-top: 0;
-}
-
-#ancestry_chart li table {
-	margin: 5px 0;
-}
-
-[dir=rtl] #ancestry_chart ul {
-	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
-}
-
-[dir=rtl] #ancestry_chart li {
-	margin: 0;
-	padding: 0 2px 0 0;
-	left: auto;
-}
-
-[dir=rtl] #ancestry_chart {
-	margin-right: 10px;
-}
-
-#descendancy_chart {
+#compact_chart,
+#fan_chart,
+.chart_common,
+#ancestry_booklet,
+#descendancy_booklet,
+#familybook_chart,
+#hourglass_chart {
 	margin: 20px;
 }
 
-#descendancy_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
+/*-- ancestry and descendancy chart common styles --*/
+.chart_common li {
 	list-style: none;
-	margin: 0 0 5px 15px;
-	padding-bottom: 0;
-	padding-right: 0;
-	padding-top: 0;
 }
 
-#descendancy_chart li {
-	list-style: none;
-	margin: 5px 0 0 -15px;
-	padding-bottom: 0;
-	padding-right: 0;
-	padding-top: 0;
+.chart_common .generation {
+	background: transparent url(images/vline.png) left top repeat-y;
+	margin:     0 0 0 15px;
+	padding:    0;
+	display:    block;
 }
 
-#descendancy_chart span.details1 div[class^="fact_"] {
+[dir='rtl'] .chart_common .generation {
+	margin:              0 15px 0 0;
+	background-position: right top;
+}
+
+.chart_common .generation > li {
+	margin: 5px 0;
+}
+
+.chart_common table {
+	padding:         0;
+	border-spacing:  0;
+	border-collapse: collapse;
+	margin:          5px 0;
+}
+
+.chart_common td {
+	border:  0;
+	padding: 0;
+}
+
+.chart_common span.details1 div[class^="fact_"] {
 	display: inline-block;
 }
 
-#descendancy_chart td.details1 {
-	padding-top: 5px;
+.chart_common span.details1 .date {
+	color: inherit;
 }
 
-[dir=rtl] #descendancy_chart ul {
-	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
+.chart_common li > span.details1 {
+	white-space: nowrap;
 }
+
 
 #familybook_chart {
 	margin-left: 10px;
@@ -1557,14 +1525,6 @@ ul {
 	position: relative;
 	top: 0;
 	left: 0;
-}
-
-#compact_chart,
-#fan_chart,
-#ancestry_chart,
-#familybook_chart,
-#hourglass_chart {
-	margin: 20px;
 }
 
 .fan_chart_menu {
@@ -2715,61 +2675,39 @@ a.showit > span {
 	text-align: center;
 }
 
+/* Popup menu used in boxes on charts etc. */
 .itr {
-	line-height: 1.5;
-	position: absolute;
-}
-
-.itr:hover .popup {
-	display: block;
-	position: absolute;
-	right: 0;
-	width: 12em;
-	z-index: 10;
-}
-
-.block .itr,
-#family-table .itr,
-#ancestry_chart .itr,
-#descendancy_chart .itr,
-#familybook_chart .itr,
-#hourglass_chart .itr,
-#relatives_content .itr {
 	position: relative;
-	top: 0;
+	line-height: 1.5;
 }
 
 .popup {
 	display: none;
+	position: absolute;
+	top: 20px;
+	right: 0;
+	left: auto;
 }
 
 .popup ul {
-	background-image: none !important;
-	font-size: 9px;
+	white-space: nowrap;
+	font-size: smaller;
 	list-style: none;
 	margin: 0;
 	padding: 0 10px;
 }
 
-.popup li {
-	padding: 1px 5px;
+.popup > ul {
+	padding: 2px 10px;
 }
 
-.popup li span {
+.popup li .NAME {
 	padding: 0 5px;
-}
-
-.popup li ul,
-.popup li ul li,
-.popup li span span {
-	padding: 0;
 }
 
 .itr:hover .popup {
 	display: block;
-	position: absolute;
-	width: 12em;
-	right: 0;
+	z-index: 9999;
 }
 
 [dir=rtl] .itr:hover .popup {

--- a/themes/fab/css-1.6.2/style.css
+++ b/themes/fab/css-1.6.2/style.css
@@ -936,98 +936,63 @@ div.fact_SHARED_NOTE {
 	clear: both;
 }
 
-/*-- descendancy chart specific stylesheets --*/
-#descendancy_chart {
-	margin: 20px;
-}
-
-#descendancy_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
-	list-style: none;
-	margin: 0 0 5px 15px;
-	padding: 0 15px;
-}
-
-#descendancy_chart li {
-	list-style: none;
-	margin: 0 0 0 -13px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-li .person_box,
-li .person_boxF {
-	margin: 3px 0;
-}
-
-#descendancy_chart span.details1 div[class^="fact_"] {
-	display: inline-block;
-}
-
-#descendancy_chart td.details1 {
-	padding-top: 5px;
-}
-
-/*-- descendancy chart rtl specific stylesheets --*/
-[dir=rtl] #descendancy_chart ul {
-	background-position: right top;
-	left: auto;
-	margin: 0 15px 0 0;
-}
-
-[dir=rtl] #descendancy_chart li {
-	margin: 0 -13px 0 0;
-	padding: 0 2px 0 0;
-	left: auto;
-}
-
-/*-- ancestry chart specific stylesheets --*/
-#ancestry_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
-	list-style: none;
-	display: block;
-	margin: 0 0 0 15px;
-	padding: 0 15px;
-}
-
-#ancestry_chart li {
-	list-style: none;
-	margin: 0 0 2px -13px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#ancestry_chart li table {
-	margin: 5px 0;
-}
-
-/*-- ancestry chart rtl specific stylesheets --*/
-[dir=rtl] #ancestry_chart ul {
-	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
-}
-
-#ancestry_chart span.details1 div[class^="fact_"] {
-	display: inline-block;
-}
-
-[dir=rtl] #ancestry_chart li {
-	margin: 0 -13px 0 0;
-	padding: 0 2px 0 0;
-	left: auto;
-}
-
 #compact_chart,
 #fan_chart,
-#ancestry_chart,
+.chart_common,
+#ancestry_booklet,
+#descendancy_booklet,
 #familybook_chart,
 #hourglass_chart {
 	margin: 20px;
+}
+
+/*-- ancestry and descendancy chart common styles --*/
+.chart_common li {
+	list-style: none;
+}
+
+.chart_common li {
+	list-style: none;
+}
+
+.chart_common .generation {
+	background: transparent url(images/vline.png) left top repeat-y;
+	margin:     0 0 0 15px;
+	padding:    0;
+	display:    block;
+}
+
+[dir='rtl'] .chart_common .generation {
+	margin:              0 15px 0 0;
+	background-position: right top;
+}
+
+.chart_common .generation > li {
+	margin: 5px 0;
+}
+
+.chart_common table {
+	padding:         0;
+	border-spacing:  0;
+	border-collapse: collapse;
+	margin:          5px 0;
+}
+
+.chart_common td {
+	border:  0;
+	padding: 0;
+}
+
+.chart_common span.details1 div[class^="fact_"] {
+	display: inline-block;
+}
+
+.chart_common span.details1 .date {
+	color: inherit;
+}
+
+.chart_common li > span.details1 {
+	white-space: nowrap;
 }
 
 .fan_chart_menu {
@@ -1664,53 +1629,42 @@ dt {
 	margin: 0 5px;
 }
 
+/* Popup menu used in boxes on charts etc. */
 .itr {
-	position: absolute;
-	line-height: 1.5;
-}
-
-.block .itr,
-#family-table .itr,
-#ancestry_chart .itr,
-#descendancy_chart .itr,
-#familybook_chart .itr,
-#hourglass_chart .itr,
-#relatives_content .itr {
 	position: relative;
-	top: 0;
+	line-height: 1.5;
 }
 
 .popup {
 	display: none;
+	position: absolute;
+	top: 20px;
+	right: 0;
+	left: auto;
 }
 
 .popup ul {
-	background-image: none !important;
+	white-space: nowrap;
 	font-size: smaller;
 	list-style: none;
 	margin: 0;
 	padding: 0 10px;
 }
 
+.popup > ul {
+	padding: 2px 10px;
+}
+
 .popup li {
-	padding: 1px 5px;
+	margin: 2px 0;
 }
 
-.popup li span {
+.popup li .NAME {
 	padding: 0 5px;
-}
-
-.popup li ul,
-.popup li ul li,
-.popup li span span {
-	padding: 0;
 }
 
 .itr:hover .popup {
 	display: block;
-	position: absolute;
-	width: 160px;
-	right: 0;
 	z-index: 9999;
 }
 

--- a/themes/minimal/css-1.6.2/style.css
+++ b/themes/minimal/css-1.6.2/style.css
@@ -953,91 +953,63 @@ img.block {
 	right: -20px;
 }
 
-/*-- descendancy chart specific stylesheets --*/
-#descendancy_chart {
-	margin: 20px;
-}
-
-#descendancy_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
-	list-style: none;
-	margin: 0 0 5px 15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#descendancy_chart li {
-	list-style: none;
-	margin: 5px 0 0 -14px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#descendancy_chart span.details1 div[class^="fact_"] {
-	display: inline-block;
-}
-
-#descendancy_chart td.details1 {
-	padding-top: 5px;
-}
-
-/*-- descendancy chart rtl specific stylesheets --*/
-[dir=rtl] #descendancy_chart ul {
-	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
-}
-
-/*-- ancestry chart specific stylesheets --*/
-#ancestry_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
-	list-style: none;
-	display: block;
-	margin: 0 0 0 15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#ancestry_chart li {
-	list-style: url(images/spacer.png);
-	margin: 0 0 2px -13px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#ancestry_chart li table {
-	margin: 5px 0;
-}
-
-#ancestry_chart span.details1 div[class^="fact_"] {
-	display: inline-block;
-}
-
-/*-- ancestry chart rtl specific stylesheets --*/
-[dir=rtl] #ancestry_chart ul {
-	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
-}
-
-[dir=rtl] #ancestry_chart li {
-	margin: 0;
-	padding: 0 2px 0 0;
-	left: auto;
-}
-
 #compact_chart,
 #fan_chart,
-#ancestry_chart,
+.chart_common,
+#ancestry_booklet,
+#descendancy_booklet,
 #familybook_chart,
 #hourglass_chart {
 	margin: 20px;
+}
+
+/*-- ancestry and descendancy chart common styles --*/
+.chart_common li {
+	list-style: none;
+}
+
+.chart_common li {
+	list-style: none;
+}
+
+.chart_common .generation {
+	background: transparent url(images/vline.png) left top repeat-y;
+	margin:     0 0 0 15px;
+	padding:    0;
+	display:    block;
+}
+
+[dir='rtl'] .chart_common .generation {
+	margin:              0 15px 0 0;
+	background-position: right top;
+}
+
+.chart_common .generation > li {
+	margin: 5px 0;
+}
+
+.chart_common table {
+	padding:         0;
+	border-spacing:  0;
+	border-collapse: collapse;
+	margin:          5px 0;
+}
+
+.chart_common td {
+	border:  0;
+	padding: 0;
+}
+
+.chart_common span.details1 div[class^="fact_"] {
+	display: inline-block;
+}
+
+.chart_common span.details1 .date {
+	color: inherit;
+}
+
+.chart_common li > span.details1 {
+	white-space: nowrap;
 }
 
 .fan_chart_menu {
@@ -1789,53 +1761,38 @@ dt {
 	text-align: center;
 }
 
+/* Popup menu used in boxes on charts etc. */
 .itr {
-	position: absolute;
-	line-height: 1.5;
-}
-
-.block .itr,
-#family-table .itr,
-#ancestry_chart .itr,
-#descendancy_chart .itr,
-#familybook_chart .itr,
-#hourglass_chart .itr,
-#relatives_content .itr {
 	position: relative;
-	top: 0;
+	line-height: 1.5;
 }
 
 .popup {
 	display: none;
+	position: absolute;
+	top: 20px;
+	right: 0;
+	left: auto;
 }
 
 .popup ul {
-	background-image: none !important;
-	font-size: 9px;
+	white-space: nowrap;
+	font-size: smaller;
 	list-style: none;
 	margin: 0;
 	padding: 0 10px;
 }
 
-.popup li {
-	padding: 1px 5px;
+.popup > ul {
+	padding: 2px 10px;
 }
 
-.popup li span {
+.popup li .NAME {
 	padding: 0 5px;
-}
-
-.popup li ul,
-.popup li ul li,
-.popup li span span {
-	padding: 0;
 }
 
 .itr:hover .popup {
 	display: block;
-	position: absolute;
-	width: 12em;
-	right: 0;
 	z-index: 9999;
 }
 

--- a/themes/webtrees/css-1.6.2/style.css
+++ b/themes/webtrees/css-1.6.2/style.css
@@ -733,86 +733,59 @@ a:hover .nameZoom {
 	background-color: #fff;
 }
 
-/*-- descendancy chart specific stylesheets --*/
-#descendancy_chart {
+#compact_chart,
+#fan_chart,
+.chart_common,
+#ancestry_booklet,
+#descendancy_booklet,
+#familybook_chart,
+#hourglass_chart {
 	margin: 20px;
 }
 
-#descendancy_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
+/*-- ancestry and descendancy chart common styles --*/
+.chart_common li {
 	list-style: none;
-	margin: 0 0 5px 15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
 }
 
-#descendancy_chart li {
-	list-style: none;
-	margin: 5px 0 0 -15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
+.chart_common .generation {
+	background: transparent url(images/vline.png) left top repeat-y;
+	margin:     0 0 0 15px;
+	padding:    0;
+	display:    block;
 }
 
-#descendancy_chart span.details1 div[class^="fact_"] {
-	display: inline-block;
-}
-
-#descendancy_chart td.details1 {
-	padding-top: 5px;
-}
-
-[dir=rtl] #descendancy_chart ul {
+[dir='rtl'] .chart_common .generation {
+	margin:              0 15px 0 0;
 	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
 }
 
-/*-- ancestry chart specific stylesheets --*/
-#ancestry_chart table div p {
-	font-size: 90%;
-	margin: 0;
-}
-
-#ancestry_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
-	list-style: none;
-	display: block;
-	margin: 0 0 0 15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#ancestry_chart li {
-	list-style: none;
-	margin: 0 0 2px -13px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#ancestry_chart li table {
+.chart_common .generation > li {
 	margin: 5px 0;
 }
 
-[dir=rtl] #ancestry_chart ul {
-	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
+.chart_common table {
+	padding:         0;
+	border-spacing:  0;
+	border-collapse: collapse;
+	margin:          5px 0;
 }
 
-#ancestry_chart span.details1 div[class^="fact_"] {
+.chart_common td {
+	border:  0;
+	padding: 0;
+}
+
+.chart_common span.details1 div[class^="fact_"] {
 	display: inline-block;
 }
 
-[dir=rtl] #ancestry_chart li {
-	margin: 0;
-	padding: 0 2px 0 0;
-	left: auto;
+.chart_common span.details1 .date {
+	color: inherit;
+}
+
+.chart_common li > span.details1 {
+	white-space: nowrap;
 }
 
 /*-- timeline chart specific styles --*/
@@ -856,14 +829,6 @@ a:hover .nameZoom {
 	background-color: #5f5;
 	border: outset #5f5 1px;
 	vertical-align: top;
-}
-
-#compact_chart,
-#fan_chart,
-#ancestry_chart,
-#familybook_chart,
-#hourglass_chart {
-	margin: 20px;
 }
 
 .fan_chart_menu {
@@ -1613,53 +1578,38 @@ td.descriptionbox a {
 	text-align: center;
 }
 
+/* Popup menu used in boxes on charts etc. */
 .itr {
-	position: absolute;
-	line-height: 1.5;
-}
-
-.block .itr,
-#family-table .itr,
-#ancestry_chart .itr,
-#descendancy_chart .itr,
-#familybook_chart .itr,
-#hourglass_chart .itr,
-#relatives_content .itr {
 	position: relative;
-	top: 0;
+	line-height: 1.5;
 }
 
 .popup {
 	display: none;
+	position: absolute;
+	top: 20px;
+	right: 0;
+	left: auto;
 }
 
 .popup ul {
-	background-image: none !important;
-	font-size: 9px;
+	white-space: nowrap;
+	font-size: smaller;
 	list-style: none;
 	margin: 0;
 	padding: 0 10px;
 }
 
-.popup li {
-	padding: 1px 5px;
+.popup > ul {
+	padding: 2px 10px;
 }
 
-.popup li span {
+.popup li .NAME {
 	padding: 0 5px;
-}
-
-.popup li ul,
-.popup li ul li,
-.popup li span span {
-	padding: 0;
 }
 
 .itr:hover .popup {
 	display: block;
-	position: absolute;
-	width: 12em;
-	right: 0;
 	z-index: 9999;
 }
 

--- a/themes/xenea/css-1.6.2/style.css
+++ b/themes/xenea/css-1.6.2/style.css
@@ -1808,91 +1808,59 @@ img.block {
 	right: 0;
 }
 
-/*-- descendancy chart specific stylesheets --*/
-#descendancy_chart {
-	margin: 20px;
-}
-
-#descendancy_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
-	list-style: none;
-	margin: 0 0 5px 15px; /* top right bottom left */
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#descendancy_chart li {
-	list-style: none;
-	margin: 5px 0 0 -15px; /* top right bottom left */
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#descendancy_chart span.details1 div[class^="fact_"] {
-	display: inline-block;
-}
-
-#descendancy_chart td.details1 {
-	padding-top: 5px;
-}
-
-/*-- descendancy chart rtl specific stylesheets --*/
-[dir=rtl] #descendancy_chart ul {
-	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
-}
-
-/*-- ancestry chart specific stylesheets --*/
-#ancestry_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
-	list-style: none;
-	display: block;
-	margin: 0 0 0 15px; /* top right bottom left */
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#ancestry_chart li {
-	list-style: none;
-	margin: 0 0 2px -15px; /* top right bottom left */
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#ancestry_chart li table {
-	margin: 5px 0;
-}
-
-#ancestry_chart span.details1 div[class^="fact_"] {
-	display: inline-block;
-}
-
-/*-- ancestry chart rtl specific stylesheets --*/
-[dir=rtl] #ancestry_chart ul {
-	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
-}
-
-[dir=rtl] #ancestry_chart li {
-	margin: 0;
-	padding: 0 2px 0 0;
-	left: auto;
-}
-
 #compact_chart,
 #fan_chart,
-#ancestry_chart,
+.chart_common,
+#ancestry_booklet,
+#descendancy_booklet,
 #familybook_chart,
 #hourglass_chart {
 	margin: 20px;
+}
+
+/*-- ancestry and descendancy chart common styles --*/
+.chart_common li {
+	list-style: none;
+}
+
+.chart_common .generation {
+	background: transparent url(images/vline.png) left top repeat-y;
+	margin:     0 0 0 15px;
+	padding:    0;
+	display:    block;
+}
+
+[dir='rtl'] .chart_common .generation {
+	margin:              0 15px 0 0;
+	background-position: right top;
+}
+
+.chart_common .generation > li {
+	margin: 5px 0;
+}
+
+.chart_common table {
+	padding:         0;
+	border-spacing:  0;
+	border-collapse: collapse;
+	margin:          5px 0;
+}
+
+.chart_common td {
+	border:  0;
+	padding: 0;
+}
+
+.chart_common span.details1 div[class^="fact_"] {
+	display: inline-block;
+}
+
+.chart_common span.details1 .date {
+	color: inherit;
+}
+
+.chart_common li > span.details1 {
+	white-space: nowrap;
 }
 
 .fan_chart_menu {
@@ -2717,53 +2685,38 @@ dt {
 	text-align: center;
 }
 
+/* Popup menu used in boxes on charts etc. */
 .itr {
-	position: absolute;
-	line-height: 1.5;
-}
-
-.block .itr,
-#family-table .itr,
-#ancestry_chart .itr,
-#descendancy_chart .itr,
-#familybook_chart .itr,
-#hourglass_chart .itr,
-#relatives_content .itr {
 	position: relative;
-	top: 0;
+	line-height: 1.5;
 }
 
 .popup {
 	display: none;
+	position: absolute;
+	top: 20px;
+	right: 0;
+	left: auto;
 }
 
 .popup ul {
-	background-image: none !important;
-	font-size: 9px;
+	white-space: nowrap;
+	font-size: smaller;
 	list-style: none;
 	margin: 0;
 	padding: 0 10px;
 }
 
-.popup li {
-	padding: 1px 5px;
+.popup > ul {
+	padding: 2px 10px;
 }
 
-.popup li span {
+.popup li .NAME {
 	padding: 0 5px;
-}
-
-.popup li ul,
-.popup li ul li,
-.popup li span span {
-	padding: 0;
 }
 
 .itr:hover .popup {
 	display: block;
-	position: absolute;
-	width: 12em;
-	right: 0;
 	z-index: 9999;
 }
 


### PR DESCRIPTION
Current code/css for ancestry & decendancy charts makes it very difficult to style the popup menus (Yeah I know you love them!) without having a knock on effect on the chart. 

By adding a class to the chart code (class="generation") it makes it possible to completely decouple the menu. At the same time
1.  I realized that the code for both charts was virtually identical which allows for common css (class="chart_common")
2.  I could remove validation errors (mostly table related stuff) - I've ignored nested divs within anchors (see issue #348)