### PR TITLE
Fixes problems with updating records when using the update all button

### DIFF
--- a/app/Module/BatchUpdateModule.php
+++ b/app/Module/BatchUpdateModule.php
@@ -146,9 +146,9 @@ class BatchUpdateModule extends AbstractModule implements ModuleConfigInterface 
 						$newrecord = $this->PLUGIN->updateRecord($xref, $record);
 						if ($newrecord != $record) {
 							if ($newrecord) {
-								GedcomRecord::getInstance($this->xref, $WT_TREE)->updateRecord($newrecord, $this->PLUGIN->chan);
+								GedcomRecord::getInstance($xref, $WT_TREE)->updateRecord($newrecord, $this->PLUGIN->chan);
 							} else {
-								GedcomRecord::getInstance($this->xref, $WT_TREE)->deleteRecord();
+								GedcomRecord::getInstance($xref, $WT_TREE)->deleteRecord();
 							}
 						}
 					}


### PR DESCRIPTION
As per issue #764. It was simpler to leave the parameters of function getActionButtons(...) alone for the 'Update all' case as it affects the test in function createSubmitButton for enabling or disabling the button.