### PR TITLE
Accelerate relationship name calculation

### DIFF
--- a/app/Functions/Functions.php
+++ b/app/Functions/Functions.php
@@ -666,6 +666,9 @@ class Functions {
 		}
 	}
 
+	// Cache for generic relationships determination
+	protected static $relationshipsCache = array();
+
 	/**
 	 * Convert a relationship path into a relationship name.
 	 *
@@ -2156,6 +2159,10 @@ class Functions {
 
 		// Split the relationship into sub-relationships, e.g., third-cousin’s great-uncle.
 		// Try splitting at every point, and choose the path with the shorted translated name.
+		// But before starting to recursively go through all combinations, do a cache look-up
+		if (array_key_exists($path, self::$relationshipsCache)) {
+        	return self::$relationshipsCache[$path];
+		}
 
 		$relationship = null;
 		$path1        = substr($path, 0, 3);
@@ -2173,6 +2180,8 @@ class Functions {
 			$path1 .= substr($path2, 0, 3);
 			$path2 = substr($path2, 3);
 		}
+		// and store the result in the cache
+		self::$relationshipsCache[$path] = $relationship;
 
 		return $relationship;
 	}

--- a/app/Functions/Functions.php
+++ b/app/Functions/Functions.php
@@ -2161,7 +2161,7 @@ class Functions {
 		// Try splitting at every point, and choose the path with the shorted translated name.
 		// But before starting to recursively go through all combinations, do a cache look-up
 		if (array_key_exists($path, self::$relationshipsCache)) {
-        	return self::$relationshipsCache[$path];
+			return self::$relationshipsCache[$path];
 		}
 
 		$relationship = null;

--- a/app/Functions/Functions.php
+++ b/app/Functions/Functions.php
@@ -666,7 +666,7 @@ class Functions {
 		}
 	}
 
-	// Cache for generic relationships determination
+	/** @var string[] Cache for generic relationships (key stores the path, and value represents the relationship name) */
 	protected static $relationshipsCache = array();
 
 	/**


### PR DESCRIPTION
In the case of very long and complex relationship paths (>10 segments including 'hus'/'wif' or 'bro'/sis') it can take a very long time to calculate the relationship name. The code in `app/Functions/Functions.php#getRelationshipNameFromPath` does cater for many straightforward established relationship names, but at the end segments the relationship path and tries to find the best matching name combination. The code does this recursively. In the worst case this can take up to `3^(number of path segments - 1)` function calls, e.g. 10 path segments -> 19600 calls, 15 path segments -> 4.7M calls, 20 path segments -> 1.1B calls. On an average webserver this can easily exceed the configured maximum execution time.
After analysing the code in detail it turned out that the recursive segmentation leads to the same sub-segments sampled over and over again.
I propose to use a simple cache that stores any already computed relationship name for any complex sub-segment, and before heading into the recursion, check if that path is already in the cache. With this approach the number of recursive calls as well as the total execution time goes significantly down. Again, in a worst case scenario the number of calls would now be: 10 path segments -> 330 calls, 15 path segments -> 1120 calls, 20 path segments -> 2660 calls.