### PR TITLE
Added England & Wales1939 Register as Census

### DIFF
--- a/app/Census/CensusColumnBirthDayMonthSlashYear.php
+++ b/app/Census/CensusColumnBirthDayMonthSlashYear.php
@@ -15,35 +15,27 @@
  */
 namespace Fisharebest\Webtrees\Census;
 
-/**
- * Definitions for a census
- */
-class CensusOfWales extends Census implements CensusPlaceInterface {
-	/**
-	 * All available censuses for this census place.
-	 *
-	 * @return CensusInterface[]
-	 */
-	public function allCensusDates() {
-		return array(
-			new CensusOfWales1841(),
-			new CensusOfWales1851(),
-			new CensusOfWales1861(),
-			new CensusOfWales1871(),
-			new CensusOfWales1881(),
-			new CensusOfWales1891(),
-			new CensusOfWales1901(),
-			new CensusOfWales1911(),
-			new RegisterOfWales1939()
-		);
-	}
+use Fisharebest\Webtrees\Individual;
 
+/**
+ * The individual's date of birth.
+ */
+class CensusColumnBirthDayMonthSlashYear extends AbstractCensusColumn implements CensusColumnInterface {
 	/**
-	 * Where did this census occur, in GEDCOM format.
+	 * Generate the likely value of this census column, based on available information.
+	 *
+	 * @param Individual      $individual
+	 * @param Individual|null $head
 	 *
 	 * @return string
 	 */
-	public function censusPlace() {
-		return 'Wales';
+	public function generate(Individual $individual, Individual $head = null) {
+		$birth_date = $individual->getBirthDate();
+
+		if ($birth_date->minimumJulianDay() === $birth_date->maximumJulianDay()) {
+			return $birth_date->minimumDate()->format('%j %M/%Y');
+		} else {
+			return '';
+		}
 	}
 }

--- a/app/Census/CensusOfEngland.php
+++ b/app/Census/CensusOfEngland.php
@@ -34,6 +34,7 @@ class CensusOfEngland extends Census implements CensusPlaceInterface {
 			new CensusOfEngland1891(),
 			new CensusOfEngland1901(),
 			new CensusOfEngland1911(),
+			new RegisterOfEngland1939()
 		);
 	}
 

--- a/app/Census/RegisterOfEngland1939.php
+++ b/app/Census/RegisterOfEngland1939.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2016 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace Fisharebest\Webtrees\Census;
+
+/**
+ * Definitions for a census
+ */
+class RegisterOfEngland1939 extends CensusOfEngland implements CensusInterface {
+	/**
+	 * When did this census occur.
+	 *
+	 * @return string
+	 */
+	public function censusDate() {
+		return '29 SEP 1939';
+	}
+
+	/**
+	 * The columns of the census.
+	 *
+	 * @return CensusColumnInterface[]
+	 */
+	public function columns() {
+		return array(
+			new CensusColumnNull($this, 'Schedule', 'Schedule Number'),
+			new CensusColumnNull($this, 'SubNum', 'Schedule Sub Number'),
+			new CensusColumnSurnameGivenNames($this, 'Name', 'Surname & other names'),
+			new CensusColumnNull($this, 'Role', 'Officer, Visitor, Servant, Patient, Inmate'),
+			new CensusColumnSexMF($this, 'Gender', 'Male or Female'),
+			new CensusColumnBirthDayMonthSlashYear($this, 'DoB', 'Date of birth'),
+			new CensusColumnConditionEnglish($this, 'Marr Status', 'Single, Married, Widowed or Divorced'),
+			new CensusColumnOccupation($this, 'Occupation', 'Occupation')
+		);
+	}
+}

--- a/app/Census/RegisterOfWales1939.php
+++ b/app/Census/RegisterOfWales1939.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2016 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace Fisharebest\Webtrees\Census;
+
+/**
+ * Definitions for a census
+ */
+class RegisterOfWales1939 extends CensusOfWales implements CensusInterface {
+	/**
+	 * When did this census occur.
+	 *
+	 * @return string
+	 */
+	public function censusDate() {
+		return '29 SEP 1939';
+	}
+
+	/**
+	 * The columns of the census.
+	 *
+	 * @return CensusColumnInterface[]
+	 */
+	public function columns() {
+		return array(
+			new CensusColumnNull($this, 'Schedule', 'Schedule Number'),
+			new CensusColumnNull($this, 'SubNum', 'Schedule Sub Number'),
+			new CensusColumnSurnameGivenNames($this, 'Name', 'Surname & other names'),
+			new CensusColumnNull($this, 'Role', 'Officer, Visitor, Servant, Patient, Inmate'),
+			new CensusColumnSexMF($this, 'Gender', 'Male or Female'),
+			new CensusColumnBirthDayMonthSlashYear($this, 'DoB', 'Date of birth'),
+			new CensusColumnConditionEnglish($this, 'Marr Status', 'Single, Married, Widowed or Divorced'),
+			new CensusColumnOccupation($this, 'Occupation', 'Occupation')
+		);
+	}
+}

--- a/tests/app/Census/CensusColumnBirthDayMonthSlashYearTest.php
+++ b/tests/app/Census/CensusColumnBirthDayMonthSlashYearTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2016 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace Fisharebest\Webtrees\Census;
+
+use Fisharebest\Webtrees\Date;
+use Fisharebest\Webtrees\Individual;
+use Mockery;
+
+/**
+ * Test harness for the class CensusColumnBirthDayMonthSlashYearTest
+ */
+class CensusColumnBirthDayMonthSlashYearTest extends \PHPUnit_Framework_TestCase {
+	/**
+	 * Delete mock objects
+	 */
+	public function tearDown() {
+		Mockery::close();
+	}
+
+	/**
+	 * @covers Fisharebest\Webtrees\Census\CensusColumnBirthDayMonthSlashYearTest
+	 * @covers Fisharebest\Webtrees\Census\AbstractCensusColumn
+	 */
+	public function testGenerateColumn() {
+		$cal_date = Mockery::mock('Fisharebest\Webtrees\Date\CalendarDate');
+		$cal_date->shouldReceive('format')->andReturn('30 Jun/1832');
+
+		$date = Mockery::mock('Fisharebest\Webtrees\Date');
+		$date->shouldReceive('minimumJulianDay')->andReturn($cal_date);
+		$date->shouldReceive('maximumJulianDay')->andReturn($cal_date);
+		$date->shouldReceive('minimumDate')->andReturn($cal_date);
+
+		$individual = Mockery::mock('Fisharebest\Webtrees\Individual');
+		$individual->shouldReceive('getBirthDate')->andReturn($date);
+
+		$census = Mockery::mock('Fisharebest\Webtrees\Census\CensusInterface');
+		$census->shouldReceive('censusDate')->andReturn('30 JUN 1832');
+
+		$column = new CensusColumnBirthDayMonthSlashYear($census, '', '');
+
+		$this->assertSame('30 Jun/1832', $column->generate($individual));
+	}
+}

--- a/tests/app/Census/CensusOfEnglandTest.php
+++ b/tests/app/Census/CensusOfEnglandTest.php
@@ -41,7 +41,7 @@ class CensusOfEnglandTest extends \PHPUnit_Framework_TestCase {
 
 		$census_dates = $census->allCensusDates();
 
-		$this->assertCount(8, $census_dates);
+		$this->assertCount(9, $census_dates);
 		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusOfEngland1841', $census_dates[0]);
 		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusOfEngland1851', $census_dates[1]);
 		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusOfEngland1861', $census_dates[2]);
@@ -50,5 +50,6 @@ class CensusOfEnglandTest extends \PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusOfEngland1891', $census_dates[5]);
 		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusOfEngland1901', $census_dates[6]);
 		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusOfEngland1911', $census_dates[7]);
+		$this->assertInstanceOf('Fisharebest\Webtrees\Census\RegisterOfEngland1939', $census_dates[8]);
 	}
 }

