### PR TITLE
Wrong path to edituser in Login Block

### DIFF
--- a/app/Module/LoginBlockModule.php
+++ b/app/Module/LoginBlockModule.php
@@ -60,7 +60,7 @@ class LoginBlockModule extends AbstractModule implements ModuleBlockInterface {
 		if (Auth::check()) {
 			$title   = I18N::translate('Logout');
 			$content = '<div class="center"><form method="post" action="logout.php" name="logoutform" onsubmit="return true;">';
-			$content .= '<br><a href="../../edituser.php" class="name2">' . I18N::translate('Logged in as ') . ' ' . Auth::user()->getRealNameHtml() . '</a><br><br>';
+			$content .= '<br><a href="edituser.php" class="name2">' . I18N::translate('Logged in as ') . ' ' . Auth::user()->getRealNameHtml() . '</a><br><br>';
 			$content .= '<input type="submit" value="' . I18N::translate('Logout') . '">';
 
 			$content .= '<br><br></form></div>';


### PR DESCRIPTION
When authenticated, the link behind the "logged in as user" points to a wrong URL: it is `../../edituser.php` instead of simply `edituser.php`