### PR TITLE
Fix duplicate translation

### DIFF
--- a/language/af.po
+++ b/language/af.po
@@ -199,13 +199,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] ""
-msgstr[1] ""
-
 #: app/Module/RelativesTabModule.php:60
 #, php-format
 msgid "%s year"
@@ -342,7 +335,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/ar.po
+++ b/language/ar.po
@@ -222,17 +222,6 @@ msgstr[3] "%s مستخدمين مسجلين"
 msgstr[4] "%s مستخدماً مسجلاً"
 msgstr[5] "%s مستخدماً مسجلاً"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s شهراً"
-msgstr[1] "شهراً واحداً"
-msgstr[2] "شهران"
-msgstr[3] "%s أشهر"
-msgstr[4] "%s شهراً"
-msgstr[5] "%s شهراً"
-
 #: app/Module/RelativesTabModule.php:60
 #, php-format
 msgid "%s year"
@@ -421,7 +410,7 @@ msgstr[4] "قبل %s دقيقة"
 msgstr[5] "قبل %s دقيقة"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/bs.po
+++ b/language/bs.po
@@ -202,14 +202,6 @@ msgstr[0] "%s prijavljeni korisnik"
 msgstr[1] "%s prijavljeni korisnici"
 msgstr[2] "%s prijavljenih korisnika"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s mjesec"
-msgstr[1] "%s mjeseci"
-msgstr[2] "%s mjeseci"
-
 #: app/Module/RelativesTabModule.php:60
 #, php-format
 msgid "%s year"
@@ -359,13 +351,13 @@ msgstr[1] ""
 msgstr[2] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%s mjesec"
+msgstr[1] "%s mjeseci"
+msgstr[2] "%s mjeseci"
 
 #: app/I18N.php:513
 #, php-format

--- a/language/ca.po
+++ b/language/ca.po
@@ -201,13 +201,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] "%s usuari amb accés"
 msgstr[1] "%s usuaris amb accés"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s mes"
-msgstr[1] "%s mesos"
-
 #: app/Module/RelativesTabModule.php:60
 #, php-format
 msgid "%s year"
@@ -344,7 +337,7 @@ msgstr[0] "fa %s minut"
 msgstr[1] "fa %s minuts"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/cs.po
+++ b/language/cs.po
@@ -209,14 +209,6 @@ msgstr[0] "%s přihlášený uživatel"
 msgstr[1] "%s přihlášení uživatelé"
 msgstr[2] "%s přihlášených uživatelů"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s měsíc"
-msgstr[1] "%s měsíce"
-msgstr[2] "%s měsíců"
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -358,7 +350,7 @@ msgstr[1] "před %s minutami"
 msgstr[2] "před %s minutami"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/da.po
+++ b/language/da.po
@@ -201,13 +201,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] "%s bruger"
 msgstr[1] "%s brugere"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s måned"
-msgstr[1] "%s måneder"
-
 #: app/Module/RelativesTabModule.php:60
 #, php-format
 msgid "%s year"
@@ -344,7 +337,7 @@ msgstr[0] "%s minut siden"
 msgstr[1] "%s minutter siden"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/de.po
+++ b/language/de.po
@@ -197,13 +197,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] "%s angemeldeter Benutzer"
 msgstr[1] "%s angemeldete Benutzer"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s Monat"
-msgstr[1] "%s Monate"
-
 #: app/Module/RelativesTabModule.php:60
 #, php-format
 msgid "%s year"
@@ -340,7 +333,7 @@ msgstr[0] "vor einer Minute"
 msgstr[1] "vor %s Minuten"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/dv.po
+++ b/language/dv.po
@@ -192,12 +192,6 @@ msgid "%s logged-in user"
 msgid_plural "%s logged-in users"
 msgstr[0] ""
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] ""
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -315,7 +309,7 @@ msgid_plural "%s minutes ago"
 msgstr[0] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/el.po
+++ b/language/el.po
@@ -203,13 +203,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] "%s συνδεδεμένος χρήστης"
 msgstr[1] "%s συνδεδεμένοι χρήστες"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s μήνας"
