### PR TITLE
Remove dialog related html from dom on closure

### DIFF
--- a/js/webtrees-1.6.2.js
+++ b/js/webtrees-1.6.2.js
@@ -54,6 +54,9 @@ function modalDialog(url, title, width) {
 				jQuery('.ui-widget-overlay').on('click', function () {
 					jQuery(self).dialog('close');
 				});
+			},
+			close: function() {
+					jQuery(this).dialog ('destroy').remove ();
 			}
 		});
 


### PR DESCRIPTION
Each time a dialog is opened jQuery creates a new set of markup, however on closure it isn't remove from the DOM, so stale, inaccessible markup can accumulate.