### PR TITLE
Unified before/After changes list

### DIFF
--- a/themes/_administration/css-1.7.0/style.css
+++ b/themes/_administration/css-1.7.0/style.css
@@ -715,3 +715,10 @@ a.icon-uarrow:hover {
 	position: absolute;
 	width: 1px;
 }
+
+.btn-chg-action {
+	display: block;
+	width: 100px;
+	margin: 2px 0;
+	white-space: normal;
+}


### PR DESCRIPTION
Many moons ago I created a simplified version of this using a 3rd party script and posted an image on the forum. It didn't go down well. Stephen (Toyguy) felt it made it difficult to use cut and paste when a change needed modifying. I think this submission addresses that whilst still making the actual change very visible.

Use Fisharebest\Algorithm\MyersDiff to create a unified before/after display in the style of the batch update facility (more or less duplicating code found in BatchUpdateBasePlugin functions getActionPreview, decorateInsertedText, decorateDeletedText and createEditLinks). In addition added an undo icon for pending and accepted changes