-msgstr[1] "%s μήνες"
-
 #: app/Module/RelativesTabModule.php:60
 #, php-format
 msgid "%s year"
@@ -346,7 +339,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/en-AU.po
+++ b/language/en-AU.po
@@ -199,13 +199,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] ""
-msgstr[1] ""
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -335,7 +328,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/en-GB.po
+++ b/language/en-GB.po
@@ -206,13 +206,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] ""
-msgstr[1] ""
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -342,7 +335,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/en-US.po
+++ b/language/en-US.po
@@ -197,13 +197,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] ""
-msgstr[1] ""
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -333,7 +326,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/es.po
+++ b/language/es.po
@@ -202,13 +202,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] "%s usuario en sesión"
 msgstr[1] "%s usuarios en sesión"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s mes"
-msgstr[1] "%s meses"
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -338,7 +331,7 @@ msgstr[0] "hace %s minuto"
 msgstr[1] "hace %s minutos"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/et.po
+++ b/language/et.po
@@ -202,13 +202,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] "%s sisseloginud kasutaja"
 msgstr[1] "%s sisseloginud kasutajat"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s kuu"
-msgstr[1] "%s kuud"
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -338,7 +331,7 @@ msgstr[0] "%s minut tagasi"
 msgstr[1] "%s minutit tagasi"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/fa.po
+++ b/language/fa.po
@@ -196,12 +196,6 @@ msgid "%s logged-in user"
 msgid_plural "%s logged-in users"
 msgstr[0] "%s کاربر وارد شده اند"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s ماه"
-
 #: app/Module/RelativesTabModule.php:60
 #, php-format
 msgid "%s year"
@@ -329,11 +323,11 @@ msgid_plural "%s minutes ago"
 msgstr[0] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"
-msgstr[0] ""
+msgstr[0] "%s ماه"
 
 #: app/I18N.php:513
 #, php-format

--- a/language/fi.po
+++ b/language/fi.po
@@ -197,13 +197,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] "%s kirjautunut käyttäjä"
 msgstr[1] "%s  kirjautunutta käyttäjää"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s kuukausi"
-msgstr[1] "%s kuukautta"
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -333,7 +326,7 @@ msgstr[0] "%s minuutti sitten"
 msgstr[1] "%s minuutteja sitten"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/fo.po
+++ b/language/fo.po
@@ -199,13 +199,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] ""
-msgstr[1] ""
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -335,7 +328,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/fr-CA.po
+++ b/language/fr-CA.po
@@ -206,13 +206,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] "%s utilisateur connecté"
 msgstr[1] "%s utilisateurs connectés"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s mois"
-msgstr[1] "%s mois"
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -342,7 +335,7 @@ msgstr[0] "il y a %s minute"
 msgstr[1] "il y a %s minutes"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/fr.po
+++ b/language/fr.po
@@ -204,13 +204,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] "%s utilisateur connecté"
 msgstr[1] "%s utilisateurs connectés"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s mois"
-msgstr[1] "%s mois"
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -340,7 +333,7 @@ msgstr[0] "il y a %s minute"
 msgstr[1] "il y a %s minutes"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/gl.po
+++ b/language/gl.po
@@ -199,13 +199,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] "%s usuario conectado"
 msgstr[1] "%s usuarios conectados"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s mes"
-msgstr[1] "%s meses"
-
 #: app/Module/RelativesTabModule.php:60
 #, php-format
 msgid "%s year"
@@ -342,12 +335,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%s mes"
+msgstr[1] "%s meses"
 
 #: app/I18N.php:513
 #, php-format

--- a/language/he.po
+++ b/language/he.po
@@ -204,13 +204,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] "משתמש מחובר %s"
 msgstr[1] "%s משתמשים מחוברים"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "חודש אחד"
-msgstr[1] "%s חודשים"
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -340,7 +333,7 @@ msgstr[0] "לפני דקה"
 msgstr[1] "לפני %s דקות"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/hr.po
+++ b/language/hr.po
@@ -208,14 +208,6 @@ msgstr[0] "%s prijavljeni korisnik"
 msgstr[1] "%s prijavljena korisnika"
 msgstr[2] "%s prijavljenih korisnika"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s mjesec"
