### PR TITLE
Redirect to canonical url

### DIFF
--- a/family.php
+++ b/family.php
@@ -31,8 +31,20 @@ require './includes/session.php';
 
 $controller = new FamilyController;
 
+if (!$controller->record) {
+    http_response_code(404);
+    $controller->pageHeader();
+    echo '<p class="ui-state-error">', I18N::translate('This family does not exist or you do not have permission to view it.'), '</p>';
+
+	return;      
+}
+
+// elseif ($controller->record && $controller->record->getTree()->getPreference('SHOW_PRIVATE_RELATIONSHIPS'))
+// Continue - to display the children/parents/grandparents.
+// We'll check for showing the details again later
+$controller->pageHeader();
+
 if ($controller->record && $controller->record->canShow()) {
-	$controller->pageHeader();
 	if ($controller->record->isPendingDeletion()) {
 		if (Auth::isModerator($controller->record->getTree())) {
 			echo
@@ -70,16 +82,6 @@ if ($controller->record && $controller->record->canShow()) {
 				'</p>';
 		}
 	}
-} elseif ($controller->record && $controller->record->getTree()->getPreference('SHOW_PRIVATE_RELATIONSHIPS')) {
-	$controller->pageHeader();
-	// Continue - to display the children/parents/grandparents.
-	// We'll check for showing the details again later
-} else {
-	http_response_code(404);
-	$controller->pageHeader();
-	echo '<p class="ui-state-error">', I18N::translate('This family does not exist or you do not have permission to view it.'), '</p>';
-
-	return;
 }
 
 ?>

--- a/includes/session.php
+++ b/includes/session.php
@@ -523,6 +523,40 @@ if (substr(WT_SCRIPT_NAME, 0, 5) === 'admin' || WT_SCRIPT_NAME === 'module.php' 
 	Session::put('theme_id', $theme_id);
 }
 
+/*
+ * Theme and language parameters have been set.
+ * To have a canonical URI, those parameters will now be stripped.
+ * Then a 301 redirect (Moved Permanently)  and a Location
+ * directive will be sent to the user, containing the new URI.
+ */
+if (isset($_GET['lang'])) {
+	$requesturl = parse_url($_SERVER['REQUEST_URI']);
+	// the new query parameters, stripped of lang and theme.
+	$newquery = array();
+	
+	foreach (explode("&", $requesturl['query']) as $queryparameter) {
+		list($queryparametername, $queryparametervalue) = explode("=", $queryparameter);
+		
+		if (preg_match("/^lang$/i", $queryparametername)) {
+			continue;
+		}
+		
+		if (preg_match("/^theme$/i", $queryparametername)) {
+			continue;
+		}
+		
+		$newquery[$queryparametername] = $queryparametervalue;
+	}
+	// will give you ged=gedname&pid=I123 etc.
+	$requesturl['query'] = implode("&", $newquery);
+	// WT_BASE_URL . WT_SCRIPT_NAME is also possible.
+	$redirection =   $requesturl['path'] . '?' . http_build_query($newquery);
+
+	header("HTTP/1.1 301 Moved Permanently");
+	header('Location: ' . $redirection);
+}
+
+
 // Search engines are only allowed to see certain pages.
 if (Auth::isSearchEngine() && !in_array(WT_SCRIPT_NAME, array(
 	'index.php', 'indilist.php', 'module.php', 'mediafirewall.php',

--- a/individual.php
+++ b/individual.php
@@ -80,17 +80,23 @@ if ($controller->record && $controller->record->canShow()) {
 				'</p>';
 		}
 	}
-} elseif ($controller->record && $controller->record->canShowName()) {
+} else if ($controller->record && $controller->record->canShowName()) {
 	// Just show the name.
 	$controller->pageHeader();
 	echo '<h2>', $controller->record->getFullName(), '</h2>';
 	echo '<p class="ui-state-highlight">', I18N::translate('The details of this individual are private.'), '</p>';
 
+	return; 
+} else if ($controller->record && !($controller->record->canShowName())) {
+	http_response_code(403);
+	$controller->pageHeader();
+	echo '<p class="ui-state-error">', I18N::translate('You do not have permission to view this individual.'), '</p>';
+	
 	return;
 } else {
 	http_response_code(404);
 	$controller->pageHeader();
-	echo '<p class="ui-state-error">', I18N::translate('This individual does not exist or you do not have permission to view it.'), '</p>';
+	echo '<p class="ui-state-error">', I18N::translate('This individual does not exist.'), '</p>';
 
 	return;
 }

--- a/individual.php
+++ b/individual.php
@@ -80,23 +80,17 @@ if ($controller->record && $controller->record->canShow()) {
 				'</p>';
 		}
 	}
-} else if ($controller->record && $controller->record->canShowName()) {
+} elseif ($controller->record && $controller->record->canShowName()) {
 	// Just show the name.
 	$controller->pageHeader();
 	echo '<h2>', $controller->record->getFullName(), '</h2>';
 	echo '<p class="ui-state-highlight">', I18N::translate('The details of this individual are private.'), '</p>';
 
-	return; 
-} else if ($controller->record && !($controller->record->canShowName())) {
-	http_response_code(403);
-	$controller->pageHeader();
-	echo '<p class="ui-state-error">', I18N::translate('You do not have permission to view this individual.'), '</p>';
-	
 	return;
 } else {
 	http_response_code(404);
 	$controller->pageHeader();
-	echo '<p class="ui-state-error">', I18N::translate('This individual does not exist.'), '</p>';
+	echo '<p class="ui-state-error">', I18N::translate('This individual does not exist or you do not have permission to view it.'), '</p>';
 
 	return;
 }


### PR DESCRIPTION
Redirect to canonical url by stripping lang and theme parameters after evaluating. fixes #605 

```shell
 curl -Ls -I -o - "https://testdomain/individual.php?pid=I355&ged=gedcom.ged&lang=de_DE" 
HTTP/1.1 301 Moved Permanently
Date: Wed, 10 Jun 2015 15:46:23 GMT
Server: Apache/2.2.15 (CentOS)
X-Powered-By: PHP/5.5.5
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
Pragma: no-cache
Set-Cookie: WT_SESSION=3hq151hm32na9gvsnqegqa29c2; path=/; HttpOnly
Set-Cookie: WT_SESSION=ll3oo2isqcc6vd963lbloj37l7; path=/; HttpOnly
Location: /individual.php?pid=I355&ged=gedcom.ged
Connection: close
Content-Type: text/html; charset=UTF-8

HTTP/1.1 200 OK
Date: Wed, 10 Jun 2015 15:46:24 GMT
Server: Apache/2.2.15 (CentOS)
X-Powered-By: PHP/5.5.5
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
Pragma: no-cache
Set-Cookie: WT_SESSION=bjnp6k6q8f6v9f2i8ve32s2af4; path=/; HttpOnly
Set-Cookie: WT_SESSION=942ek5gjbjpm4cqbagtquc1or5; path=/; HttpOnly
Connection: close
Content-Type: text/html; charset=UTF-8
```

By the way - why are there two sesssion cookies?