### PR TITLE
Added puphpet box configuration for apache2 developer VM

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,11 +2,16 @@
 
 .gitattributes export-ignore
 .gitignore     export-ignore
+.gitmodules    export-ignore
 .travis.yml    export-ignore
 Makefile       export-ignore
 build/         export-ignore
+tests/         export-ignore
+tools/         export-ignore
 js/*.patch     export-ignore
 phpunit.xml    export-ignore
+VAGRANT.sh     export-ignore
+README-vagrant.md                                              export-ignore
 library/bombayworks/zendframework1/library/Zend/Acl/           export-ignore
 library/bombayworks/zendframework1/library/Zend/Amf/           export-ignore
 library/bombayworks/zendframework1/library/Zend/Application/   export-ignore
@@ -54,4 +59,3 @@ library/bombayworks/zendframework1/library/Zend/Tool/          export-ignore
 library/bombayworks/zendframework1/library/Zend/View/          export-ignore
 library/bombayworks/zendframework1/library/Zend/Wildfire/      export-ignore
 library/bombayworks/zendframework1/library/Zend/XmlRpc/        export-ignore
-tests/                                                         export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.swp
 .idea/
 vendor/.git
+.vagrant/
+/Vagrantfile
+/puphpet/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tools/vagrant"]
+	path = tools/vagrant
+	url = git@github.com:WorkingDevel/webtrees-vagrant.git

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,4 @@
+build:
+    dependencies:
+        before:
+            - "sed -i -e 's#git@github.com:#https://github.com/#g' .gitmodules"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ php:
   - 5.4
   - 5.3
   - hhvm
+git:
+  submodules: false

--- a/README-vagrant.md
+++ b/README-vagrant.md
@@ -1,0 +1,73 @@
+# Vagrant development box for [fisharebest/webtrees](https://github.com/fisharebest/webtrees)
+
+Don't use this repo directly. It is meant to work as sub-module in fisharebest/webtrees under `tools/vagrant`. Please checkout fisharebest/webtrees and ran there the VAGRANT.sh.
+
+# Vagrant - Usage
+
+This uses [Vagrant](http://vagrantup.com) and [VirtualBox](http://virtualbox.org) to set up a virtual machine with an installed webserver (either apache2.4 or nginx with PHP5.4).
+* Install first VirtualBox and Vagrant on your host.
+
+## Linux
+
+### Get the VM running
+
+* We are assuming you are in the project root directory. All here mentioned paths are starting from there.
+
+#### Permissions on your host
+* you need to set the owner group of your project root and sub directories to www-data(gid: 33) by
+ * run `sudo chgrp -Rc 33 .` (make sure you are in the project root before running!)
+
+#### Run the vagrant box
+* run `./VAGRANT.sh`
+ * it copies `tools/vagrant/linux/apache2` to project root, so you can control vagrant via PhpStorm Tools menu
+* run `vagrant up`
+ * Attention: you need a good internet connection first time you run `vagrant up`. It downloads and install a lot of packages into the vagrant box
+
+* run `sudo tools/vagrant/linux/configure-vagrant-host.sh` to set up needed hosts-ip resolution automatically in `/etc/hosts` or
+ * edit `/etc/hosts` by hand add following entries
+  - `192.168.56.181    webtrees.nginx.dev www.webtrees.nginx.dev`
+  - `192.168.56.182    webtrees.apache2.dev www.webtrees.apache2.dev`
+
+* You can now login via ssh running `vagrant ssh`
+* The website is reachable via
+ * apache2 based: `webtrees.apache2.dev`
+ * nginx based  : `webtrees.nginx.dev`
+ 
+### Set up webtrees
+
+* call http://webtrees.apache2.dev/setup.php in your browser
+* On page Connection to database server
+ * Database user account: `webtrees_dbu`
+ * Database password: `webtrees`
+* Next page 'Database and table names'
+ * Database name: `webtrees_dev`
+ * Table prefix: `webtrees_`
+* Next page 'System settings' (you can choose here everything on your own)
+ * Your name: `Administrator`
+ * Login ID: `admin`
+ * Password: `webtrees`
+ * Email address: `admin@webtrees.apache2.dev`
+* Now you can login with
+ * Username: `admin`
+ * Password: `webtreeswebtrees`
+ 
+### Trouble shooting
+
+* During `vagrant up` or vagrant provision occurs the message _Warning: Could not retrieve fact fqdn_. Just ignore it, nothing is wrong.
+* If `vagrant up` doesn't run successfully through
+ * It could be your hosts file permissions on project root prevent setting up the share folder, execute `sudo chgrp -Rc 33 .` in project root
+ * execute `vagrant provision` after every change
+
+## Windows
+
+... to be done ...
+
+
+# Updating
+
+* go to https://puphpet.com/
+* upload either the `tools/vagrant/linux/apache2/puphpet/config.yaml`, `tools/vagrant/linux/nginx/puphpet/config.yaml`
+* change your settings
+* download the new configuration
+* extract the zip contents under `tools/vagrant/linux/` or `tools/vagrant/windows/` (skip the cryptic named folder, just the content in it)
+

--- a/VAGRANT.sh
+++ b/VAGRANT.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+### init some used functions
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+### configuration
+OS=linux
+SERVER=${1:-apache2}
+
+VAGRANT_FILE_PATH="tools/vagrant/${OS}/${SERVER}"
+SETUP_DIR="$SCRIPT_DIR"
+
+function checkout_submodule() {
+    cd "$SCRIPT_DIR"
+    git submodule init
+    git submodule update
+}
+
+function setup_vagrant() {
+    . "$SCRIPT_DIR/tools/vagrant/linux/functions.sh"
+
+    $DIFF_TOOL -Nr --exclude='*id_rsa*' "$SCRIPT_DIR/${VAGRANT_FILE_PATH}/puphpet/" "$SETUP_DIR/puphpet/"
+    NEW=$?
+
+    if [[ ${NEW} -gt 0 ]]; then
+        rsync -av --delete --exclude=files/dot/ssh/ "$SCRIPT_DIR/${VAGRANT_FILE_PATH}/puphpet/" "$SETUP_DIR/puphpet/"
+        rsync -av "$SCRIPT_DIR/${VAGRANT_FILE_PATH}/puphpet/files/dot/ssh/" "$SETUP_DIR/puphpet/files/dot/ssh/"
+        cp "$SCRIPT_DIR/${VAGRANT_FILE_PATH}/Vagrantfile" ./
+        log DONE "copying from $SCRIPT_DIR/${VAGRANT_FILE_PATH}"
+    else
+        log DONE "no changes detected -> nothing to do"
+    fi
+
+    log INFO "You should run now 'vagrant up' or 'vagrant provision' now... "
+}
+
+if [[ ! -f tools/vagrant/LICENSE ]]; then
+    checkout_submodule
+fi
+
+setup_vagrant


### PR DESCRIPTION
For development with webtrees it is nice to have a configured webserver running out of the box on your current devevelopment workspace. Virtual machines are a good way (and may be the best) for this especially under windows. https://puphpet.com/ is providing a configuration builder for such webserver-VMs.
I have created a configuration for a apache2 webserver that serves the webtrees code from workspace. PhpStorm is also able to control the created vagrant box.

At the moment the configuration is only for users of a Linux system, for Windows it is still needed to create a configuration, but it could be derived from the linux configuration as https://puphpet.com/ can import and modify already created puphpet confiugration files.