### PR TITLE
Census Assistant notes styling and bug fixes

### DIFF
--- a/app/Module/CensusAssistantModule.php
+++ b/app/Module/CensusAssistantModule.php
@@ -304,13 +304,13 @@ class CensusAssistantModule extends AbstractModule {
 				$fmt_headers[$key] = '<span title="' . Filter::escapeHtml($value) . '">' . $key . '</span>';
 			}
 
-			// Substitue header labels and format as HTML
+			// Substitute header labels and format as HTML
 			$thead = '<tr><th>' . strtr(str_replace('|', '</th><th>', $header), $fmt_headers) . '</th></tr>';
 			$thead = str_replace('.b.', '', $thead);
 
 			// Format data as HTML
 			$tbody = '';
-			foreach (explode("\n", $data) as $row) {
+			foreach (explode("\n", ltrim($data)) as $row) {
 				$tbody .= '<tr>';
 				foreach (explode('|', $row) as $column) {
 					$tbody .= '<td>' . $column . '</td>';
@@ -320,12 +320,14 @@ class CensusAssistantModule extends AbstractModule {
 
 			return
 				$title . "\n" . // The newline allows the framework to expand the details and turn the first line into a link
+				'<div class="markdown census-assistant-note">' .
 				'<p>' . $preamble . '</p>' .
-				'<table class="table-census-assistant">' .
+				'<table>' .
 				'<thead>' . $thead . '</thead>' .
 				'<tbody>' . $tbody . '</tbody>' .
 				'</table>' .
-				'<p>' . $postamble . '</p>';
+				'<p>' . $postamble . '</p>' .
+				'</div>';
 		} else {
 			// Not a census-assistant shared note - apply default formatting
 			return Filter::formatText($note->getNote(), $WT_TREE);
@@ -348,7 +350,7 @@ class CensusAssistantModule extends AbstractModule {
 			$html .= '<th title="' . $column->title() . '">' . $column->abbreviation() . '</th>';
 		}
 
-		return '<tr><th hidden></th>' . $html . '<th></th></th></tr>';
+		return '<tr><th hidden></th>' . $html . '<th></th></tr>';
 	}
 
 	/**

--- a/app/Module/IndividualFactsTabModule.php
+++ b/app/Module/IndividualFactsTabModule.php
@@ -120,13 +120,7 @@ class IndividualFactsTabModule extends AbstractModule implements ModuleTabInterf
 
 		ob_start();
 
-		echo '<table class="facts_table">';
-		echo '<tbody>';
-		if (!$indifacts) {
-			echo '<tr><td colspan="2" class="facts_value">', I18N::translate('There are no facts for this individual.'), '</td></tr>';
-		}
-
-		echo '<tr><td colspan="2" class="descriptionbox rela"><form action="?"><input id="checkbox_rela_facts" type="checkbox" ';
+		echo '<div class="descriptionbox rela"><form action="?"><input id="checkbox_rela_facts" type="checkbox" ';
 		echo $controller->record->getTree()->getPreference('EXPAND_RELATIVES_EVENTS') ? 'checked' : '';
 		echo ' onclick="jQuery(\'tr.rela\').toggle();"><label for="checkbox_rela_facts">', I18N::translate('Events of close relatives'), '</label>';
 		if (file_exists(Site::getPreference('INDEX_DIRECTORY') . 'histo.' . WT_LOCALE . '.php')) {
@@ -134,7 +128,12 @@ class IndividualFactsTabModule extends AbstractModule implements ModuleTabInterf
 			echo $EXPAND_HISTO_EVENTS ? 'checked' : '';
 			echo ' onclick="jQuery(\'tr.histo\').toggle();"><label for="checkbox_histo">', I18N::translate('Historical facts'), '</label>';
 		}
-		echo '</form></td></tr>';
+		echo '</form></div>';
+		echo '<table class="facts_table">';
+		echo '<tbody>';
+		if (!$indifacts) {
+			echo '<tr><td colspan="2" class="facts_value">', I18N::translate('There are no facts for this individual.'), '</td></tr>';
+		}
 
 		foreach ($indifacts as $fact) {
 			FunctionsPrintFacts::printFact($fact, $controller->record);

--- a/app/Module/NotesTabModule.php
+++ b/app/Module/NotesTabModule.php
@@ -61,14 +61,13 @@ class NotesTabModule extends AbstractModule implements ModuleTabInterface {
 		global $WT_TREE, $controller;
 
 		ob_start();
-		echo '<table class="facts_table">';
 		?>
-		<tr>
-			<td colspan="2" class="descriptionbox rela">
+		<div class="descriptionbox rela">
 				<input id="checkbox_note2" type="checkbox" <?php echo $WT_TREE->getPreference('SHOW_LEVEL2_NOTES') ? 'checked' : ''; ?> onclick="jQuery('tr.row_note2').toggle();">
-				<label for="checkbox_note2"><?php echo I18N::translate('Show all notes'); ?></label>
-			</td>
-		</tr>
+		<label for="checkbox_note2"><?php echo I18N::translate('Show all notes'); ?></label>
+		</div>
+		<table class="facts_table">
+
 		<?php
 		foreach ($this->getFactsWithNotes() as $fact) {
 			if ($fact->getTag() == 'NOTE') {

--- a/modules_v3/GEDFact_assistant/census/census-edit.php
+++ b/modules_v3/GEDFact_assistant/census/census-edit.php
@@ -218,11 +218,14 @@ $controller
 
 	/* Update the census text from the various input fields */
 	function updateCensusText() {
-		var html     = "";
-		var title    = jQuery("#Titl").val();
-		var citation = jQuery("#citation").val();
-		var locality = jQuery("#locality").val();
-		var notes    = jQuery("#notes").val();
+		var html        = "";
+		var title       = jQuery("#Titl").val();
+		var citation    = jQuery("#citation").val();
+		var locality    = jQuery("#locality").val();
+		var notes       = jQuery("#notes").val();
+		var table       = jQuery("#tblSample");
+		var max_col_ndx = table.find("thead th").length - 1;
+		var line        = "";
 
 		if (title !== "") {
 			html += title + "\n";
@@ -236,24 +239,20 @@ $controller
 
 		html += "\n.start_formatted_area.\n";
 
-		jQuery("#tblSample thead th").each(function(n, el) {
-			if (n > 1) {
-				html += "|";
-			}
-			if (n > 0) {
-				html += ".b." + jQuery(el).html();
-			}
+		table.find("thead th").each(function (n, el) {
+			if (n === 0 || n === max_col_ndx) { // Skip prefix & suffix cells
+			 return true;
+			 }
+			line += "|.b." + jQuery(el).html();
 		});
-		html += "\n";
+		html += line.substr(1) + "\n";
 
-		jQuery("#tblSample tbody tr").each(function(n, el) {
+		table.find("tbody tr").each(function(n, el) {
+			line = "";
 			jQuery("input", jQuery(el)).each(function(n, el) {
-				if (n > 0) {
-					html += "|";
-				}
-				html += jQuery(el).val();
+				line += "|" + jQuery(el).val();
 			});
-			html += "\n";
+			html += line.substr(1) + "\n";
 		});
 
 		html += ".end_formatted_area.\n";
@@ -265,7 +264,7 @@ $controller
 		jQuery("#NOTE").val(html);
 
 		var pid_array = '';
-		jQuery("#tblSample tbody td:first-child").each(function(n, el) {
+		table.find("tbody td:first-child").each(function(n, el) {
 			if (n > 0) {
 				pid_array += ',';
 			}

--- a/themes/clouds/css-1.7.4/style.css
+++ b/themes/clouds/css-1.7.4/style.css
@@ -2035,6 +2035,8 @@ dd .deletelink {
 	clear: both;
 }
 
+/* ===== markdown formatting ===== */
+
 .markdown p {
 	margin: 0 0 0.5em;
 	white-space: pre-wrap;
@@ -2153,6 +2155,20 @@ dd .deletelink {
 #family-table .fact_SOUR {
 	margin: 5px 3px 5px 0;
 	clear: both;
+}
+
+#notes_content .facts_table,
+#personal_facts_content .facts_table {
+	table-layout: fixed;
+}
+
+#notes_content > div,
+#personal_facts_content > div {
+	margin: 2px 2px 0;
+}
+
+.census-assistant-note {
+	overflow-x: auto;
 }
 
 .facts_table .field em {
@@ -3196,12 +3212,6 @@ dd .deletelink {
 [dir=rtl] #cboxSlideshow {
 	right: 57px;
 	left: auto;
-}
-
-/* ===== Census assistant module ===== */
-table.table-census-assistant th {
-	font-weight: bold;
-	text-align: left;
 }
 
 /* Stories module */

--- a/themes/colors/css-1.7.4/style.css
+++ b/themes/colors/css-1.7.4/style.css
@@ -2039,6 +2039,8 @@ dd .deletelink {
 	clear: both;
 }
 
+/* ===== markdown formatting ===== */
+
 .markdown p {
 	margin: 0 0 0.5em;
 	white-space: pre-wrap;
@@ -2157,6 +2159,20 @@ dd .deletelink {
 #family-table .fact_SOUR {
 	margin: 5px 3px 5px 0;
 	clear: both;
+}
+
+#notes_content .facts_table,
+#personal_facts_content .facts_table {
+	table-layout: fixed;
+}
+
+#notes_content > div,
+#personal_facts_content > div {
+	margin: 2px 2px 0;
+}
+
+.census-assistant-note {
+	overflow-x: auto;
 }
 
 .facts_table .field em {
@@ -3194,12 +3210,6 @@ dd .deletelink {
 [dir=rtl] #cboxSlideshow {
 	right: 57px;
 	left: auto;
-}
-
-/* ===== Census assistant module ===== */
-table.table-census-assistant th {
-	font-weight: bold;
-	text-align: left;
 }
 
 /* Stories module */

--- a/themes/fab/css-1.7.4/style.css
+++ b/themes/fab/css-1.7.4/style.css
@@ -1953,6 +1953,8 @@ dd .deletelink {
 	clear: both;
 }
 
+/* ===== markdown formatting ===== */
+
 .markdown p {
 	margin: 0 0 0.5em;
 	white-space: pre-wrap;
@@ -2072,6 +2074,20 @@ dd .deletelink {
 #family-table .fact_SOUR {
 	margin: 5px 3px 5px 0;
 	clear: both;
+}
+
+#notes_content .facts_table,
+#personal_facts_content .facts_table {
+	table-layout: fixed;
+}
+
+#notes_content > div,
+#personal_facts_content > div {
+	margin: 2px 2px 0;
+}
+
+.census-assistant-note {
+	overflow-x: auto;
 }
 
 .facts_table .field em {
@@ -3135,12 +3151,6 @@ dd .deletelink {
 [dir=rtl] #cboxSlideshow {
 	right: 57px;
 	left: auto;
-}
-
-/* ===== Census assistant module ===== */
-table.table-census-assistant th {
-	font-weight: bold;
-	text-align: left;
 }
 
 /* Stories module */

--- a/themes/minimal/css-1.7.4/style.css
+++ b/themes/minimal/css-1.7.4/style.css
@@ -1960,6 +1960,8 @@ dd .deletelink {
 	clear: both;
 }
 
+/* ===== markdown formatting ===== */
+
 .markdown p {
 	margin: 0 0 0.5em;
 	white-space: pre-wrap;
@@ -2058,6 +2060,20 @@ dd .deletelink {
 #family-table .fact_SOUR {
 	margin: 5px 3px 5px 0;
 	clear: both;
+}
+
+#notes_content .facts_table,
+#personal_facts_content .facts_table {
+	table-layout: fixed;
+}
+
+#notes_content > div,
+#personal_facts_content > div {
+	margin: 2px 2px 0;
+}
+
+.census-assistant-note {
+	overflow-x: auto;
 }
 
 .facts_table .field em {
@@ -3121,12 +3137,6 @@ dd .deletelink {
 [dir=rtl] #cboxSlideshow {
 	right: 57px;
 	left: auto;
-}
-
-/* ===== Census assistant module ===== */
-table.table-census-assistant th {
-	font-weight: bold;
-	text-align: left;
 }
 
 /* Stories module */

--- a/themes/webtrees/css-1.7.4/style.css
+++ b/themes/webtrees/css-1.7.4/style.css
@@ -1950,6 +1950,8 @@ dd .deletelink {
 	clear: both;
 }
 
+/* markdown formatting ===== */
+
 .markdown p {
 	margin: 0 0 0.5em;
 	white-space: pre-wrap;
@@ -2068,6 +2070,20 @@ dd .deletelink {
 #family-table .fact_SOUR {
 	margin: 5px 3px 5px 0;
 	clear: both;
+}
+
+#notes_content .facts_table,
+#personal_facts_content .facts_table {
+	table-layout: fixed;
+}
+
+#notes_content > div,
+#personal_facts_content > div {
+	margin: 2px 2px 0;
+}
+
+.census-assistant-note {
+	overflow-x: auto;
 }
 
 .facts_table .field em {
@@ -3094,12 +3110,6 @@ dd .deletelink {
 [dir=rtl] #cboxSlideshow {
 	right: 57px;
 	left: auto;
-}
-
-/* ===== Census assistant module ===== */
-table.table-census-assistant th {
-	font-weight: bold;
-	text-align: left;
 }
 
 /* Stories module */
@@ -5224,7 +5234,7 @@ footer {
 		right: 0;
 	}
 	[dir=rtl] .secondary-menu {
-		left: 0px;
+		left: 0;
 		right: auto;
 	}
 	/* Primary Menu */

--- a/themes/xenea/css-1.7.4/style.css
+++ b/themes/xenea/css-1.7.4/style.css
@@ -1964,6 +1964,8 @@ dd .deletelink {
 	clear: both;
 }
 
+/* ===== markdown formatting ===== */
+
 .markdown p {
 	margin: 0 0 0.5em;
 	white-space: pre-wrap;
@@ -2082,6 +2084,20 @@ dd .deletelink {
 #family-table .fact_SOUR {
 	margin: 5px 3px 5px 0;
 	clear: both;
+}
+
+#notes_content .facts_table,
+#personal_facts_content .facts_table {
+	table-layout: fixed;
+}
+
+#notes_content > div,
+#personal_facts_content > div {
+	margin: 2px 2px 0;
+}
+
+.census-assistant-note {
+	overflow-x: auto;
 }
 
 .facts_table .field em {
@@ -3113,12 +3129,6 @@ dd .deletelink {
 [dir=rtl] #cboxSlideshow {
 	right: 57px;
 	left: auto;
-}
-
-/* ===== Census assistant module ===== */
-table.table-census-assistant th {
-	font-weight: bold;
-	text-align: left;
 }
 
 /* Stories module */


### PR DESCRIPTION
Added styling for Census Assistant notes (same as markdown).

census-edit.php fixed bug in function updateCensusText whereby hidden <th> elements were included in the column count when generating the note text.

fixed bug in CensusAssistantModule.php function formatCensusNote to remove leading \n char from $data (real solution would be to change regex on line 294 but I go cross eyed looking at that).