--- a/tests/app/Census/CensusOfWalesTest.php
+++ b/tests/app/Census/CensusOfWalesTest.php
@@ -41,7 +41,7 @@ class CensusOfWalesTest extends \PHPUnit_Framework_TestCase {
 
 		$census_dates = $census->allCensusDates();
 
-		$this->assertCount(8, $census_dates);
+		$this->assertCount(9, $census_dates);
 		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusOfWales1841', $census_dates[0]);
 		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusOfWales1851', $census_dates[1]);
 		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusOfWales1861', $census_dates[2]);
@@ -50,5 +50,6 @@ class CensusOfWalesTest extends \PHPUnit_Framework_TestCase {
 		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusOfWales1891', $census_dates[5]);
 		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusOfWales1901', $census_dates[6]);
 		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusOfWales1911', $census_dates[7]);
+		$this->assertInstanceOf('Fisharebest\Webtrees\Census\RegisterOfWales1939', $census_dates[8]);
 	}
 }

--- a/tests/app/Census/RegisterOfEngland1939Test.php
+++ b/tests/app/Census/RegisterOfEngland1939Test.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2016 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace Fisharebest\Webtrees\Census;
+
+/**
+ * Test harness for the class RegisterOfEngland1939
+ */
+class RegisterOfEngland1939Test extends \PHPUnit_Framework_TestCase {
+	/**
+	 * Test the census place and date
+	 *
+	 * @covers Fisharebest\Webtrees\Census\RegisterOfEngland1939
+	 */
+	public function testPlaceAndDate() {
+		$census = new RegisterOfEngland1939;
+
+		$this->assertSame('England', $census->censusPlace());
+		$this->assertSame('29 SEP 1939', $census->censusDate());
+	}
+
+	/**
+	 * Test the census columns
+	 *
+	 * @covers Fisharebest\Webtrees\Census\RegisterOfEngland1939
+	 * @covers Fisharebest\Webtrees\Census\AbstractCensusColumn
+	 */
+	public function testColumns() {
+		$census  = new RegisterOfEngland1939;
+		$columns = $census->columns();
+
+		$this->assertCount(8, $columns);
+		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusColumnNull', $columns[0]);
+		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusColumnNull', $columns[1]);
+		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusColumnSurnameGivenNames', $columns[2]);
+		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusColumnNull', $columns[3]);
+		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusColumnSexMF', $columns[4]);
+		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusColumnBirthDayMonthSlashYear', $columns[5]);
+		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusColumnConditionEnglish', $columns[6]);
+		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusColumnOccupation', $columns[7]);
+
+		$this->assertSame('Schedule', $columns[0]->abbreviation());
+		$this->assertSame('SubNum', $columns[1]->abbreviation());
+		$this->assertSame('Name', $columns[2]->abbreviation());
+		$this->assertSame('Role', $columns[3]->abbreviation());
+		$this->assertSame('Gender', $columns[4]->abbreviation());
+		$this->assertSame('DoB', $columns[5]->abbreviation());
+		$this->assertSame('Marr Status', $columns[6]->abbreviation());
+		$this->assertSame('Occupation', $columns[7]->abbreviation());
+
+		$this->assertSame('Schedule Number', $columns[0]->title());
+		$this->assertSame('Schedule Sub Number', $columns[1]->title());
+		$this->assertSame('Surname & other names', $columns[2]->title());
+		$this->assertSame('Officer, Visitor, Servant, Patient, Inmate', $columns[3]->title());
+		$this->assertSame('Male or Female', $columns[4]->title());
+		$this->assertSame('Date of birth', $columns[5]->title());
+		$this->assertSame('Single, Married, Widowed or Divorced', $columns[6]->title());
+		$this->assertSame('Occupation', $columns[7]->title());
+	}
+}

