### PR TITLE
fixed gender pronouns from exclusively male

### DIFF
--- a/admin_site_config.php
+++ b/admin_site_config.php
@@ -471,7 +471,7 @@ $controller->pageHeader();
 		<div class="col-sm-9">
 			<?php echo edit_field_yes_no('USE_REGISTRATION_MODULE', Site::getPreference('USE_REGISTRATION_MODULE')); ?>
 			<p class="small text-muted">
-				<?php echo /* I18N: Help text for the “Allow visitors to request account registration” site configuration setting */ I18N::translate('Gives visitors the option of registering themselves for an account on the website.<br><br>The visitor will receive an email message with a code to verify his application for an account.  After verification, an administrator will have to approve the registration before it becomes active.'); ?>
+				<?php echo /* I18N: Help text for the “Allow visitors to request account registration” site configuration setting */ I18N::translate('Gives visitors the option of registering themselves for an account on the website.<br><br>The visitor will receive an email message with a code to verify their application for an account.  After verification, an administrator will have to approve the registration before it becomes active.'); ?>
 			</p>
 		</div>
 	</fieldset>

--- a/app/Module/ClippingsCartModule.php
+++ b/app/Module/ClippingsCartModule.php
@@ -99,13 +99,13 @@ class ClippingsCartModule extends Module implements ModuleMenuInterface, ModuleS
 						<input type="hidden" name="type" value="<?php echo $clip_ctrl->type; ?>">
 						<input type="hidden" name="action" value="add1"></td></tr>
 						<tr><td class="optionbox"><input type="radio" name="others" checked value="none"><?php echo I18N::translate('Add just this individual.'); ?></td></tr>
-						<tr><td class="optionbox"><input type="radio" name="others" value="parents"><?php echo I18N::translate('Add this individual, his parents, and siblings.'); ?></td></tr>
-						<tr><td class="optionbox"><input type="radio" name="others" value="ancestors" id="ancestors"><?php echo I18N::translate('Add this individual and his direct line ancestors.'); ?><br>
+						<tr><td class="optionbox"><input type="radio" name="others" value="parents"><?php echo I18N::translate('Add this individual, their parents, and siblings.'); ?></td></tr>
+						<tr><td class="optionbox"><input type="radio" name="others" value="ancestors" id="ancestors"><?php echo I18N::translate('Add this individual and their direct line ancestors.'); ?><br>
 							&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<?php echo I18N::translate('Number of generations'); ?> <input type="text" size="5" name="level1" value="<?php echo $MAX_PEDIGREE_GENERATIONS; ?>" onfocus="radAncestors('ancestors');"></td></tr>
-						<tr><td class="optionbox"><input type="radio" name="others" value="ancestorsfamilies" id="ancestorsfamilies"><?php echo I18N::translate('Add this individual, his direct line ancestors, and their families.'); ?><br >
+						<tr><td class="optionbox"><input type="radio" name="others" value="ancestorsfamilies" id="ancestorsfamilies"><?php echo I18N::translate('Add this individual, their direct line ancestors, and their families.'); ?><br >
 							&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<?php echo I18N::translate('Number of generations'); ?> <input type="text" size="5" name="level2" value="<?php echo $MAX_PEDIGREE_GENERATIONS; ?>" onfocus="radAncestors('ancestorsfamilies');"></td></tr>
-						<tr><td class="optionbox"><input type="radio" name="others" value="members"><?php echo I18N::translate('Add this individual, his spouse, and children.'); ?></td></tr>
-						<tr><td class="optionbox"><input type="radio" name="others" value="descendants" id="descendants"><?php echo I18N::translate('Add this individual, his spouse, and all descendants.'); ?><br >
+						<tr><td class="optionbox"><input type="radio" name="others" value="members"><?php echo I18N::translate('Add this individual, their spouse, and children.'); ?></td></tr>
+						<tr><td class="optionbox"><input type="radio" name="others" value="descendants" id="descendants"><?php echo I18N::translate('Add this individual, their spouse, and all descendants.'); ?><br >
 							&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<?php echo I18N::translate('Number of generations'); ?> <input type="text" size="5" name="level3" value="<?php echo $MAX_PEDIGREE_GENERATIONS; ?>" onfocus="radAncestors('descendants');"></td></tr>
 						<tr><td class="topbottombar"><input type="submit" value="<?php echo I18N::translate('Continue adding'); ?>">
 					</table>