-msgstr[1] "%s mjeseca"
-msgstr[2] "%s mjeseci"
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -357,7 +349,7 @@ msgstr[1] "Prije %s minute"
 msgstr[2] "Prije %s minuta"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/hu.po
+++ b/language/hu.po
@@ -202,13 +202,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] "%s belépett felhasználó"
 msgstr[1] "%s belépett felhasználó"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s hónap"
-msgstr[1] "%s hónap"
-
 #: app/Module/RelativesTabModule.php:60
 #, php-format
 msgid "%s year"
@@ -345,7 +338,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/id.po
+++ b/language/id.po
@@ -199,12 +199,6 @@ msgid "%s logged-in user"
 msgid_plural "%s logged-in users"
 msgstr[0] ""
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] ""
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -322,7 +316,7 @@ msgid_plural "%s minutes ago"
 msgstr[0] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/is.po
+++ b/language/is.po
@@ -197,13 +197,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] "%s innskráður notandi"
 msgstr[1] "%s innskráður notendur"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s mánuður"
-msgstr[1] "%s mánuðir"
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -333,7 +326,7 @@ msgstr[0] "%s mínúta síðan"
 msgstr[1] "%s mínútur síðan"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/it.po
+++ b/language/it.po
@@ -203,13 +203,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] "%s utente corrente"
 msgstr[1] "%s utenti correnti"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s mese"
-msgstr[1] "%s mesi"
-
 #: app/Module/RelativesTabModule.php:60
 #, php-format
 msgid "%s year"
@@ -346,7 +339,7 @@ msgstr[0] "%s minuto fa"
 msgstr[1] "%s minuti fa"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/ja.po
+++ b/language/ja.po
@@ -195,12 +195,6 @@ msgid "%s logged-in user"
 msgid_plural "%s logged-in users"
 msgstr[0] ""
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] ""
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -318,7 +312,7 @@ msgid_plural "%s minutes ago"
 msgstr[0] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/ka.po
+++ b/language/ka.po
@@ -192,12 +192,6 @@ msgid "%s logged-in user"
 msgid_plural "%s logged-in users"
 msgstr[0] "%s დარეგისტრირებული იუზერი"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s თვე"
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -315,7 +309,7 @@ msgid_plural "%s minutes ago"
 msgstr[0] "%s წუთის წინ"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/ko.po
+++ b/language/ko.po
@@ -195,12 +195,6 @@ msgid "%s logged-in user"
 msgid_plural "%s logged-in users"
 msgstr[0] ""
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] ""
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -318,7 +312,7 @@ msgid_plural "%s minutes ago"
 msgstr[0] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/lt.po
+++ b/language/lt.po
@@ -210,14 +210,6 @@ msgstr[0] "%s prisijungęs naudotojas"
 msgstr[1] "%s prisijungę naudotojai"
 msgstr[2] "%s prisijungusių naudotojų"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s mėnesis"
-msgstr[1] "%s mėnesiai"
-msgstr[2] "%s mėnesių"
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -361,7 +353,7 @@ msgstr[1] "prieš %s minutes"
 msgstr[2] "prieš %s minutčių"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/lv.po
+++ b/language/lv.po
@@ -204,14 +204,6 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -351,7 +343,7 @@ msgstr[1] ""
 msgstr[2] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/mi.po
+++ b/language/mi.po
@@ -197,13 +197,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] ""
-msgstr[1] ""
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -333,7 +326,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/mr.po
+++ b/language/mr.po
@@ -197,13 +197,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] ""
-msgstr[1] ""
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -333,7 +326,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/ms.po
+++ b/language/ms.po
@@ -200,13 +200,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] ""
-msgstr[1] ""
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -336,7 +329,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/nb.po
+++ b/language/nb.po
@@ -199,13 +199,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] "%s innlogget bruker"
 msgstr[1] "%s innloggede brukere"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s måned"
-msgstr[1] "%s måneder"
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -335,7 +328,7 @@ msgstr[0] "%s minutt siden"
 msgstr[1] "%s minutter siden"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/ne.po