--- a/tests/app/Census/RegisterOfWales1939Test.php
+++ b/tests/app/Census/RegisterOfWales1939Test.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2016 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace Fisharebest\Webtrees\Census;
+
+/**
+ * Test harness for the class RegisterOfWales1939
+ */
+class RegisterOfWales1939Test extends \PHPUnit_Framework_TestCase {
+	/**
+	 * Test the census place and date
+	 *
+	 * @covers Fisharebest\Webtrees\Census\RegisterOfWales1939
+	 */
+	public function testPlaceAndDate() {
+		$census = new RegisterOfWales1939;
+
+		$this->assertSame('Wales', $census->censusPlace());
+		$this->assertSame('29 SEP 1939', $census->censusDate());
+	}
+
+	/**
+	 * Test the census columns
+	 *
+	 * @covers Fisharebest\Webtrees\Census\RegisterOfWales1939
+	 * @covers Fisharebest\Webtrees\Census\AbstractCensusColumn
+	 */
+	public function testColumns() {
+		$census  = new RegisterOfWales1939;
+		$columns = $census->columns();
+
+		$this->assertCount(8, $columns);
+		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusColumnNull', $columns[0]);
+		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusColumnNull', $columns[1]);
+		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusColumnSurnameGivenNames', $columns[2]);
+		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusColumnNull', $columns[3]);
+		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusColumnSexMF', $columns[4]);
+		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusColumnBirthDayMonthSlashYear', $columns[5]);
+		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusColumnConditionEnglish', $columns[6]);
+		$this->assertInstanceOf('Fisharebest\Webtrees\Census\CensusColumnOccupation', $columns[7]);
+
+		$this->assertSame('Schedule', $columns[0]->abbreviation());
+		$this->assertSame('SubNum', $columns[1]->abbreviation());
+		$this->assertSame('Name', $columns[2]->abbreviation());
+		$this->assertSame('Role', $columns[3]->abbreviation());
+		$this->assertSame('Gender', $columns[4]->abbreviation());
+		$this->assertSame('DoB', $columns[5]->abbreviation());
+		$this->assertSame('Marr Status', $columns[6]->abbreviation());
+		$this->assertSame('Occupation', $columns[7]->abbreviation());
+
+		$this->assertSame('Schedule Number', $columns[0]->title());
+		$this->assertSame('Schedule Sub Number', $columns[1]->title());
+		$this->assertSame('Surname & other names', $columns[2]->title());
+		$this->assertSame('Officer, Visitor, Servant, Patient, Inmate', $columns[3]->title());
+		$this->assertSame('Male or Female', $columns[4]->title());
+		$this->assertSame('Date of birth', $columns[5]->title());
+		$this->assertSame('Single, Married, Widowed or Divorced', $columns[6]->title());
+		$this->assertSame('Occupation', $columns[7]->title());
+	}
+}


### PR DESCRIPTION
Have taken column headings from record rather than transcript and checked against the National Archives at http://www.nationalarchives.gov.uk/help-with-your-research/research-guides/1939-register/#4-what-information-can-i-find-in-the-1939-register