### PR TITLE
Moved global var $WT_SESSION as public static to Globals class

### DIFF
--- a/action.php
+++ b/action.php
@@ -18,12 +18,6 @@ namespace Webtrees;
 
 use Zend_Session;
 
-/**
- * Defined in session.php
- *
- * @global Zend_Session $WT_SESSION
- */
-
 define('WT_SCRIPT_NAME', 'action.php');
 require './includes/session.php';
 
@@ -68,17 +62,17 @@ case 'copy-fact':
 					$type = $record::RECORD_TYPE; // paste only to the same record type
 					break;
 				}
-				if (!is_array($WT_SESSION->clipboard)) {
-					$WT_SESSION->clipboard = array();
+				if (!is_array(Globals::$WT_SESSION->clipboard)) {
+					Globals::$WT_SESSION->clipboard = array();
 				}
-				$WT_SESSION->clipboard[$fact_id] = array(
+				Globals::$WT_SESSION->clipboard[$fact_id] = array(
 					'type'   =>$type,
 					'factrec'=>$fact->getGedcom(),
 					'fact'   =>$fact->getTag()
 					);
 				// The clipboard only holds 10 facts
-				while (count($WT_SESSION->clipboard) > 10) {
-					array_shift($WT_SESSION->clipboard);
+				while (count(Globals::$WT_SESSION->clipboard) > 10) {
+					array_shift(Globals::$WT_SESSION->clipboard);
 				}
 				FlashMessages::addMessage(I18N::translate('The record has been copied to the clipboard.'));
 				break 2;
@@ -94,8 +88,8 @@ case 'paste-fact':
 
 	$record = GedcomRecord::getInstance($xref);
 
-	if ($record && $record->canEdit() && isset($WT_SESSION->clipboard[$fact_id])) {
-		$record->createFact($WT_SESSION->clipboard[$fact_id]['factrec'], true);
+	if ($record && $record->canEdit() && isset(Globals::$WT_SESSION->clipboard[$fact_id])) {
+		$record->createFact(Globals::$WT_SESSION->clipboard[$fact_id]['factrec'], true);
 	}
 	break;
 
@@ -223,7 +217,7 @@ case 'theme':
 	// Change the current theme
 	$theme = Filter::post('theme');
 	if (Site::getPreference('ALLOW_USER_THEMES') && array_key_exists($theme, Theme::themeNames())) {
-		$WT_SESSION->theme_id = $theme;
+		Globals::$WT_SESSION->theme_id = $theme;
 		// Remember our selection
 		Auth::user()->setPreference('theme', $theme);
 	} else {

--- a/admin_pgv_to_wt.php
+++ b/admin_pgv_to_wt.php
@@ -19,12 +19,6 @@ namespace Webtrees;
 use PDO;
 use PDOException;
 
-/**
- * Defined in session.php
- *
- * @global Zend_Session $WT_SESSION
- */
-
 define('WT_SCRIPT_NAME', 'admin_pgv_to_wt.php');
 require './includes/session.php';
 
@@ -119,7 +113,7 @@ if ($PGV_PATH) {
 
 if ($PGV_PATH) {
 	// The account we are using is about to be deleted.
-	$WT_SESSION->wt_user = null;
+	Globals::$WT_SESSION->wt_user = null;
 }
 
 $controller->pageHeader();

--- a/app/Auth.php
+++ b/app/Auth.php
@@ -141,9 +141,7 @@ class Auth {
 	 * @return string|null
 	 */
 	public static function id() {
-		global $WT_SESSION;
-
-		return $WT_SESSION ? $WT_SESSION->wt_user : null;
+		return Globals::$WT_SESSION ? Globals::$WT_SESSION->wt_user : null;
 	}
 
 	/**
@@ -172,9 +170,8 @@ class Auth {
 	 * @param User $user
 	 */
 	public static function login(User $user) {
-		global $WT_SESSION;
 
-		$WT_SESSION->wt_user = $user->getUserId();
+		Globals::$WT_SESSION->wt_user = $user->getUserId();
 		Zend_Session::regenerateId();
 	}
 

--- a/app/Controller/LifespanController.php
+++ b/app/Controller/LifespanController.php
@@ -64,7 +64,6 @@ class LifespanController extends PageController {
 	 * Startup activity
 	 */
 	function __construct() {
-		global $WT_SESSION;
 
 		parent::__construct();
 		$this->setPageTitle(I18N::translate('Lifespans'));
@@ -105,8 +104,8 @@ class LifespanController extends PageController {
 			$this->place = $place;
 		} else {
 			// Modify an existing list of records
-			if (is_array($WT_SESSION->timeline_pids)) {
-				$this->pids = $WT_SESSION->timeline_pids;
+			if (is_array(Globals::$WT_SESSION->timeline_pids)) {
+				$this->pids = Globals::$WT_SESSION->timeline_pids;
 			} else {
 				$this->pids = array();
 			}
@@ -122,7 +121,7 @@ class LifespanController extends PageController {
 				$this->addFamily($this->getSignificantIndividual(), false);
 			}
 		}
-		$WT_SESSION->timeline_pids = $this->pids;
+		Globals::$WT_SESSION->timeline_pids = $this->pids;
 
 		$this->beginYear = $beginYear;
 		$this->endYear   = $endYear;
@@ -162,7 +161,7 @@ class LifespanController extends PageController {
 					}
 				}
 			}
-			$WT_SESSION->timeline_pids = null;
+			Globals::$WT_SESSION->timeline_pids = null;
 		}
 
 		// Sort the array in order of birth year

--- a/app/Filter.php
+++ b/app/Filter.php
@@ -436,16 +436,15 @@ class Filter {
 	 * @return string
 	 */
 	public static function getCsrfToken() {
-		global $WT_SESSION;
 
-		if ($WT_SESSION->CSRF_TOKEN === null) {
+		if (Globals::$WT_SESSION->CSRF_TOKEN === null) {
 			$charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcedfghijklmnopqrstuvwxyz0123456789';
 			for ($n = 0; $n < 32; ++$n) {
-				$WT_SESSION->CSRF_TOKEN .= substr($charset, mt_rand(0, 61), 1);
+				Globals::$WT_SESSION->CSRF_TOKEN .= substr($charset, mt_rand(0, 61), 1);
 			}
 		}
 
-		return $WT_SESSION->CSRF_TOKEN;
+		return Globals::$WT_SESSION->CSRF_TOKEN;
 	}
 
 	/**

--- a/app/Globals.php
+++ b/app/Globals.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Webtrees;
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2015 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Class to keep all global variables together for refactoring them later.
+ *
+ * @package Webtrees
+ * @author Christoph Graupner <ch.graupner@workingdeveloper.de>
+ */
+class Globals {
+    /**
+     * @var \Zend_Session
+     */
+    public static $WT_SESSION = null;
+}

--- a/app/I18N.php
+++ b/app/I18N.php
@@ -184,7 +184,7 @@ class I18N {
 	 * @return string $string
 	 */
 	public static function init($locale = null) {
-		global $WT_SESSION, $WT_TREE;
+		global $WT_TREE;
 
 		// The translation libraries only work with a cache.
 		$cache_options = array(
@@ -209,9 +209,9 @@ class I18N {
 			if (array_key_exists(Filter::get('lang'), $installed_languages)) {
 				// Requested in the URL?
 				$locale = Filter::get('lang');
-			} elseif (array_key_exists($WT_SESSION->locale, $installed_languages)) {
+			} elseif (array_key_exists(Globals::$WT_SESSION->locale, $installed_languages)) {
 				// Rembered from a previous visit?
-				$locale = $WT_SESSION->locale;
+				$locale = Globals::$WT_SESSION->locale;
 			} else {
 				// Browser preference takes priority over gedcom default
 				if (empty($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {

--- a/includes/functions/functions_print.php
+++ b/includes/functions/functions_print.php
@@ -596,12 +596,12 @@ function CheckFactUnique($uniquefacts, $recfacts, $type) {
  * @param string $type      the type of record INDI, FAM, SOUR etc
  */
 function print_add_new_fact($id, $usedfacts, $type) {
-	global $WT_SESSION, $WT_TREE;
+	global $WT_TREE;
 
 	// -- Add from clipboard
-	if ($WT_SESSION->clipboard) {
+	if (Globals::$WT_SESSION->clipboard) {
 		$newRow = true;
-		foreach (array_reverse($WT_SESSION->clipboard, true) as $fact_id=>$fact) {
+		foreach (array_reverse(Globals::$WT_SESSION->clipboard, true) as $fact_id=>$fact) {
 			if ($fact["type"] == $type || $fact["type"] == 'all') {
 				if ($newRow) {
 					$newRow = false;

--- a/includes/hitcount.php
+++ b/includes/hitcount.php
@@ -60,8 +60,8 @@ if ($page_parameter) {
 	)->execute(array(WT_GED_ID, WT_SCRIPT_NAME, $page_parameter))->fetchOne();
 
 	// Only record one hit per session
-	if ($page_parameter && empty($WT_SESSION->SESSION_PAGE_HITS[WT_SCRIPT_NAME . $page_parameter])) {
-		$WT_SESSION->SESSION_PAGE_HITS[WT_SCRIPT_NAME . $page_parameter] = true;
+	if ($page_parameter && empty(Globals::$WT_SESSION->SESSION_PAGE_HITS[WT_SCRIPT_NAME . $page_parameter])) {
+		Globals::$WT_SESSION->SESSION_PAGE_HITS[WT_SCRIPT_NAME . $page_parameter] = true;
 		if (is_null($hitCount)) {
 			$hitCount = 1;
 			Database::prepare(

--- a/includes/session.php
+++ b/includes/session.php
@@ -29,7 +29,7 @@ if (!defined('WT_SCRIPT_NAME')) {
 
 // To embed webtrees code in other applications, we must explicitly declare any global variables that we create.
 // session.php
-global $WT_REQUEST, $WT_SESSION, $WT_TREE, $GEDCOM, $SEARCH_SPIDER, $TEXT_DIRECTION;
+global $WT_REQUEST, $WT_TREE, $GEDCOM, $SEARCH_SPIDER, $TEXT_DIRECTION;
 // most pages
 global $controller;
 
@@ -379,12 +379,12 @@ Zend_Session::start($cfg);
 // Register a session “namespace” to store session data.  This is better than
 // using $_SESSION, as we can avoid clashes with other modules or applications,
 // and problems with servers that have enabled “register_globals”.
-$WT_SESSION = new Zend_Session_Namespace('WEBTREES');
+Globals::$WT_SESSION = new Zend_Session_Namespace('WEBTREES');
 
-if (!$SEARCH_SPIDER && !$WT_SESSION->initiated) {
+if (!$SEARCH_SPIDER && !Globals::$WT_SESSION->initiated) {
 	// A new session, so prevent session fixation attacks by choosing a new PHPSESSID.
 	Zend_Session::regenerateId();
-	$WT_SESSION->initiated = true;
+	Globals::$WT_SESSION->initiated = true;
 } else {
 	// An existing session
 }
@@ -398,9 +398,9 @@ define('WT_USER_NAME', Auth::id() ? Auth::user()->getUserName() : '');
 if (isset($_REQUEST['ged'])) {
 	// .... from the URL or form action
 	$GEDCOM = $_REQUEST['ged'];
-} elseif ($WT_SESSION->GEDCOM) {
+} elseif (Globals::$WT_SESSION->GEDCOM) {
 	// .... the most recently used one
-	$GEDCOM = $WT_SESSION->GEDCOM;
+	$GEDCOM = Globals::$WT_SESSION->GEDCOM;
 } else {
 	// Try the site default
 	$GEDCOM = Site::getPreference('DEFAULT_GEDCOM');
@@ -454,10 +454,10 @@ $GEDCOM = WT_GEDCOM;
 
 // With no parameters, init() looks to the environment to choose a language
 define('WT_LOCALE', I18N::init());
-$WT_SESSION->locale = I18N::$locale;
+Globals::$WT_SESSION->locale = I18N::$locale;
 
 // Set our gedcom selection as a default for the next page
-$WT_SESSION->GEDCOM = WT_GEDCOM;
+Globals::$WT_SESSION->GEDCOM = WT_GEDCOM;
 
 if (empty($WEBTREES_EMAIL)) {
 	$WEBTREES_EMAIL = 'webtrees-noreply@' . preg_replace('/^www\./i', '', $_SERVER['SERVER_NAME']);
@@ -470,7 +470,7 @@ define('WT_TIMESTAMP', (int) Database::prepare("SELECT UNIX_TIMESTAMP()")->fetch
 define('WT_SERVER_TIMESTAMP', WT_TIMESTAMP + (int) date('Z'));
 
 if (Auth::check()) {
-	define('WT_CLIENT_TIMESTAMP', WT_TIMESTAMP - $WT_SESSION->timediff);
+	define('WT_CLIENT_TIMESTAMP', WT_TIMESTAMP - Globals::$WT_SESSION->timediff);
 } else {
 	define('WT_CLIENT_TIMESTAMP', WT_SERVER_TIMESTAMP);
 }
@@ -503,15 +503,15 @@ if (WT_SCRIPT_NAME != 'admin_trees_manage.php' && WT_SCRIPT_NAME != 'admin_pgv_t
 }
 
 // Update the login time every 5 minutes
-if (WT_TIMESTAMP - $WT_SESSION->activity_time > 300) {
+if (WT_TIMESTAMP - Globals::$WT_SESSION->activity_time > 300) {
 	Auth::user()->setPreference('sessiontime', WT_TIMESTAMP);
-	$WT_SESSION->activity_time = WT_TIMESTAMP;
+	Globals::$WT_SESSION->activity_time = WT_TIMESTAMP;
 }
 
 // Set the theme
 if (substr(WT_SCRIPT_NAME, 0, 5) === 'admin' || WT_SCRIPT_NAME === 'module.php' && substr(Filter::get('mod_action'), 0, 5) === 'admin') {
 	// Administration scripts begin with “admin” and use a special administration theme
-	Theme::theme(new AdministrationTheme)->init($WT_SESSION, $SEARCH_SPIDER, $WT_TREE);
+	Theme::theme(new AdministrationTheme)->init(Globals::$WT_SESSION, $SEARCH_SPIDER, $WT_TREE);
 } else {
 	if (Site::getPreference('ALLOW_USER_THEMES')) {
 		// Requested change of theme?
@@ -520,8 +520,8 @@ if (substr(WT_SCRIPT_NAME, 0, 5) === 'admin' || WT_SCRIPT_NAME === 'module.php' 
 			$theme_id = '';
 		}
 		// Last theme used?
-		if (!$theme_id && array_key_exists($WT_SESSION->theme_id, Theme::themeNames())) {
-			$theme_id = $WT_SESSION->theme_id;
+		if (!$theme_id && array_key_exists(Globals::$WT_SESSION->theme_id, Theme::themeNames())) {
+			$theme_id = Globals::$WT_SESSION->theme_id;
 		}
 	} else {
 		$theme_id = '';
@@ -544,12 +544,12 @@ if (substr(WT_SCRIPT_NAME, 0, 5) === 'admin' || WT_SCRIPT_NAME === 'module.php' 
 	}
 	foreach (Theme::installedThemes() as $theme) {
 		if ($theme->themeId() === $theme_id) {
-			Theme::theme($theme)->init($WT_SESSION, $SEARCH_SPIDER, $WT_TREE);
+			Theme::theme($theme)->init(Globals::$WT_SESSION, $SEARCH_SPIDER, $WT_TREE);
 		}
 	}
 
 	// Remember this setting
-	$WT_SESSION->theme_id = $theme_id;
+	Globals::$WT_SESSION->theme_id = $theme_id;
 }
 
 // Page hit counter - load after theme, as we need theme formatting

--- a/index_edit.php
+++ b/index_edit.php
@@ -23,7 +23,6 @@ use Zend_Session;
  *
  * @global string       $SEARCH_SPIDER
  * @global string       $TEXT_DIRECTION
- * @global Zend_Session $WT_SESSION
  * @global Tree         $WT_TREE
  */
 
@@ -56,7 +55,7 @@ if ($user_id) {
 
 if ($user_id < 0 || $gedcom_id < 0 || Auth::isAdmin() && $user_id != Auth::id()) {
 	// We're doing this from an admin page.  Use the admin theme, and return there afterwards.
-	Theme::theme(new AdministrationTheme)->init($WT_SESSION, $SEARCH_SPIDER, $WT_TREE);
+	Theme::theme(new AdministrationTheme)->init(Globals::$WT_SESSION, $SEARCH_SPIDER, $WT_TREE);
 	$return_to = 'admin_trees_manage.php?ged=';
 } else {
 	$return_to = 'index.php';

--- a/login.php
+++ b/login.php
@@ -23,7 +23,6 @@ use Zend_Session;
 /**
  * Defined in session.php
  *
- * @global Zend_Session                 $WT_SESSION
  * @global Tree                         $WT_TREE
  * @global Zend_Controller_Request_Http $WT_REQUEST
  */
@@ -97,10 +96,10 @@ case 'login':
 		Auth::login($user);
 		Log::addAuthenticationLog('Login: ' . Auth::user()->getUserName() . '/' . Auth::user()->getRealName());
 
-		$WT_SESSION->timediff      = $timediff;
-		$WT_SESSION->locale        = Auth::user()->getPreference('language');
-		$WT_SESSION->theme_id      = Auth::user()->getPreference('theme');
-		$WT_SESSION->activity_time = WT_TIMESTAMP;
+		Globals::$WT_SESSION->timediff      = $timediff;
+		Globals::$WT_SESSION->locale        = Auth::user()->getPreference('language');
+		Globals::$WT_SESSION->theme_id      = Auth::user()->getPreference('theme');
+		Globals::$WT_SESSION->activity_time = WT_TIMESTAMP;
 
 		Auth::user()->setPreference('sessiontime', WT_TIMESTAMP);
 
@@ -275,7 +274,7 @@ case 'register':
 	$controller->setPageTitle(I18N::translate('Request new user account'));
 
 	// The form parameters are mandatory, and the validation errors are shown in the client.
-	if ($WT_SESSION->good_to_send && $user_name && $user_password01 && $user_password01 == $user_password02 && $user_realname && $user_email && $user_comments) {
+	if (Globals::$WT_SESSION->good_to_send && $user_name && $user_password01 && $user_password01 == $user_password02 && $user_realname && $user_email && $user_comments) {
 
 		// These validation errors cannot be shown in the client.
 		if (User::findByIdentifier($user_name)) {
@@ -399,7 +398,7 @@ case 'register':
 		}
 	}
 
-	$WT_SESSION->good_to_send = true;
+	Globals::$WT_SESSION->good_to_send = true;
 	$controller
 		->pageHeader()
 		->addInlineJavascript('function regex_quote(str) {return str.replace(/[\\\\.?+*()[\](){}|]/g, "\\\\$&");}');

--- a/message.php
+++ b/message.php
@@ -16,14 +16,6 @@ namespace Webtrees;
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-use Zend_Session;
-
-/**
- * Defined in session.php
- *
- * @global Zend_Session $WT_SESSION
- */
-
 define('WT_SCRIPT_NAME', 'message.php');
 require './includes/session.php';
 
@@ -73,18 +65,18 @@ if (Auth::check()) {
 // This makes it harder for spammers.
 switch ($action) {
 case 'compose':
-	$WT_SESSION->good_to_send = true;
+	Globals::$WT_SESSION->good_to_send = true;
 	break;
 case 'send':
 	// Only send messages if we've come straight from the compose page.
-	if (!$WT_SESSION->good_to_send) {
+	if (!Globals::$WT_SESSION->good_to_send) {
 		Log::addAuthenticationLog('Attempt to send a message without visiting the compose page.  Spam attack?');
 		$action = 'compose';
 	}
 	if (!Filter::checkCsrf()) {
 		$action = 'compose';
 	}
-	unset($WT_SESSION->good_to_send);
+	unset(Globals::$WT_SESSION->good_to_send);
 	break;
 }
 

--- a/modules_v3/clippings/ClippingsCart.php
+++ b/modules_v3/clippings/ClippingsCart.php
@@ -60,14 +60,14 @@ class ClippingsCart {
 	 * Create the clippings controller
 	 */
 	public function __construct() {
-		global $WT_TREE, $MEDIA_DIRECTORY, $WT_SESSION;
+		global $WT_TREE, $MEDIA_DIRECTORY;
 
 		// Our cart is an array of items in the session
-		if (!is_array($WT_SESSION->cart)) {
-			$WT_SESSION->cart = array();
+		if (!is_array(Globals::$WT_SESSION->cart)) {
+			Globals::$WT_SESSION->cart = array();
 		}
-		if (!array_key_exists(WT_GED_ID, $WT_SESSION->cart)) {
-			$WT_SESSION->cart[WT_GED_ID] = array();
+		if (!array_key_exists(WT_GED_ID, Globals::$WT_SESSION->cart)) {
+			Globals::$WT_SESSION->cart[WT_GED_ID] = array();
 		}
 
 		$this->action           = Filter::get('action');
@@ -149,12 +149,12 @@ class ClippingsCart {
 						$this->addFamilyDescendancy($family, $this->level3);
 					}
 				}
-				uksort($WT_SESSION->cart[WT_GED_ID], 'Webtrees\ClippingsCart::compareClippings');
+				uksort(Globals::$WT_SESSION->cart[WT_GED_ID], 'Webtrees\ClippingsCart::compareClippings');
 			}
 		} elseif ($this->action === 'remove') {
-			unset ($WT_SESSION->cart[WT_GED_ID][$this->id]);
+			unset (Globals::$WT_SESSION->cart[WT_GED_ID][$this->id]);
 		} elseif ($this->action === 'empty') {
-			$WT_SESSION->cart[WT_GED_ID] = array();
+			Globals::$WT_SESSION->cart[WT_GED_ID] = array();
 		} elseif ($this->action === 'download') {
 			$media      = array();
 			$mediacount = 0;
@@ -194,7 +194,7 @@ class ClippingsCart {
 				break;
 			}
 
-			foreach (array_keys($WT_SESSION->cart[WT_GED_ID]) as $xref) {
+			foreach (array_keys(Globals::$WT_SESSION->cart[WT_GED_ID]) as $xref) {
 				$object = GedcomRecord::getInstance($xref);
 				// The object may have been deleted since we added it to the cart....
 				if ($object) {
@@ -202,19 +202,19 @@ class ClippingsCart {
 					// Remove links to objects that aren't in the cart
 					preg_match_all('/\n1 ' . WT_REGEX_TAG . ' @(' . WT_REGEX_XREF . ')@(\n[2-9].*)*/', $record, $matches, PREG_SET_ORDER);
 					foreach ($matches as $match) {
-						if (!array_key_exists($match[1], $WT_SESSION->cart[WT_GED_ID])) {
+						if (!array_key_exists($match[1], Globals::$WT_SESSION->cart[WT_GED_ID])) {
 							$record = str_replace($match[0], '', $record);
 						}
 					}
 					preg_match_all('/\n2 ' . WT_REGEX_TAG . ' @(' . WT_REGEX_XREF . ')@(\n[3-9].*)*/', $record, $matches, PREG_SET_ORDER);
 					foreach ($matches as $match) {
-						if (!array_key_exists($match[1], $WT_SESSION->cart[WT_GED_ID])) {
+						if (!array_key_exists($match[1], Globals::$WT_SESSION->cart[WT_GED_ID])) {
 							$record = str_replace($match[0], '', $record);
 						}
 					}
 					preg_match_all('/\n3 ' . WT_REGEX_TAG . ' @(' . WT_REGEX_XREF . ')@(\n[4-9].*)*/', $record, $matches, PREG_SET_ORDER);
 					foreach ($matches as $match) {
-						if (!array_key_exists($match[1], $WT_SESSION->cart[WT_GED_ID])) {
+						if (!array_key_exists($match[1], Globals::$WT_SESSION->cart[WT_GED_ID])) {
 							$record = str_replace($match[0], '', $record);
 						}
 					}
@@ -333,14 +333,12 @@ class ClippingsCart {
 	 * @param GedcomRecord $record
 	 */
 	function addClipping(GedcomRecord $record) {
-		global $WT_SESSION;
-
 		if ($record->canShowName()) {
-			$WT_SESSION->cart[WT_GED_ID][$record->getXref()] = true;
+			Globals::$WT_SESSION->cart[WT_GED_ID][$record->getXref()] = true;
 			// Add directly linked records
 			preg_match_all('/\n\d (?:OBJE|NOTE|SOUR|REPO) @(' . WT_REGEX_XREF . ')@/', $record->getGedcom(), $matches);
 			foreach ($matches[1] as $match) {
-				$WT_SESSION->cart[WT_GED_ID][$match] = true;
+				Globals::$WT_SESSION->cart[WT_GED_ID][$match] = true;
 			}
 		}
 	}

--- a/modules_v3/clippings/module.php
+++ b/modules_v3/clippings/module.php
@@ -48,7 +48,7 @@ class clippings_WT_Module extends Module implements ModuleMenuInterface, ModuleS
 			echo $html;
 			break;
 		case 'index':
-			global $MAX_PEDIGREE_GENERATIONS, $controller, $WT_SESSION, $GEDCOM_MEDIA_PATH;
+			global $MAX_PEDIGREE_GENERATIONS, $controller, $GEDCOM_MEDIA_PATH;
 
 			$clip_ctrl = new ClippingsCart;
 
@@ -63,7 +63,7 @@ class clippings_WT_Module extends Module implements ModuleMenuInterface, ModuleS
 			echo 'function radAncestors(elementid) {var radFamilies=document.getElementById(elementid);radFamilies.checked=true;}';
 			echo '</script>';
 
-			if (!$WT_SESSION->cart[WT_GED_ID]) {
+			if (!Globals::$WT_SESSION->cart[WT_GED_ID]) {
 				echo '<h2>', I18N::translate('Family tree clippings cart'), '</h2>';
 			}
 
@@ -125,7 +125,7 @@ class clippings_WT_Module extends Module implements ModuleMenuInterface, ModuleS
 				<?php }
 				}
 
-			if (!$WT_SESSION->cart[WT_GED_ID]) {
+			if (!Globals::$WT_SESSION->cart[WT_GED_ID]) {
 				if ($clip_ctrl->action != 'add') {
 
 					echo I18N::translate('The clippings cart allows you to take extracts (“clippings”) from this family tree and bundle them up into a single file for downloading and subsequent importing into your own genealogy program.  The downloadable file is recorded in GEDCOM format.<br><ul><li>How to take clippings?<br>This is really simple.  Whenever you see a clickable name (individual, family, or source) you can go to the Details page of that name.  There you will see the <b>Add to clippings cart</b> option.  When you click that link you will be offered several options to download.</li><li>How to download?<br>Once you have items in your cart, you can download them just by clicking the “Download” link.  Follow the instructions and links.</li></ul>');
@@ -252,7 +252,7 @@ class clippings_WT_Module extends Module implements ModuleMenuInterface, ModuleS
 						<th class="list_label"><?php echo I18N::translate('Remove'); ?></th>
 					</tr>
 			<?php
-				foreach (array_keys($WT_SESSION->cart[WT_GED_ID]) as $xref) {
+				foreach (array_keys(Globals::$WT_SESSION->cart[WT_GED_ID]) as $xref) {
 					$record = GedcomRecord::getInstance($xref);
 					if ($record) {
 						switch ($record::RECORD_TYPE) {
@@ -348,7 +348,6 @@ class clippings_WT_Module extends Module implements ModuleMenuInterface, ModuleS
 
 	/** {@inheritdoc} */
 	public function getSidebarAjaxContent() {
-		global $WT_SESSION;
 
 		$clip_ctrl         = new ClippingsCart;
 		$add               = Filter::get('add', WT_REGEX_XREF);
@@ -392,9 +391,9 @@ class clippings_WT_Module extends Module implements ModuleMenuInterface, ModuleS
 				}
 			}
 		} elseif ($remove) {
-			unset ($WT_SESSION->cart[WT_GED_ID][$remove]);
+			unset (Globals::$WT_SESSION->cart[WT_GED_ID][$remove]);
 		} elseif (isset($_REQUEST['empty'])) {
-			$WT_SESSION->cart[WT_GED_ID] = array();
+			Globals::$WT_SESSION->cart[WT_GED_ID] = array();
 		} elseif (isset($_REQUEST['download'])) {
 			return $this->downloadForm($clip_ctrl);
 		}
@@ -407,17 +406,15 @@ class clippings_WT_Module extends Module implements ModuleMenuInterface, ModuleS
 	 * @return string
 	 */
 	public function getCartList() {
-		global $WT_SESSION;
-
 		// Keep track of the INDI from the parent page, otherwise it will
 		// get lost after ajax updates
 		$pid = Filter::get('pid', WT_REGEX_XREF);
 
-		if (!$WT_SESSION->cart[WT_GED_ID]) {
+		if (!Globals::$WT_SESSION->cart[WT_GED_ID]) {
 			$out = I18N::translate('Your clippings cart is empty.');
 		} else {
 			$out = '<ul>';
-			foreach (array_keys($WT_SESSION->cart[WT_GED_ID]) as $xref) {
+			foreach (array_keys(Globals::$WT_SESSION->cart[WT_GED_ID]) as $xref) {
 				$record = GedcomRecord::getInstance($xref);
 				if ($record instanceof Individual || $record instanceof Family) {
 					switch ($record::RECORD_TYPE) {
@@ -448,7 +445,7 @@ class clippings_WT_Module extends Module implements ModuleMenuInterface, ModuleS
 			$out .= '</ul>';
 		}
 
-		if ($WT_SESSION->cart[WT_GED_ID]) {
+		if (Globals::$WT_SESSION->cart[WT_GED_ID]) {
 			$out .=
 				'<br><a href="module.php?mod=' . $this->getName() . '&amp;mod_action=ajax&amp;sb_action=clippings&amp;empty=true&amp;pid=' . $pid . '" class="remove_cart">' .
 				I18N::translate('Empty the clippings cart') .
@@ -459,7 +456,7 @@ class clippings_WT_Module extends Module implements ModuleMenuInterface, ModuleS
 				'</a>';
 		}
 		$record = Individual::getInstance($pid);
-		if ($record && !array_key_exists($record->getXref(), $WT_SESSION->cart[WT_GED_ID])) {
+		if ($record && !array_key_exists($record->getXref(), Globals::$WT_SESSION->cart[WT_GED_ID])) {
 			$out .= '<br><a href="module.php?mod=' . $this->getName() . '&amp;mod_action=ajax&amp;sb_action=clippings&amp;add=' . $pid . '&amp;pid=' . $pid . '" class="add_cart"><i class="icon-clippings"></i> ' . I18N::translate('Add %s to the clippings cart', $record->getFullName()) . '</a>';
 		}
 		return $out;

--- a/setup.php
+++ b/setup.php
@@ -25,7 +25,7 @@ if (strpos(ini_get('disable_functions'), 'ini_set') === false) {
 }
 
 // To embed webtrees code in other applications, we must explicitly declare any global variables that we create.
-global $WT_REQUEST, $WT_SESSION;
+global $WT_REQUEST;
 
 define('WT_SCRIPT_NAME', 'setup.php');
 define('WT_CONFIG_FILE', 'config.ini.php');
@@ -65,9 +65,9 @@ if (version_compare(PHP_VERSION, WT_REQUIRED_PHP_VERSION) < 0) {
 }
 
 $WT_REQUEST          = new Zend_Controller_Request_Http;
-$WT_SESSION          = new \stdClass;
-$WT_SESSION->locale  = null; // Needed for I18N
-$WT_SESSION->wt_user = null; // Needed for Auth
+Globals::$WT_SESSION          = new \stdClass;
+Globals::$WT_SESSION->locale  = null; // Needed for I18N
+Globals::$WT_SESSION->wt_user = null; // Needed for Auth
 define('WT_LOCALE', I18N::init(Filter::post('lang', '[@a-zA-Z_]+')));
 
 header('Content-Type: text/html; charset=UTF-8');

--- a/site-offline.php
+++ b/site-offline.php
@@ -32,8 +32,8 @@ define('WT_ROOT', '');
 define('WT_GED_ID', 0);
 define('WT_DATA_DIR', realpath('data') . DIRECTORY_SEPARATOR);
 
-$WT_SESSION         = new \stdClass;
-$WT_SESSION->locale = '';
+Globals::$WT_SESSION         = new \stdClass;
+Globals::$WT_SESSION->locale = '';
 
 define('WT_LOCALE', I18N::init());
 

--- a/site-unavailable.php
+++ b/site-unavailable.php
@@ -35,8 +35,8 @@ define('WT_ROOT', '');
 define('WT_GED_ID', 0);
 define('WT_DATA_DIR', realpath('data') . DIRECTORY_SEPARATOR);
 
-$WT_SESSION         = new \stdClass;
-$WT_SESSION->locale = '';
+Globals::$WT_SESSION         = new \stdClass;
+Globals::$WT_SESSION->locale = '';
 
 define('WT_LOCALE', I18N::init());
 

--- a/statistics.php
+++ b/statistics.php
@@ -21,7 +21,6 @@ use Zend_Session;
 /**
  * Defined in session.php
  *
- * @global Zend_Session $WT_SESSION
  * @global string       $GEDCOM
  */
 
@@ -506,21 +505,21 @@ if (!$ajax) {
 		if (!isset($plotnp)) {
 			$plotnp = 201;
 		}
-		if (isset($WT_SESSION->statTicks[$GEDCOM])) {
-			$x_axis_boundary_ages    = $WT_SESSION->statTicks[$GEDCOM]['x_axis_boundary_ages'];
-			$x_axis_boundary_months  = $WT_SESSION->statTicks[$GEDCOM]['x_axis_boundary_months'];
-			$x_axis_boundary_numbers = $WT_SESSION->statTicks[$GEDCOM]['x_axis_boundary_numbers'];
-			$x_axis_boundary_periods = $WT_SESSION->statTicks[$GEDCOM]['z_axis_boundary_periods'];
+		if (isset(Globals::$WT_SESSION->statTicks[$GEDCOM])) {
+			$x_axis_boundary_ages    = Globals::$WT_SESSION->statTicks[$GEDCOM]['x_axis_boundary_ages'];
+			$x_axis_boundary_months  = Globals::$WT_SESSION->statTicks[$GEDCOM]['x_axis_boundary_months'];
+			$x_axis_boundary_numbers = Globals::$WT_SESSION->statTicks[$GEDCOM]['x_axis_boundary_numbers'];
+			$x_axis_boundary_periods = Globals::$WT_SESSION->statTicks[$GEDCOM]['z_axis_boundary_periods'];
 		} else {
 			$x_axis_boundary_ages    = '1,5,10,20,30,40,50,60,70,80,90,100';
 			$x_axis_boundary_months  = '-24,-12,0,8,12,18,24,48';
 			$x_axis_boundary_numbers = '1,2,3,4,5,6,7,8,9,10';
 			$x_axis_boundary_periods = '1700,1750,1800,1850,1900,1950,2000';
 		}
-		if (isset($WT_SESSION->statTicks1[$GEDCOM])) {
-			$chart_shows = $WT_SESSION->statTicks1[$GEDCOM]['chart_shows'];
-			$chart_type  = $WT_SESSION->statTicks1[$GEDCOM]['chart_type'];
-			$surname     = $WT_SESSION->statTicks1[$GEDCOM]['surname'];
+		if (isset(Globals::$WT_SESSION->statTicks1[$GEDCOM])) {
+			$chart_shows = Globals::$WT_SESSION->statTicks1[$GEDCOM]['chart_shows'];
+			$chart_type  = Globals::$WT_SESSION->statTicks1[$GEDCOM]['chart_type'];
+			$surname     = Globals::$WT_SESSION->statTicks1[$GEDCOM]['surname'];
 		} else {
 			$chart_shows = 'world';
 			$chart_type  = 'indi_distribution_chart';

--- a/statisticsplot.php
+++ b/statisticsplot.php
@@ -21,7 +21,6 @@ use Zend_Session;
 /**
  * Defined in session.php
  *
- * @global Zend_Session $WT_SESSION
  * @global string       $GEDCOM
  */
 
@@ -890,14 +889,14 @@ if ($action === 'update') {
 	$chart_type  = $_POST['chart_type'];
 	$surname     = $_POST['SURN'];
 
-	$WT_SESSION->statTicks[$GEDCOM]['x_axis_boundary_ages']          = $xgl;
-	$WT_SESSION->statTicks[$GEDCOM]['x_axis_boundary_ages_marriage'] = $xglm;
-	$WT_SESSION->statTicks[$GEDCOM]['x_axis_boundary_months']        = $xgm;
-	$WT_SESSION->statTicks[$GEDCOM]['x_axis_boundary_numbers']       = $xga;
-	$WT_SESSION->statTicks[$GEDCOM]['z_axis_boundary_periods']       = $zgp;
-	$WT_SESSION->statTicks[$GEDCOM]['chart_shows']                   = $chart_shows;
-	$WT_SESSION->statTicks[$GEDCOM]['chart_type']                    = $chart_type;
-	$WT_SESSION->statTicks[$GEDCOM]['SURN']                          = $surname;
+	Globals::$WT_SESSION->statTicks[$GEDCOM]['x_axis_boundary_ages']          = $xgl;
+	Globals::$WT_SESSION->statTicks[$GEDCOM]['x_axis_boundary_ages_marriage'] = $xglm;
+	Globals::$WT_SESSION->statTicks[$GEDCOM]['x_axis_boundary_months']        = $xgm;
+	Globals::$WT_SESSION->statTicks[$GEDCOM]['x_axis_boundary_numbers']       = $xga;
+	Globals::$WT_SESSION->statTicks[$GEDCOM]['z_axis_boundary_periods']       = $zgp;
+	Globals::$WT_SESSION->statTicks[$GEDCOM]['chart_shows']                   = $chart_shows;
+	Globals::$WT_SESSION->statTicks[$GEDCOM]['chart_type']                    = $chart_type;
+	Globals::$WT_SESSION->statTicks[$GEDCOM]['SURN']                          = $surname;
 
 	// Save the input variables
 	$savedInput                          = array();
@@ -912,11 +911,11 @@ if ($action === 'update') {
 	$savedInput['chart_shows']           = $chart_shows;
 	$savedInput['chart_type']            = $chart_type;
 	$savedInput['SURN']                  = $surname;
-	$WT_SESSION->statisticsplot[$GEDCOM] = $savedInput;
+	Globals::$WT_SESSION->statisticsplot[$GEDCOM] = $savedInput;
 	unset($savedInput);
 } else {
 	// Recover the saved input variables
-	$savedInput  = $WT_SESSION->statisticsplot[$GEDCOM];
+	$savedInput  = Globals::$WT_SESSION->statisticsplot[$GEDCOM];
 	$x_axis      = $savedInput['x_axis'];
 	$y_axis      = $savedInput['y_axis'];
 	$z_axis      = $savedInput['z_axis'];

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -318,6 +318,7 @@ return array(
     'Webtrees\\GEDFact_assistant_WT_Module' => $baseDir . '/modules_v3/GEDFact_assistant/module.php',
     'Webtrees\\GedcomRecord' => $baseDir . '/app/GedcomRecord.php',
     'Webtrees\\GedcomRecordController' => $baseDir . '/app/Controller/GedcomRecordController.php',
+    'Webtrees\\Globals' => $baseDir . '/app/Globals.php',
     'Webtrees\\GregorianDate' => $baseDir . '/app/Date/GregorianDate.php',
     'Webtrees\\HijriDate' => $baseDir . '/app/Date/HijriDate.php',
     'Webtrees\\HourglassController' => $baseDir . '/app/Controller/HourglassController.php',


### PR DESCRIPTION
To get rid off global variables it is maybe as a first step to move the global variables to a class as public static class variable.
Advantage:
* no 'global' declaration in functions needed (less chance to forget)
* easier to locate via search
* PhpStorm can give code completion and propose globals on class
Disadvantage:
* more to write `Globals::$WT_SESSION` instead of `$WT_SESSION`.

I did it just for the `$WT_SESSION` the other could follow if proposal is accepted.

@fisharebest What do you think?