### PR TITLE
Spouse bug corrected in Base.php

### DIFF
--- a/library/WT/Report/Base.php
+++ b/library/WT/Report/Base.php
@@ -1831,6 +1831,7 @@ function ifStartHandler($attrs) {
 				$level++;
 				$value = get_gedcom_value($id, $level, $gedrec);
 			}
+			$value = preg_replace("/^@(".WT_REGEX_XREF.")@$/", "$1", $value);		
 			$value = "\"" . addslashes($value) . "\"";
 		}
 		$condition = str_replace("@$id", $value, $condition);


### PR DESCRIPTION
(See issue https://github.com/fisharebest/webtrees/issues/350)
The spouse name of the root person in pedigree report & children spouse names in family report were missing.
This version of 'Base.php' file fix the bug.