### PR TITLE
Decouple popup menu css from charts css

### DIFF
--- a/ancestry.php
+++ b/ancestry.php
@@ -142,7 +142,7 @@ switch ($controller->chart_style) {
 case 0:
 	// List
 	$pidarr=array();
-	echo '<ul id="ancestry_chart">';
+	echo '<ul id="ancestry_chart" class="chart_common">';
 	$controller->printChildAscendancy($controller->root, 1, $OLD_PGENS-1);
 	echo '</ul>';
 	echo '<br>';
@@ -150,7 +150,7 @@ case 0:
 case 1:
 	// TODO: this should be a parameter to a function, not a global
 	$show_cousins = $controller->show_cousins;
-	echo '<div id="ancestry_chart">';
+	echo '<div id="ancestry_booklet">';
 	// Booklet
 	// first page : show indi facts
 	print_pedigree_person($controller->root);

--- a/descendancy.php
+++ b/descendancy.php
@@ -96,13 +96,13 @@ if ($controller->error_message) {
 } else {
 	switch ($controller->chart_style) {
 	case 0: // List
-		echo '<ul style="list-style: none; display: block;" id="descendancy_chart">';
+		echo '<ul id="descendancy_chart" class="chart_common">';
 		$controller->printChildDescendancy($controller->root, $controller->generations);
 		echo '</ul>';
 		break;
 	case 1: // Booklet
 		$show_cousins = true;
-		echo '<div id="descendancy_chart">';
+		echo '<div id="descendancy_booklet">';
 		$controller->printChildFamily($controller->root, $controller->generations);
 		echo '</div>';
 		break;

--- a/library/WT/Controller/Ancestry.php
+++ b/library/WT/Controller/Ancestry.php
@@ -103,7 +103,7 @@ class WT_Controller_Ancestry extends WT_Controller_Chart {
 		}
 		// child
 		echo '<li>';
-		echo '<table border="0" cellpadding="0" cellspacing="0"><tr><td><a name="sosa', $sosa, '"></a>';
+		echo '<table><tr><td>';
 		if ($sosa==1) {
 			echo '<img src="', $WT_IMAGES['spacer'], '" height="3" width="', $Dindent, '" alt=""></td><td>';
 		} else {
@@ -136,8 +136,8 @@ class WT_Controller_Ancestry extends WT_Controller_Chart {
 
 		if ($family && $new && $depth>0) {
 			// print marriage info
-			echo '<span class="details1" style="white-space: nowrap;" >';
-			echo '<img src="', $WT_IMAGES['spacer'], '" height="2" width="', $Dindent, '" align="middle" alt=""><a href="#" onclick="return expand_layer(\'sosa_', $sosa, '\');" class="top"><i id="sosa_', $sosa, '_img" class="icon-minus" title="', WT_I18N::translate('View family'), '"></i></a>';
+			echo '<span class="details1">';
+			echo '<img src="', $WT_IMAGES['spacer'], '" height="2" width="', $Dindent, '" alt=""><a href="#" onclick="return expand_layer(\'sosa_', $sosa, '\');" class="top"><i id="sosa_', $sosa, '_img" class="icon-minus" title="', WT_I18N::translate('View family'), '"></i></a>';
 			echo '&nbsp;<span dir="ltr" class="person_box">&nbsp;', ($sosa*2), '&nbsp;</span>&nbsp;', WT_I18N::translate('and');
 			echo '&nbsp;<span dir="ltr" class="person_boxF">&nbsp;', ($sosa*2+1), '&nbsp;</span>&nbsp;';
 			if ($family->canShow()) {
@@ -147,7 +147,7 @@ class WT_Controller_Ancestry extends WT_Controller_Chart {
 			}
 			echo '</span>';
 			// display parents recursively - or show empty boxes
-			echo '<ul style="list-style: none; display: block;" id="sosa_', $sosa, '">';
+			echo '<ul id="sosa_', $sosa, '" class="generation">';
 			$this->printChildAscendancy($family->getHusband(), $sosa*2, $depth-1);
 			$this->printChildAscendancy($family->getWife(), $sosa*2+1, $depth-1);
 			echo '</ul>';

--- a/library/WT/Controller/Descendancy.php
+++ b/library/WT/Controller/Descendancy.php
@@ -133,7 +133,7 @@ class WT_Controller_Descendancy extends WT_Controller_Chart {
 		global $WT_IMAGES, $Dindent;
 
 		echo "<li>";
-		echo "<table border=\"0\" cellpadding=\"0\" cellspacing=\"0\"><tr><td>";
+		echo "<table><tr><td>";
 		if ($depth==$this->generations) echo "<img src=\"".$WT_IMAGES["spacer"]."\" height=\"3\" width=\"$Dindent\" alt=\"\"></td><td>";
 		else {
 			echo "<img src=\"".$WT_IMAGES["spacer"]."\" height=\"3\" width=\"3\" alt=\"\">";
@@ -195,7 +195,7 @@ class WT_Controller_Descendancy extends WT_Controller_Chart {
 		// print marriage info
 		echo '<li>';
 		echo '<img src="', $WT_IMAGES['spacer'], '" height="2" width="', ($Dindent+4), '" alt="">';
-		echo '<span class="details1" style="white-space:nowrap;">';
+		echo '<span class="details1">';
 		echo "<a href=\"#\" onclick=\"expand_layer('".$uid."'); return false;\" class=\"top\"><i id=\"".$uid."_img\" class=\"icon-minus\" title=\"".WT_I18N::translate('View family')."\"></i></a>";
 		if ($family->canShow()) {
 			foreach ($family->getFacts(WT_EVENTS_MARR) as $fact) {
@@ -206,9 +206,9 @@ class WT_Controller_Descendancy extends WT_Controller_Chart {
 
 		// print spouse
 		$spouse=$family->getSpouse($person);
-		echo '<ul style="list-style:none; display:block;" id="'.$uid.'">';
+		echo '<ul id="'.$uid.'" class="generation">';
 		echo '<li>';
-		echo '<table border="0" cellpadding="0" cellspacing="0"><tr><td>';
+		echo '<table><tr><td>';
 		print_pedigree_person($spouse);
 		echo '</td>';
 

--- a/themes/clouds/css-1.6.2/style.css
+++ b/themes/clouds/css-1.6.2/style.css
@@ -1266,59 +1266,51 @@ td.descriptionbox a {
 	text-align: center;
 }
 
+/* styles for popup menus */
 .itr {
-	position: absolute;
+	position: relative;
 	line-height: 1.5;
 }
 
-.block .itr,
-#family-table .itr,
-#ancestry_chart .itr,
-#descendancy_chart .itr,
-#familybook_chart .itr,
-#hourglass_chart .itr,
-#relatives_content .itr {
-	position: relative;
-	top: 0;
+.popup {
+	position: absolute;
+	top: 20px;
+	right: 0;
+	left: auto;
+	visibility: hidden;
+	opacity: 0;
+	transition: visibility 0s ease .25s,opacity .25s ease;
+	z-index: 9999;
+/*	-webkit-box-shadow: 5px 5px 5px 0 rgba(0,0,0,.4);
+	-moz-box-shadow: 5px 5px 5px 0 rgba(0,0,0,.4);
+	box-shadow: 5px 5px 5px 0 rgba(0,0,0,.4);*/
 }
 
-.popup {
-	display: none;
+[dir=rtl] .popup {
+	left: 0;
+	right: auto;
 }
 
 .popup ul {
-	background-image: none !important;
+	white-space: nowrap;
 	list-style: none;
-	font-size: 9px;
 	margin: 0;
 	padding: 0 10px;
+	font-size: smaller;
 }
 
-.popup li {
-	padding: 1px 5px;
+.popup > ul {
+	padding: 2px 10px;
 }
 
-.popup li span {
+.popup li .NAME {
 	padding: 0 5px;
 }
 
-.popup li ul,
-.popup li ul li,
-.popup li span span {
-	padding: 0;
-}
-
 .itr:hover .popup {
-	display: block;
-	position: absolute;
-	width: 12em;
-	right: 0;
-	z-index: 9999;
-}
-
-[dir=rtl] .itr:hover .popup {
-	left: 0;
-	right: auto;
+	visibility: visible;
+	opacity: 1;
+	transition-delay: 0s;
 }
 
 /* styles for FindFacts pop-up */
@@ -3213,97 +3205,60 @@ table.table-census-assistant th {
 }
 
 /* ====== Charts Styles ======== */
-#ancestry_chart,
 #compact_chart,
-#descendancy_chart,
-#familybook_chart,
 #fan_chart,
-#hourglass_chart,
-#relationship_chart {
+.chart_common,
+#ancestry_booklet,
+#descendancy_booklet,
+#familybook_chart,
+#hourglass_chart {
 	margin: 20px;
 }
 
-/*-- ancestry  --*/
-#ancestry_chart table div p {
-	font-size: 90%;
-	margin: 0;
+/* styles for vertical lines in ancestry and descendancy charts */
+.chart_common li {
+	list-style: none;
 }
 
-#ancestry_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
-	list-style: none;
-	display: block;
+.chart_common li > span.details1 {
+	white-space: nowrap;
+}
+
+.chart_common .generation {
+	background: transparent url(images/vline.png) left top repeat-y;
 	margin: 0 0 0 15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
+	padding: 0;
+	display: block;
 }
 
-#ancestry_chart li {
-	list-style: none;
-	margin: 0 0 2px -13px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
+[dir=rtl] .chart_common .generation {
+	margin: 0 15px 0 0;
+	background-position: right top
+;
 }
 
-#ancestry_chart li table {
+.chart_common .generation > li {
 	margin: 5px 0;
 }
 
-[dir=rtl] #ancestry_chart ul {
-	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
+.chart_common table {
+	padding: 0;
+	border-spacing: 0;
+	border-collapse: collapse;
+	margin: 5px 0;
 }
 
-#ancestry_chart span.details1 div[class^="fact_"] {
+.chart_common td {
+	border: 0;
+	padding: 0;
+}
+
+.chart_common span.details1 div[class^=fact_] {
 	display: inline-block;
 }
 
-[dir=rtl] #ancestry_chart li {
-	margin: 0;
-	padding: 0 2px 0 0;
-	left: auto;
-}
-
-/*-- descendancy  --*/
-#descendancy_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
-	list-style: none;
-	margin: 0 0 5px 15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#descendancy_chart li {
-	list-style: none;
-	margin: 5px 0 0 -15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#descendancy_chart span.details1 div[class^="fact_"] {
-	display: inline-block;
-}
-
-#descendancy_chart td.details1 {
-	padding-top: 5px;
-}
-
-[dir=rtl] #descendancy_chart ul {
-	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
-}
-
-[dir=rtl] #descendancy_chart li {
-	margin: 5px -15px 0 0;
-	left: auto;
+.chart_common span.details1 .date {
+	color: inherit;
 }
 
 /*-- Family book  --*/

--- a/themes/colors/css-1.6.2/style.css
+++ b/themes/colors/css-1.6.2/style.css
@@ -1309,59 +1309,51 @@ td.descriptionbox a {
 	text-align: center;
 }
 
+/* styles for popup menus */
 .itr {
-	position: absolute;
+	position: relative;
 	line-height: 1.5;
 }
 
-.block .itr,
-#family-table .itr,
-#ancestry_chart .itr,
-#descendancy_chart .itr,
-#familybook_chart .itr,
-#hourglass_chart .itr,
-#relatives_content .itr {
-	position: relative;
-	top: 0;
+.popup {
+	position: absolute;
+	top: 20px;
+	right: 0;
+	left: auto;
+	visibility: hidden;
+	opacity: 0;
+	transition: visibility 0s ease .25s,opacity .25s ease;
+	z-index: 9999;
+/*	-webkit-box-shadow: 5px 5px 5px 0 rgba(0,0,0,.4);
+	-moz-box-shadow: 5px 5px 5px 0 rgba(0,0,0,.4);
+	box-shadow: 5px 5px 5px 0 rgba(0,0,0,.4);*/
 }
 
-.popup {
-	display: none;
+[dir=rtl] .popup {
+	left: 0;
+	right: auto;
 }
 
 .popup ul {
-	background-image: none !important;
+	white-space: nowrap;
 	list-style: none;
-	font-size: 9px;
 	margin: 0;
 	padding: 0 10px;
+	font-size: smaller;
 }
 
-.popup li {
-	padding: 1px 5px;
+.popup > ul {
+	padding: 2px 10px;
 }
 
-.popup li span {
+.popup li .NAME {
 	padding: 0 5px;
 }
 
-.popup li ul,
-.popup li ul li,
-.popup li span span {
-	padding: 0;
-}
-
 .itr:hover .popup {
-	display: block;
-	position: absolute;
-	width: 12em;
-	right: 0;
-	z-index: 9999;
-}
-
-[dir=rtl] .itr:hover .popup {
-	left: 0;
-	right: auto;
+	visibility: visible;
+	opacity: 1;
+	transition-delay: 0s;
 }
 
 /* styles for FindFacts pop-up */
@@ -3254,97 +3246,60 @@ table.table-census-assistant th {
 }
 
 /* ====== Charts Styles ======== */
-#ancestry_chart,
 #compact_chart,
-#descendancy_chart,
-#familybook_chart,
 #fan_chart,
-#hourglass_chart,
-#relationship_chart {
+.chart_common,
+#ancestry_booklet,
+#descendancy_booklet,
+#familybook_chart,
+#hourglass_chart {
 	margin: 20px;
 }
 
-/*-- ancestry  --*/
-#ancestry_chart table div p {
-	font-size: 90%;
-	margin: 0;
+/* styles for vertical lines in ancestry and descendancy charts */
+.chart_common li {
+	list-style: none;
 }
 
-#ancestry_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
-	list-style: none;
-	display: block;
+.chart_common li > span.details1 {
+	white-space: nowrap;
+}
+
+.chart_common .generation {
+	background: transparent url(images/vline.png) left top repeat-y;
 	margin: 0 0 0 15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
+	padding: 0;
+	display: block;
 }
 
-#ancestry_chart li {
-	list-style: none;
-	margin: 0 0 2px -13px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
+[dir=rtl] .chart_common .generation {
+	margin: 0 15px 0 0;
+	background-position: right top
+;
 }
 
-#ancestry_chart li table {
+.chart_common .generation > li {
 	margin: 5px 0;
 }
 
-[dir=rtl] #ancestry_chart ul {
-	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
+.chart_common table {
+	padding: 0;
+	border-spacing: 0;
+	border-collapse: collapse;
+	margin: 5px 0;
 }
 
-#ancestry_chart span.details1 div[class^="fact_"] {
+.chart_common td {
+	border: 0;
+	padding: 0;
+}
+
+.chart_common span.details1 div[class^=fact_] {
 	display: inline-block;
 }
 
-[dir=rtl] #ancestry_chart li {
-	margin: 0;
-	padding: 0 2px 0 0;
-	left: auto;
-}
-
-/*-- descendancy  --*/
-#descendancy_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
-	list-style: none;
-	margin: 0 0 5px 15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#descendancy_chart li {
-	list-style: none;
-	margin: 5px 0 0 -15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#descendancy_chart span.details1 div[class^="fact_"] {
-	display: inline-block;
-}
-
-#descendancy_chart td.details1 {
-	padding-top: 5px;
-}
-
-[dir=rtl] #descendancy_chart ul {
-	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
-}
-
-[dir=rtl] #descendancy_chart li {
-	margin: 5px -15px 0 0;
-	left: auto;
+.chart_common span.details1 .date {
+	color: inherit;
 }
 
 /*-- Family book  --*/

--- a/themes/fab/css-1.6.2/style.css
+++ b/themes/fab/css-1.6.2/style.css
@@ -1250,59 +1250,51 @@ a.showit:hover > span {
 	text-align: center;
 }
 
+/* styles for popup menus */
 .itr {
-	position: absolute;
+	position: relative;
 	line-height: 1.5;
 }
 
-.block .itr,
-#family-table .itr,
-#ancestry_chart .itr,
-#descendancy_chart .itr,
-#familybook_chart .itr,
-#hourglass_chart .itr,
-#relatives_content .itr {
-	position: relative;
-	top: 0;
+.popup {
+	position: absolute;
+	top: 20px;
+	right: 0;
+	left: auto;
+	visibility: hidden;
+	opacity: 0;
+	transition: visibility 0s ease .25s,opacity .25s ease;
+	z-index: 9999;
+/*	-webkit-box-shadow: 5px 5px 5px 0 rgba(0,0,0,.4);
+	-moz-box-shadow: 5px 5px 5px 0 rgba(0,0,0,.4);
+	box-shadow: 5px 5px 5px 0 rgba(0,0,0,.4);*/
 }
 
-.popup {
-	display: none;
+[dir=rtl] .popup {
+	left: 0;
+	right: auto;
 }
 
 .popup ul {
-	background-image: none !important;
+	white-space: nowrap;
 	list-style: none;
-	font-size: 9px;
 	margin: 0;
 	padding: 0 10px;
+	font-size: smaller;
 }
 
-.popup li {
-	padding: 1px 5px;
+.popup > ul {
+	padding: 2px 10px;
 }
 
-.popup li span {
+.popup li .NAME {
 	padding: 0 5px;
 }
 
-.popup li ul,
-.popup li ul li,
-.popup li span span {
-	padding: 0;
-}
-
 .itr:hover .popup {
-	display: block;
-	position: absolute;
-	width: 10em;
-	right: 0;
-	z-index: 9999;
-}
-
-[dir=rtl] .itr:hover .popup {
-	left: 0;
-	right: auto;
+	visibility: visible;
+	opacity: 1;
+	transition-delay: 0s;
 }
 
 /* styles for FindFacts pop-up */
@@ -3169,109 +3161,60 @@ table.table-census-assistant th {
 }
 
 /* ====== Charts Styles ======== */
-#ancestry_chart,
 #compact_chart,
-#descendancy_chart,
-#familybook_chart,
 #fan_chart,
-#hourglass_chart,
-#relationship_chart {
+.chart_common,
+#ancestry_booklet,
+#descendancy_booklet,
+#familybook_chart,
+#hourglass_chart {
 	margin: 20px;
 }
 
-/*-- ancestry  --*/
-#ancestry_chart table div p {
-	font-size: 90%;
-	margin: 0;
-}
-
-#rootid, 
-#pid1, 
-#pid2 {
-width: 40px;
-}
-
-/*-- ancestry chart specific stylesheets --*/
-#ancestry_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
+/* styles for vertical lines in ancestry and descendancy charts */
+.chart_common li {
 	list-style: none;
-	display: block;
+}
+
+.chart_common li > span.details1 {
+	white-space: nowrap;
+}
+
+.chart_common .generation {
+	background: transparent url(images/vline.png) left top repeat-y;
 	margin: 0 0 0 15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
+	padding: 0;
+	display: block;
 }
 
-#ancestry_chart li {
-	list-style: none;
-	margin: 0 0 2px -13px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
+[dir=rtl] .chart_common .generation {
+	margin: 0 15px 0 0;
+	background-position: right top
+;
 }
 
-#ancestry_chart li table {
+.chart_common .generation > li {
 	margin: 5px 0;
 }
 
-[dir=rtl] #ancestry_chart ul {
-	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
+.chart_common table {
+	padding: 0;
+	border-spacing: 0;
+	border-collapse: collapse;
+	margin: 5px 0;
 }
 
-#ancestry_chart span.details1 div[class^="fact_"] {
+.chart_common td {
+	border: 0;
+	padding: 0;
+}
+
+.chart_common span.details1 div[class^=fact_] {
 	display: inline-block;
 }
 
-[dir=rtl] #ancestry_chart li {
-	margin: 0;
-	padding: 0 2px 0 0;
-	left: auto;
-}
-
-/*-- descendancy  --*/
-#descendancy_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
-	list-style: none;
-	margin: 0 0 5px 15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#descendancy_chart li {
-	list-style: none;
-	margin: 5px 0 0 -15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-/*
-li .person_box,
-li .person_boxF {
-	margin: 3px 0;
-}
-*/
-#descendancy_chart span.details1 div[class^="fact_"] {
-	display: inline-block;
-}
-
-#descendancy_chart td.details1 {
-	padding-top: 5px;
-}
-
-[dir=rtl] #descendancy_chart ul {
-	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
-}
-
-[dir=rtl] #descendancy_chart li {
-	margin: 5px -15px 0 0;
-	left: auto;
+.chart_common span.details1 .date {
+	color: inherit;
 }
 
 /*-- Family book  --*/

--- a/themes/minimal/css-1.6.2/style.css
+++ b/themes/minimal/css-1.6.2/style.css
@@ -1157,59 +1157,51 @@ td.descriptionbox a {
 	text-align: center;
 }
 
+/* styles for popup menus */
 .itr {
-	position: absolute;
+	position: relative;
 	line-height: 1.5;
 }
 
-.block .itr,
-#family-table .itr,
-#ancestry_chart .itr,
-#descendancy_chart .itr,
-#familybook_chart .itr,
-#hourglass_chart .itr,
-#relatives_content .itr {
-	position: relative;
-	top: 0;
+.popup {
+	position: absolute;
+	top: 20px;
+	right: 0;
+	left: auto;
+	visibility: hidden;
+	opacity: 0;
+	transition: visibility 0s ease .25s,opacity .25s ease;
+	z-index: 9999;
+/*	-webkit-box-shadow: 5px 5px 5px 0 rgba(0,0,0,.4);
+	-moz-box-shadow: 5px 5px 5px 0 rgba(0,0,0,.4);
+	box-shadow: 5px 5px 5px 0 rgba(0,0,0,.4);*/
 }
 
-.popup {
-	display: none;
+[dir=rtl] .popup {
+	left: 0;
+	right: auto;
 }
 
 .popup ul {
-	background-image: none !important;
+	white-space: nowrap;
 	list-style: none;
-	font-size: 9px;
 	margin: 0;
 	padding: 0 10px;
+	font-size: smaller;
 }
 
-.popup li {
-	padding: 1px 5px;
+.popup > ul {
+	padding: 2px 10px;
 }
 
-.popup li span {
+.popup li .NAME {
 	padding: 0 5px;
 }
 
-.popup li ul,
-.popup li ul li,
-.popup li span span {
-	padding: 0;
-}
-
 .itr:hover .popup {
-	display: block;
-	position: absolute;
-	width: 12em;
-	right: 0;
-	z-index: 9999;
-}
-
-[dir=rtl] .itr:hover .popup {
-	left: 0;
-	right: auto;
+	visibility: visible;
+	opacity: 1;
+	transition-delay: 0s;
 }
 
 /* styles for FindFacts pop-up */
@@ -3193,97 +3185,60 @@ table.table-census-assistant th {
 
 
 /* ====== Charts Styles ======== */
-#ancestry_chart,
 #compact_chart,
-#descendancy_chart,
-#familybook_chart,
 #fan_chart,
-#hourglass_chart,
-#relationship_chart {
+.chart_common,
+#ancestry_booklet,
+#descendancy_booklet,
+#familybook_chart,
+#hourglass_chart {
 	margin: 20px;
 }
 
-/*-- ancestry  --*/
-#ancestry_chart table div p {
-	font-size: 90%;
-	margin: 0;
-}
-
-#ancestry_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
+/* styles for vertical lines in ancestry and descendancy charts */
+.chart_common li {
 	list-style: none;
-	display: block;
+}
+
+.chart_common li > span.details1 {
+	white-space: nowrap;
+}
+
+.chart_common .generation {
+	background: transparent url(images/vline.png) left top repeat-y;
 	margin: 0 0 0 15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
+	padding: 0;
+	display: block;
 }
 
-#ancestry_chart li {
-	list-style: url(images/spacer.png);
-	margin: 0 0 2px -13px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
+[dir=rtl] .chart_common .generation {
+	margin: 0 15px 0 0;
+	background-position: right top
+;
 }
 
-#ancestry_chart li table {
+.chart_common .generation > li {
 	margin: 5px 0;
 }
 
-[dir=rtl] #ancestry_chart ul {
-	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
+.chart_common table {
+	padding: 0;
+	border-spacing: 0;
+	border-collapse: collapse;
+	margin: 5px 0;
 }
 
-#ancestry_chart span.details1 div[class^="fact_"] {
+.chart_common td {
+	border: 0;
+	padding: 0;
+}
+
+.chart_common span.details1 div[class^=fact_] {
 	display: inline-block;
 }
 
-[dir=rtl] #ancestry_chart li {
-	margin: 0;
-	padding: 0 2px 0 0;
-	left: auto;
-}
-
-/*-- descendancy  --*/
-#descendancy_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
-	list-style: none;
-	margin: 0 0 5px 15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#descendancy_chart li {
-	list-style: none;
-	margin: 5px 0 0 -15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#descendancy_chart span.details1 div[class^="fact_"] {
-	display: inline-block;
-}
-
-#descendancy_chart td.details1 {
-	padding-top: 5px;
-}
-
-[dir=rtl] #descendancy_chart ul {
-	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
-}
-
-[dir=rtl] #descendancy_chart li {
-	margin: 5px -15px 0 0;
-	left: auto;
+.chart_common span.details1 .date {
+	color: inherit;
 }
 
 /*-- Family book  --*/

--- a/themes/webtrees/css-1.6.2/style.css
+++ b/themes/webtrees/css-1.6.2/style.css
@@ -1254,59 +1254,51 @@ td.descriptionbox a {
 	text-align: center;
 }
 
+/* styles for popup menus */
 .itr {
-	position: absolute;
+	position: relative;
 	line-height: 1.5;
 }
 
-.block .itr,
-#family-table .itr,
-#ancestry_chart .itr,
-#descendancy_chart .itr,
-#familybook_chart .itr,
-#hourglass_chart .itr,
-#relatives_content .itr {
-	position: relative;
-	top: 0;
+.popup {
+	position: absolute;
+	top: 20px;
+	right: 0;
+	left: auto;
+	visibility: hidden;
+	opacity: 0;
+	transition: visibility 0s ease .25s,opacity .25s ease;
+	z-index: 9999;
+/*	-webkit-box-shadow: 5px 5px 5px 0 rgba(0,0,0,.4);
+	-moz-box-shadow: 5px 5px 5px 0 rgba(0,0,0,.4);
+	box-shadow: 5px 5px 5px 0 rgba(0,0,0,.4);*/
 }
 
-.popup {
-	display: none;
+[dir=rtl] .popup {
+	left: 0;
+	right: auto;
 }
 
 .popup ul {
-	background-image: none !important;
+	white-space: nowrap;
 	list-style: none;
-	font-size: 9px;
 	margin: 0;
 	padding: 0 10px;
+	font-size: smaller;
 }
 
-.popup li {
-	padding: 1px 5px;
+.popup > ul {
+	padding: 2px 10px;
 }
 
-.popup li span {
+.popup li .NAME {
 	padding: 0 5px;
 }
 
-.popup li ul,
-.popup li ul li,
-.popup li span span {
-	padding: 0;
-}
-
 .itr:hover .popup {
-	display: block;
-	position: absolute;
-	width: 12em;
-	right: 0;
-	z-index: 9999;
-}
-
-[dir=rtl] .itr:hover .popup {
-	left: 0;
-	right: auto;
+	visibility: visible;
+	opacity: 1;
+	transition-delay: 0s;
 }
 
 /* styles for FindFacts pop-up */
@@ -3130,97 +3122,60 @@ table.table-census-assistant th {
 }
 
 /* ====== Charts Styles ======== */
-#ancestry_chart,
 #compact_chart,
-#descendancy_chart,
-#familybook_chart,
 #fan_chart,
-#hourglass_chart,
-#relationship_chart {
+.chart_common,
+#ancestry_booklet,
+#descendancy_booklet,
+#familybook_chart,
+#hourglass_chart {
 	margin: 20px;
 }
 
-/*-- ancestry  --*/
-#ancestry_chart table div p {
-	font-size: 90%;
-	margin: 0;
+/* styles for vertical lines in ancestry and descendancy charts */
+.chart_common li {
+	list-style: none;
 }
 
-#ancestry_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
-	list-style: none;
-	display: block;
+.chart_common li > span.details1 {
+	white-space: nowrap;
+}
+
+.chart_common .generation {
+	background: transparent url(images/vline.png) left top repeat-y;
 	margin: 0 0 0 15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
+	padding: 0;
+	display: block;
 }
 
-#ancestry_chart li {
-	list-style: none;
-	margin: 0 0 2px -13px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
+[dir=rtl] .chart_common .generation {
+	margin: 0 15px 0 0;
+	background-position: right top
+;
 }
 
-#ancestry_chart li table {
+.chart_common .generation > li {
 	margin: 5px 0;
 }
 
-[dir=rtl] #ancestry_chart ul {
-	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
+.chart_common table {
+	padding: 0;
+	border-spacing: 0;
+	border-collapse: collapse;
+	margin: 5px 0;
 }
 
-#ancestry_chart span.details1 div[class^="fact_"] {
+.chart_common td {
+	border: 0;
+	padding: 0;
+}
+
+.chart_common span.details1 div[class^=fact_] {
 	display: inline-block;
 }
 
-[dir=rtl] #ancestry_chart li {
-	margin: 0;
-	padding: 0 2px 0 0;
-	left: auto;
-}
-
-/*-- descendancy  --*/
-#descendancy_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
-	list-style: none;
-	margin: 0 0 5px 15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#descendancy_chart li {
-	list-style: none;
-	margin: 5px 0 0 -15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#descendancy_chart span.details1 div[class^="fact_"] {
-	display: inline-block;
-}
-
-#descendancy_chart td.details1 {
-	padding-top: 5px;
-}
-
-[dir=rtl] #descendancy_chart ul {
-	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
-}
-
-[dir=rtl] #descendancy_chart li {
-	margin: 5px -15px 0 0;
-	left: auto;
+.chart_common span.details1 .date {
+	color: inherit;
 }
 
 /*-- Family book  --*/

--- a/themes/xenea/css-1.6.2/style.css
+++ b/themes/xenea/css-1.6.2/style.css
@@ -1270,59 +1270,51 @@ td.descriptionbox a {
 	text-align: center;
 }
 
+/* styles for popup menus */
 .itr {
-	position: absolute;
+	position: relative;
 	line-height: 1.5;
 }
 
-.block .itr,
-#family-table .itr,
-#ancestry_chart .itr,
-#descendancy_chart .itr,
-#familybook_chart .itr,
-#hourglass_chart .itr,
-#relatives_content .itr {
-	position: relative;
-	top: 0;
+.popup {
+	position: absolute;
+	top: 20px;
+	right: 0;
+	left: auto;
+	visibility: hidden;
+	opacity: 0;
+	transition: visibility 0s ease .25s,opacity .25s ease;
+	z-index: 9999;
+/*	-webkit-box-shadow: 5px 5px 5px 0 rgba(0,0,0,.4);
+	-moz-box-shadow: 5px 5px 5px 0 rgba(0,0,0,.4);
+	box-shadow: 5px 5px 5px 0 rgba(0,0,0,.4);*/
 }
 
-.popup {
-	display: none;
+[dir=rtl] .popup {
+	left: 0;
+	right: auto;
 }
 
 .popup ul {
-	background-image: none !important;
+	white-space: nowrap;
 	list-style: none;
-	font-size: 9px;
 	margin: 0;
 	padding: 0 10px;
+	font-size: smaller;
 }
 
-.popup li {
-	padding: 1px 5px;
+.popup > ul {
+	padding: 2px 10px;
 }
 
-.popup li span {
+.popup li .NAME {
 	padding: 0 5px;
 }
 
-.popup li ul,
-.popup li ul li,
-.popup li span span {
-	padding: 0;
-}
-
 .itr:hover .popup {
-	display: block;
-	position: absolute;
-	width: 12em;
-	right: 0;
-	z-index: 9999;
-}
-
-[dir=rtl] .itr:hover .popup {
-	left: 0;
-	right: auto;
+	visibility: visible;
+	opacity: 1;
+	transition-delay: 0s;
 }
 
 /* styles for FindFacts pop-up */
@@ -3146,97 +3138,60 @@ table.table-census-assistant th {
 }
 
 /* ====== Charts Styles ======== */
-#ancestry_chart,
 #compact_chart,
-#descendancy_chart,
-#familybook_chart,
 #fan_chart,
-#hourglass_chart,
-#relationship_chart {
+.chart_common,
+#ancestry_booklet,
+#descendancy_booklet,
+#familybook_chart,
+#hourglass_chart {
 	margin: 20px;
 }
 
-/*-- ancestry  --*/
-#ancestry_chart table div p {
-	font-size: 90%;
-	margin: 0;
+/* styles for vertical lines in ancestry and descendancy charts */
+.chart_common li {
+	list-style: none;
 }
 
-#ancestry_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
-	list-style: none;
-	display: block;
+.chart_common li > span.details1 {
+	white-space: nowrap;
+}
+
+.chart_common .generation {
+	background: transparent url(images/vline.png) left top repeat-y;
 	margin: 0 0 0 15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
+	padding: 0;
+	display: block;
 }
 
-#ancestry_chart li {
-	list-style: none;
-	margin: 0 0 2px -13px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
+[dir=rtl] .chart_common .generation {
+	margin: 0 15px 0 0;
+	background-position: right top
+;
 }
 
-#ancestry_chart li table {
+.chart_common .generation > li {
 	margin: 5px 0;
 }
 
-[dir=rtl] #ancestry_chart ul {
-	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
+.chart_common table {
+	padding: 0;
+	border-spacing: 0;
+	border-collapse: collapse;
+	margin: 5px 0;
 }
 
-#ancestry_chart span.details1 div[class^="fact_"] {
+.chart_common td {
+	border: 0;
+	padding: 0;
+}
+
+.chart_common span.details1 div[class^=fact_] {
 	display: inline-block;
 }
 
-[dir=rtl] #ancestry_chart li {
-	margin: 0;
-	padding: 0 2px 0 0;
-	left: auto;
-}
-
-/*-- descendancy  --*/
-#descendancy_chart ul {
-	background-image:url(images/vline.png);
-	background-position:left top;background-repeat:repeat-y;
-	list-style: none;
-	margin: 0 0 5px 15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#descendancy_chart li {
-	list-style: none;
-	margin: 5px 0 0 -15px;
-	padding-top: 0;
-	padding-right: 0;
-	padding-bottom: 0;
-}
-
-#descendancy_chart span.details1 div[class^="fact_"] {
-	display: inline-block;
-}
-
-#descendancy_chart td.details1 {
-	padding-top: 5px;
-}
-
-[dir=rtl] #descendancy_chart ul {
-	background-position: right top;
-	margin: 0 15px 0 0;
-	left: auto;
-}
-
-[dir=rtl] #descendancy_chart li {
-	margin: 5px -15px 0 0;
-	left: auto;
+.chart_common span.details1 .date {
+	color: inherit;
 }
 
 /*-- Family book  --*/
@@ -4243,7 +4198,7 @@ header h1 {
 }
 
 .secondary-menu li li a:hover {
-	color: #f00;;
+	color: #f00;
 }
 
 .secondary-menu li:hover ul {


### PR DESCRIPTION
By adding a couple of classes to the ancestry & descendancy chart code, it allows for the complete decoupling of the popup menu css making it simpler and more straightforward to style.

The css for generating the connecting lines on the ancestry & descendancy charts are the same, so have combined the css.

Removed inline css allowing the code to pass HTML5 validation (bar divs nested within anchors which although it fails validation is apparently valid in HTML5).

Although I think it looks quite nice, it's not part of the original styling so have commented out box-shadow on the popup menu.