### PR TITLE
Applied fixes to satisfy 'composer validate'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.swp
 .idea/
 vendor/.git
+/Vagrantfile
+/puphpet/
+.vagrant/

--- a/composer.json
+++ b/composer.json
@@ -23,15 +23,15 @@
 		}
 	},
 	"require": {
-		"bombayworks/zendframework1": "*",
-		"ezyang/htmlpurifier": "*",
-		"fisharebest/ext-calendar": "*",
-		"ircmaxell/password-compat": "*",
-		"michelf/php-markdown": "*",
-		"patchwork/utf8": "*",
+		"bombayworks/zendframework1": "1.*",
+		"ezyang/htmlpurifier": "4.6.*",
+		"fisharebest/ext-calendar": "1.3.*",
+		"ircmaxell/password-compat": "1.0.*",
+		"michelf/php-markdown": "1.4.*",
+		"patchwork/utf8": "1.2.*",
 		"pclzip/pclzip": "dev-master",
-		"tecnick.com/tcpdf": "*",
-		"rhumsaa/uuid": "*"
+		"tecnick.com/tcpdf": "6.2.*",
+		"rhumsaa/uuid": "2.8.*"
 	},
 	"scripts": {
 		"post-install-cmd": [


### PR DESCRIPTION
Run of 'composer validate' required to add version strings in 'require'. Added them to match current used versions.

Besides of getting validate passing it's better to upgrade lib major versions 'by hand' via modifying composer.json intentionally than upgrade by accident through composer update.

Added also vagrant files to .gitignore in root directory. If vagrant/puphpet is introduced, at least 2 configurations (linux and windows) should be provided, but it is not possible to have both in the same directory. So the configs should be in sub directories and the one needed should be copied by the developer into the project root, but not committed -> so .gitignore them in root.