### PR TITLE
Only display relevant tags in admin_tree_config

### DIFF
--- a/app/GedcomTag.php
+++ b/app/GedcomTag.php
@@ -1819,20 +1819,77 @@ class GedcomTag {
 	 *
 	 * @return string[]
 	 */
-	public static function getPicklistFacts() {
-		// Just include facts that can be used at level 1 in a record
-		$tags = array(
-			'ABBR', 'ADOP', 'AFN', 'ALIA', 'ANUL', 'ASSO', 'AUTH', 'BAPL', 'BAPM', 'BARM',
-			'BASM', 'BIRT', 'BLES', 'BURI', 'CAST', 'CENS', 'CHAN', 'CHR', 'CHRA', 'CITN',
-			'CONF', 'CONL', 'CREM', 'DEAT', 'DIV', 'DIVF', 'DSCR', 'EDUC', 'EMIG', 'ENDL',
-			'ENGA', 'EVEN', 'FACT', 'FCOM', 'FORM', 'GRAD', 'IDNO', 'IMMI', 'LEGA', 'MARB',
-			'MARC', 'MARL', 'MARR', 'MARS', 'NAME', 'NATI', 'NATU', 'NCHI', 'NICK', 'NMR',
-			'OCCU', 'ORDI', 'ORDN', 'PROB', 'PROP', 'REFN', 'RELI', 'REPO', 'RESI', 'RESN',
-			'RETI', 'RFN', 'RIN', 'SEX', 'SLGC', 'SLGS', 'SSN', 'SUBM', 'TITL', 'WILL', 'WWW',
-			'_BRTM', '_COML', '_DEG', '_EYEC', '_FNRL', '_HAIR', '_HEIG', '_HNM', '_HOL',
-			'_INTE', '_MARI', '_MBON', '_MDCL', '_MEDC', '_MILI', '_MILT', '_NAME', '_NAMS',
-			'_NLIV', '_NMAR', '_NMR', '_PRMN', '_SEPR', '_TODO', '_UID', '_WEIG', '_YART',
-		);
+	public static function getPicklistFacts($factType) {
+		switch ($factType) {
+			case "sour":
+				$tags = array(
+					// Facts for sources
+					'DATA', 'AUTH', 'TITL', 'ABBR', 'PUBL', 'TEXT', 'REPO', 'REFN', 'RIN',
+					'CHAN', 'NOTE', 'SHARED_NOTE', 'OBJE',
+					// non standard tags
+					'RESN',
+				);
+				break;
+			case "fam":
+				$tags = array(
+					// Facts for families, left out HUSB, WIFE & CHIL links
+					'RESN', 'ANUL', 'CENS', 'DIV', 'DIVF', 'ENGA', 'MARB', 'MARC',
+					'MARR', 'MARL', 'MARS', 'RESI', 'EVEN', 'NCHI', 'SUBM', 'SLGS',
+					'REFN', 'RIN', 'CHAN', 'NOTE', 'SHARED_NOTE', 'SOUR', 'OBJE',
+					// non standard tags
+					'_NMR', 'MARR_CIVIL', 'MARR_RELIGIOUS', 'MARR_PARTNERS', 'MARR_UNKNOWN',
+					'_COML', '_MBON', '_MARI', '_SEPR', '_TODO',
+				);
+			break;
+			case "repo":
+				$tags = array(
+					// Facts for repositories
+					'NAME', 'ADDR', 'PHON', 'EMAIL', 'FAX', 'WWW',
+					'NOTE', 'SHARED_NOTE', 'REFN', 'RIN', 'CHAN',
+					// non standard tags
+					'RESN',
+				);
+				break;
+			case "place":
+				$tags = array(
+					// Facts for places
+					'PLAC', 'FONE', 'ROMN', 'MAP', 'NOTE', 'SHARED_NOTE',
+					// non standard tags
+					'_HEB',
+				);
+				break;
+			case "name":
+				$tags = array(
+					// Facts subordinate to NAME
+					'TYPE', 'NPFX', 'GIVN', 'NICK', 'SPFX', 'SURN', 'NSFX',
+					'NOTE', 'SHARED_NOTE', 'SOUR', 'FONE', 'ROMN',
+					// non standard tbDefinedTags
+					'_HEB', '_AKA',
+				);
+				break;
+			case "indi":
+				$tags = array(
+					// Facts, attributes for individuals (no links to FAMs)
+					'RESN', 'NAME', 'SEX', 'BIRT', 'CHR', 'DEAT', 'BURI', 'CREM',
+					'ADOP', 'BAPM', 'BARM', 'BASM', 'BLES', 'CHRA', 'CONF', 'FCOM', 'ORDN',
+					'NATU', 'EMIG', 'IMMI', 'CENS', 'PROB', 'WILL', 'GRAD', 'RETI', 'EVEN',
+					'CAST', 'DSCR', 'EDUC', 'IDNO', 'NATI', 'NCHI', 'NMR',
+					'OCCU', 'PROP', 'RELI', 'RESI', 'SSN', 'TITL', 'FACT',
+					'BAPL', 'CONL', 'ENDL',	'SLGC',
+					'SUBM', 'ASSO', 'ALIA', 'ANCI', 'DESI', 'RFN', 'AFN',
+					'REFN', 'RIN', 'CHAN', 'NOTE', 'SHARED_NOTE', 'SOUR', 'OBJE',
+					// non standard tags
+					'_BRTM', '_DEG', '_EYEC', '_FNRL', '_HAIR', '_HEIG', '_HNM', '_HOL',
+					'_INTE', '_MDCL', '_MEDC', '_MILI', '_MILT', '_NAME', '_NAMS',
+					'_NLIV', '_NMAR', '_PRMN',  '_TODO', '_UID', '_WEIG', '_YART',
+				);
+				break;
+			default:
+			// This should only appear if an unknown field was used
+				$tags = array(
+					'_TODO',
+				);
+		}
 		$facts = array();
 		foreach ($tags as $tag) {
 			$facts[$tag] = self::getLabel($tag, null);

--- a/assets/js-1.7.2/webtrees.js
+++ b/assets/js-1.7.2/webtrees.js
@@ -991,7 +991,39 @@ function findSpecialChar(field) {
 }
 
 function findFact(field, ged) {
-	return findWindow(ged, "facts", field, {
+	switch (field.id) {
+		case "INDI_FACTS_ADD":
+		case "INDI_FACTS_UNIQUE":
+		case "QUICK_REQUIRED_FACTS":
+		case "INDI_FACTS_QUICK":
+			var factTypeStr = "factINDI";
+			break;
+		case "FAM_FACTS_ADD":
+		case "FAM_FACTS_UNIQUE":
+		case "QUICK_REQUIRED_FAMFACTS":
+		case "FAM_FACTS_QUICK":
+			var factTypeStr = "factFAM";
+			break;
+		case "SOUR_FACTS_ADD":
+		case "SOUR_FACTS_UNIQUE":
+		case "SOUR_FACTS_QUICK":
+			var factTypeStr = "factSOUR";
+			break;
+		case "REPO_FACTS_ADD":
+		case "REPO_FACTS_UNIQUE":
+		case "REPO_FACTS_QUICK":
+			var factTypeStr = "factREPO";
+			break;
+		case "ADVANCED_NAME_FACTS":
+		  var factTypeStr = "factNAME";
+			break;
+		case "ADVANCED_PLAC_FACTS":
+			var factTypeStr = "factPLACE";
+			break;
+		default:
+		  var factTypeStr = "factERR";
+	}
+	return findWindow(ged, factTypeStr, field, {
 		"tags": field.value
 	});
 }
@@ -1296,4 +1328,3 @@ jQuery(".menu-theme").on("click", "li a", function () {
 		location.reload();
 	});
 });
-

--- a/find.php
+++ b/find.php
@@ -71,10 +71,40 @@ case 'source':
 case 'specialchar':
 	$controller->setPageTitle(I18N::translate('Find a special character'));
 	break;
-case 'facts':
+case 'factINDI':
 	$controller
 		->setPageTitle(I18N::translate('Find a fact or event'))
-		->addInlineJavascript('initPickFact();');
+		->addInlineJavascript('initPickFact("indi");');
+	break;
+case 'factFAM':
+	$controller
+		->setPageTitle(I18N::translate('Find a fact or event'))
+		->addInlineJavascript('initPickFact("fam");');
+	break;
+case 'factSOUR':
+	$controller
+		->setPageTitle(I18N::translate('Find a fact or event'))
+		->addInlineJavascript('initPickFact("sour");');
+	break;
+case 'factREPO':
+	$controller
+		->setPageTitle(I18N::translate('Find a fact or event'))
+		->addInlineJavascript('initPickFact("repo");');
+	break;
+case 'factNAME':
+	$controller
+		->setPageTitle(I18N::translate('Find a fact or event'))
+		->addInlineJavascript('initPickFact("name");');
+	break;
+case 'factPLACE':
+	$controller
+		->setPageTitle(I18N::translate('Find a fact or event'))
+		->addInlineJavascript('initPickFact("place");');
+	break;
+case 'factERR':
+	$controller
+		->setPageTitle(I18N::translate('Find a fact or event'))
+		->addInlineJavascript('initPickFact("error");');
 	break;
 }
 $controller->pageHeader();
@@ -272,7 +302,7 @@ if ($type == 'specialchar') {
 }
 
 // Show facts
-if ($type == "facts") {
+if ($type == "factINDI" || $type == "factFAM" || $type == "factSOUR" || $type == "factREPO" || $type == "factNAME" || $type == "factPLACE" || $type == "factERR") {
 	echo '<div id="find-facts-header">
 	<form name="filterfacts" method="get" action="find.php"
 	input type="hidden" name="type" value="facts">
@@ -377,20 +407,102 @@ if ($type == "facts") {
 		}
 	};
 
-	function initPickFact() {
+	function initPickFact(factType) {
 		var n,i,j,tmp,preselectedDefaultTags="\x01<?php foreach ($preselDefault as $p) { echo addslashes($p), '\\x01'; } ?>";
 
-		DefaultTags=[<?php
-		$firstFact = true;
-		foreach (GedcomTag::getPicklistFacts() as $factId => $factName) {
-			if ($firstFact) {
-				$firstFact = false;
-			} else {
-				echo ',';
-			}
-			echo 'new DefaultTag("' . addslashes($factId) . '","' . addslashes($factName) . '",preselectedDefaultTags.indexOf("\\x01' . addslashes($factId) . '\\x01")>=0)';
+		switch (factType) {
+			case "indi":
+				DefaultTags=[<?php
+				$firstFact = true;
+				foreach (GedcomTag::getPicklistFacts("indi") as $factId => $factName) {
+					if ($firstFact) {
+						$firstFact = false;
+					} else {
+						echo ',';
+					}
+					echo 'new DefaultTag("' . addslashes($factId) . '","' . addslashes($factName) . '",preselectedDefaultTags.indexOf("\\x01' . addslashes($factId) . '\\x01")>=0)';
+				}
+				?>];
+				break;
+			case "fam":
+				DefaultTags=[<?php
+				$firstFact = true;
+				foreach (GedcomTag::getPicklistFacts("fam") as $factId => $factName) {
+					if ($firstFact) {
+						$firstFact = false;
+					} else {
+						echo ',';
+					}
+					echo 'new DefaultTag("' . addslashes($factId) . '","' . addslashes($factName) . '",preselectedDefaultTags.indexOf("\\x01' . addslashes($factId) . '\\x01")>=0)';
+				}
+				?>];
+				break;
+			case "sour":
+				DefaultTags=[<?php
+				$firstFact = true;
+				foreach (GedcomTag::getPicklistFacts("sour") as $factId => $factName) {
+					if ($firstFact) {
+						$firstFact = false;
+					} else {
+						echo ',';
+					}
+					echo 'new DefaultTag("' . addslashes($factId) . '","' . addslashes($factName) . '",preselectedDefaultTags.indexOf("\\x01' . addslashes($factId) . '\\x01")>=0)';
+				}
+				?>];
+				break;
+			case "repo":
+				DefaultTags=[<?php
+				$firstFact = true;
+				foreach (GedcomTag::getPicklistFacts("repo") as $factId => $factName) {
+					if ($firstFact) {
+						$firstFact = false;
+					} else {
+						echo ',';
+					}
+					echo 'new DefaultTag("' . addslashes($factId) . '","' . addslashes($factName) . '",preselectedDefaultTags.indexOf("\\x01' . addslashes($factId) . '\\x01")>=0)';
+				}
+				?>];
+				break;
+			case "place":
+				DefaultTags=[<?php
+				$firstFact = true;
+				foreach (GedcomTag::getPicklistFacts("place") as $factId => $factName) {
+					if ($firstFact) {
+						$firstFact = false;
+					} else {
+						echo ',';
+					}
+					echo 'new DefaultTag("' . addslashes($factId) . '","' . addslashes($factName) . '",preselectedDefaultTags.indexOf("\\x01' . addslashes($factId) . '\\x01")>=0)';
+				}
+				?>];
+				break;
+			case "name":
+				DefaultTags=[<?php
+				$firstFact = true;
+				foreach (GedcomTag::getPicklistFacts("name") as $factId => $factName) {
+					if ($firstFact) {
+						$firstFact = false;
+					} else {
+						echo ',';
+					}
+					echo 'new DefaultTag("' . addslashes($factId) . '","' . addslashes($factName) . '",preselectedDefaultTags.indexOf("\\x01' . addslashes($factId) . '\\x01")>=0)';
+				}
+				?>];
+				break;
+			default:
+				DefaultTags=[<?php
+				$firstFact = true;
+				foreach (GedcomTag::getPicklistFacts("unknown") as $factId => $factName) {
+					if ($firstFact) {
+						$firstFact = false;
+					} else {
+						echo ',';
+					}
+					echo 'new DefaultTag("' . addslashes($factId) . '","' . addslashes($factName) . '",preselectedDefaultTags.indexOf("\\x01' . addslashes($factId) . '\\x01")>=0)';
+				}
+				?>];
+				break;
 		}
-		?>];
 		TheList=document.getElementById("tbDefinedTags");
 		i=document.getElementById("tbxFilter");
 		i.onkeypress=i.onchange=i.onkeyup=function() {


### PR DESCRIPTION
Only display relevant fact/attribute tags when editing the default tags
for individuals, families etc. in admin_tree_config