+++ b/language/ne.po
@@ -199,13 +199,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] ""
-msgstr[1] ""
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -335,7 +328,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/nl.po
+++ b/language/nl.po
@@ -203,13 +203,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] "%s aangemelde gebruiker"
 msgstr[1] "%s aangemelde gebruikers"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s maand"
-msgstr[1] "%s maanden"
-
 #: app/Module/RelativesTabModule.php:60
 #, php-format
 msgid "%s year"
@@ -346,7 +339,7 @@ msgstr[0] "%s minuut geleden"
 msgstr[1] "%s minuten geleden"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/nn.po
+++ b/language/nn.po
@@ -203,13 +203,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] "%s brukar logga inn"
 msgstr[1] "%s brukarar logga inn"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s månad"
-msgstr[1] "%s månader"
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -339,7 +332,7 @@ msgstr[0] "%s minutt sidan"
 msgstr[1] "%s minutt sidan"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/oc.po
+++ b/language/oc.po
@@ -199,13 +199,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] ""
-msgstr[1] ""
-
 #: app/Module/RelativesTabModule.php:60
 #, php-format
 msgid "%s year"
@@ -342,7 +335,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/pl.po
+++ b/language/pl.po
@@ -207,14 +207,6 @@ msgstr[0] "%s zalogowany użytkownik"
 msgstr[1] "%s zalogowanych użytkowników"
 msgstr[2] "%s zalogowanych użytkowników"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s miesiąc"
-msgstr[1] "%s miesiące"
-msgstr[2] "%s miesięcy"
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -356,7 +348,7 @@ msgstr[1] "%s minuty temu"
 msgstr[2] "%s minut temu"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/pt-BR.po
+++ b/language/pt-BR.po
@@ -204,13 +204,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] "%s usuário conectado"
 msgstr[1] "%s usuários conectados"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s mês"
-msgstr[1] "%s meses"
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -340,7 +333,7 @@ msgstr[0] "%s minuto atrás"
 msgstr[1] "%s minutos atrás"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/pt.po
+++ b/language/pt.po
@@ -202,13 +202,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] "%s usuário conectado"
 msgstr[1] "%s usuários conectados"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s mês"
-msgstr[1] "%s meses"
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -338,7 +331,7 @@ msgstr[0] "%s minuto atrás"
 msgstr[1] "%s minutos atrás"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/ro.po
+++ b/language/ro.po
@@ -207,14 +207,6 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -354,7 +346,7 @@ msgstr[1] ""
 msgstr[2] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/ru.po
+++ b/language/ru.po
@@ -213,14 +213,6 @@ msgstr[0] "%s зарегистрированный пользователь"
 msgstr[1] "%s зарегистрированных пользователей"
 msgstr[2] "%s зарегистрированных пользователей"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s месяц"
-msgstr[1] "%s месяца"
-msgstr[2] "%s месяцев"
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -362,7 +354,7 @@ msgstr[1] "%s минуты назад"
 msgstr[2] "%s минут назад"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/sk.po
+++ b/language/sk.po
@@ -209,14 +209,6 @@ msgstr[0] "%s prihlásených užívateľov"
 msgstr[1] "%s prihlásený užívateľ"
 msgstr[2] "%s prihlásení užívatelia"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s mesiac"
-msgstr[1] "%s mesiace"
-msgstr[2] "%s mesiacov"
-
 #: app/Module/RelativesTabModule.php:60
 #, php-format
 msgid "%s year"
@@ -366,7 +358,7 @@ msgstr[1] "pred %s minutami"
 msgstr[2] "pred %s minutami"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47  app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/sl.po
+++ b/language/sl.po
@@ -214,15 +214,6 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-msgstr[3] ""
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -376,7 +367,7 @@ msgstr[2] ""
 msgstr[3] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/sr-Latn.po
+++ b/language/sr-Latn.po
@@ -209,14 +209,6 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
 #: app/Module/RelativesTabModule.php:60
 #, php-format
 msgid "%s year"
@@ -366,7 +358,7 @@ msgstr[1] ""
 msgstr[2] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/sr.po
+++ b/language/sr.po
@@ -211,14 +211,6 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -360,7 +352,7 @@ msgstr[1] ""
 msgstr[2] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/sv.po
