### PR TITLE
Closing div without opening tag in Search page

### DIFF
--- a/app/Controller/SearchController.php
+++ b/app/Controller/SearchController.php
@@ -536,6 +536,7 @@ class SearchController extends PageController {
 				if (!empty($this->mynotelist)) {
 					echo '<div id="notes-results-tab">', FunctionsPrintLists::noteTable($this->mynotelist), '</div>';
 				}
+				echo '</div>';
 			} else {
 				// One or more search terms were specified, but no results were found.
 				echo '<div class="warning center">' . I18N::translate('No results found.') . '</div>';

--- a/search.php
+++ b/search.php
@@ -63,10 +63,11 @@ function checknames(frm) {
 }
 </script>
 
+<div id="search-page">
+<h2><?php echo $controller->getPageTitle(); ?></h2>
+
 <?php if ($controller->action === 'general'): ?>
 
-<div id="search-page">
-	<h2><?php echo $controller->getPageTitle(); ?></h2>
 	<form name="searchform" onsubmit="return checknames(this);">
 		<input type="hidden" name="action" value="general">
 		<input type="hidden" name="isPostBack" value="true">
@@ -143,13 +144,10 @@ function checknames(frm) {
 			</div>
 		</div>
 	</form>
-</div>
 
 <?php endif; ?>
 <?php if ($controller->action === 'replace'): ?>
-
-<div id="search-page">
-	<h2><?php echo $controller->getPageTitle(); ?></h2>
+	
 	<form method="post" name="searchform" onsubmit="return checknames(this);">
 		<input type="hidden" name="action" value="replace">
 		<input type="hidden" name="isPostBack" value="true">
@@ -220,13 +218,10 @@ function checknames(frm) {
 			</div>
 		</div>
 	</form>
-</div>
 
 <?php endif; ?>
 <?php if ($controller->action == "soundex"): ?>
 
-<div id="search-page">
-	<h2><?php echo $controller->getPageTitle(); ?></h2>
 	<form name="searchform" onsubmit="return checknames(this);">
 		<input type="hidden" name="action" value="soundex">
 		<input type="hidden" name="isPostBack" value="true">
@@ -306,8 +301,9 @@ function checknames(frm) {
 			</div>
 		</div>
 	</form>
-</div>
 
 <?php endif; ?>
 
 <?php $controller->printResults(); ?>
+
+</div>

--- a/search.php
+++ b/search.php
@@ -311,5 +311,3 @@ function checknames(frm) {
 <?php endif; ?>
 
 <?php $controller->printResults(); ?>
-
-</div>


### PR DESCRIPTION
There is a closing div tag trailing at the end of the search page, which can cause issue with theme, as it may close a unwanted div from the theme header.