### PR TITLE
Wrong cell type in Family Book

### DIFF
--- a/familybook.php
+++ b/familybook.php
@@ -85,10 +85,10 @@ $controller
 					</td>
 				</tr>
 				<tr>
-					<th>
+					<td class="descriptionbox">
 						<?php echo I18N::translate('Descendant generations'); ?>
-					</th>
-					<td>
+					</td>
+					<td class="optionbox">
 						<select name="descent">
 							<?php
 							for ($i = 0; $i <= 9; $i++) {


### PR DESCRIPTION
The "Descendant Generation" option of the Family book page does not use the descriptionbox & optionbox styles