### PR TITLE
pgv to wt: Don't search parent directory for pgv installations

### DIFF
--- a/admin_pgv_to_wt.php
+++ b/admin_pgv_to_wt.php
@@ -140,8 +140,10 @@ if (!$PGV_PATH) {
 	$pgv_dirs = array();
 	$dir      = opendir(realpath('..'));
 	while (($subdir = readdir($dir)) !== false) {
-		if (is_dir('../' . $subdir) && file_exists('../' . $subdir . '/config.php')) {
-			$pgv_dirs[] = '../' . $subdir;
+		if ($subdir!='..') {
+			if (is_dir('../' . $subdir) && file_exists('../' . $subdir . '/config.php')) {
+				$pgv_dirs[] = '../' . $subdir;
+			}
 		}
 	}
 	closedir($dir);


### PR DESCRIPTION
Starting the pgv to wt import, a search on the parent directory ".." could result in a open_basedir restriction error.