@@ -517,13 +517,13 @@ class ClippingsCartModule extends Module implements ModuleMenuInterface, ModuleS
 		<input type="hidden" name="action" value="add1">
 		<ul>
 		<li><input type="radio" name="others" checked value="none">'. I18N::translate('Add just this individual.') . '</li>
-		<li><input type="radio" name="others" value="parents">'. I18N::translate('Add this individual, his parents, and siblings.') . '</li>
-		<li><input type="radio" name="others" value="ancestors" id="ancestors">'. I18N::translate('Add this individual and his direct line ancestors.') . '<br>
+		<li><input type="radio" name="others" value="parents">'. I18N::translate('Add this individual, their parents, and siblings.') . '</li>
+		<li><input type="radio" name="others" value="ancestors" id="ancestors">'. I18N::translate('Add this individual and their direct line ancestors.') . '<br>
 				'. I18N::translate('Number of generations') . '<input type="text" size="4" name="level1" value="' . $MAX_PEDIGREE_GENERATIONS . '" onfocus="radAncestors(\'ancestors\');"></li>
-		<li><input type="radio" name="others" value="ancestorsfamilies" id="ancestorsfamilies">'. I18N::translate('Add this individual, his direct line ancestors, and their families.') . '<br>
+		<li><input type="radio" name="others" value="ancestorsfamilies" id="ancestorsfamilies">'. I18N::translate('Add this individual, their direct line ancestors, and their families.') . '<br>
 				'. I18N::translate('Number of generations') . ' <input type="text" size="4" name="level2" value="' . $MAX_PEDIGREE_GENERATIONS . '" onfocus="radAncestors(\'ancestorsfamilies\');"></li>
-		<li><input type="radio" name="others" value="members">'. I18N::translate('Add this individual, his spouse, and children.') . '</li>
-		<li><input type="radio" name="others" value="descendants" id="descendants">'. I18N::translate('Add this individual, his spouse, and all descendants.') . '<br >
+		<li><input type="radio" name="others" value="members">'. I18N::translate('Add this individual, their spouse, and children.') . '</li>
+		<li><input type="radio" name="others" value="descendants" id="descendants">'. I18N::translate('Add this individual, their spouse, and all descendants.') . '<br >
 				'. I18N::translate('Number of generations') . ' <input type="text" size="4" name="level3" value="' . $MAX_PEDIGREE_GENERATIONS . '" onfocus="radAncestors(\'descendants\');"></li>
 		</ul>
 		<input type="submit" value="'. I18N::translate('Continue adding') . '">

--- a/vendor/bombayworks/zendframework1/library/Zend/Service/Amazon/Ec2/CloudWatch.php
+++ b/vendor/bombayworks/zendframework1/library/Zend/Service/Amazon/Ec2/CloudWatch.php
@@ -170,9 +170,9 @@ class Zend_Service_Amazon_Ec2_CloudWatch extends Zend_Service_Amazon_Ec2_Abstrac
      *  instance. This allows a user to pinpoint an exact instance from which to monitor data.
      *
      * InstanceType: This dimension filters the data you request for all instances running
-     *  with this specified instance type. This allows a user to catagorize his data by the
+     *  with this specified instance type. This allows a user to catagorize their data by the
      *  type of instance running. For example, a user might compare data from an m1.small instance
-     *  and an m1.large instance to determine which has the better business value for his application.
+     *  and an m1.large instance to determine which has the better business value for their application.
      *
      * LoadBalancerName: This dimension filters the data you request for the specified LoadBalancer
      *  name. A LoadBalancer is represented by a DNS name and provides the single destination to


### PR DESCRIPTION
All the pronouns were male, but users of webtrees are not exclusively maIe.   I tried to give my daughter and account to edit our family tree and it said 'his', even though she is not male.  This pull request aims to fix those conditions.   Thanks!