+++ b/language/sv.po
@@ -201,13 +201,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] "%s inloggad användare"
 msgstr[1] "%s inloggade användare"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s månad"
-msgstr[1] "%s månader"
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -337,7 +330,7 @@ msgstr[0] "%s minut sedan"
 msgstr[1] "%s minuter sedan"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/ta.po
+++ b/language/ta.po
@@ -197,13 +197,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] ""
-msgstr[1] ""
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -333,7 +326,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/tr.po
+++ b/language/tr.po
@@ -192,12 +192,6 @@ msgid "%s logged-in user"
 msgid_plural "%s logged-in users"
 msgstr[0] "%s kullanıcı çevrimiçi"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s ay"
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -315,7 +309,7 @@ msgid_plural "%s minutes ago"
 msgstr[0] "%s dakika önce"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/tt.po
+++ b/language/tt.po
@@ -195,12 +195,6 @@ msgid "%s logged-in user"
 msgid_plural "%s logged-in users"
 msgstr[0] "%s кулланучы"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s ай"
-
 #: app/Module/RelativesTabModule.php:60
 #, php-format
 msgid "%s year"
@@ -327,7 +321,7 @@ msgid_plural "%s minutes ago"
 msgstr[0] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/uk.po
+++ b/language/uk.po
@@ -204,14 +204,6 @@ msgstr[0] "%s зареєстрований користувач"
 msgstr[1] "%s зареєстрованих користувачів"
 msgstr[2] "%s зареєстрованих користувачів"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s місяць"
-msgstr[1] "%s місяця"
-msgstr[2] "%s місяців"
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -353,7 +345,7 @@ msgstr[1] "%s хвилини тому"
 msgstr[2] "%s хвилин тому"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/vi.po
+++ b/language/vi.po
@@ -196,12 +196,6 @@ msgid "%s logged-in user"
 msgid_plural "%s logged-in users"
 msgstr[0] "%s người dung đang đăng nhập"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s tháng"
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -319,7 +313,7 @@ msgid_plural "%s minutes ago"
 msgstr[0] "%s phút qua"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/yi.po
+++ b/language/yi.po
@@ -199,13 +199,6 @@ msgid_plural "%s logged-in users"
 msgstr[0] ""
 msgstr[1] ""
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s חודש"
-msgstr[1] "%s חדשים"
-
 #: app/Module/RelativesTabModule.php:60
 #, php-format
 msgid "%s year"
@@ -342,12 +335,12 @@ msgstr[0] "%s מינוט צוריק"
 msgstr[1] "%s מינוט צוריק"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "%s חודש"
+msgstr[1] "%s חדשים"
 
 #: app/I18N.php:513
 #, php-format

--- a/language/zh-Hans.po
+++ b/language/zh-Hans.po
@@ -197,12 +197,6 @@ msgid "%s logged-in user"
 msgid_plural "%s logged-in users"
 msgstr[0] "%s 登录的用户"
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] "%s 月"
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -320,7 +314,7 @@ msgid_plural "%s minutes ago"
 msgstr[0] "%s 分钟前"
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"

--- a/language/zh-Hant.po
+++ b/language/zh-Hant.po
@@ -195,12 +195,6 @@ msgid "%s logged-in user"
 msgid_plural "%s logged-in users"
 msgstr[0] ""
 
-#: app/Module/RelativesTabModule.php:62
-#, php-format
-msgid "%s month"
-msgid_plural "%s months"
-msgstr[0] ""
-
 #: includes/functions/functions.php:555
 #, php-format
 msgctxt "FEMALE"
@@ -318,7 +312,7 @@ msgid_plural "%s minutes ago"
 msgstr[0] ""
 
 #. I18N: Part of an age string. e.g. 5 years, 4 months and 3 days
-#: app/I18N.php:463 includes/functions/functions_date.php:47
+#: app/I18N.php:463 includes/functions/functions_date.php:47 app/Module/RelativesTabModule.php:62
 #, php-format
 msgid "%s month"
 msgid_plural "%s months"


### PR DESCRIPTION
It also seems that weblate does not support (or is not configured for) single line translations as we used to prefer....