### PR TITLE
Include table prefix in foreign key names to avoid conflicts

### DIFF
--- a/app/Module/FamilyTreeFavorites/Schema/Migration2.php
+++ b/app/Module/FamilyTreeFavorites/Schema/Migration2.php
@@ -37,8 +37,8 @@ class Migration2 implements MigrationInterface {
 		try {
 			Database::exec(
 				"ALTER TABLE `##favorite`" .
-				" ADD FOREIGN KEY favorite_fk1 (user_id  ) REFERENCES `##user`   (user_id) ON DELETE CASCADE," .
-				" ADD FOREIGN KEY favorite_fk2 (gedcom_id) REFERENCES `##gedcom` (gedcom_id) ON DELETE CASCADE"
+				" ADD FOREIGN KEY `##favorite_fk1` (user_id  ) REFERENCES `##user`   (user_id) ON DELETE CASCADE," .
+				" ADD FOREIGN KEY `##favorite_fk2` (gedcom_id) REFERENCES `##gedcom` (gedcom_id) ON DELETE CASCADE"
 			);
 		} catch (PDOException $ex) {
 			// Already updated?

--- a/app/Module/FamilyTreeNews/Schema/Migration2.php
+++ b/app/Module/FamilyTreeNews/Schema/Migration2.php
@@ -36,8 +36,8 @@ class Migration2 implements MigrationInterface {
 		try {
 			Database::exec(
 				"ALTER TABLE `##news`" .
-				" ADD FOREIGN KEY news_fk1 (user_id  ) REFERENCES `##user`   (user_id)   ON DELETE CASCADE," .
-				" ADD FOREIGN KEY news_fk2 (gedcom_id) REFERENCES `##gedcom` (gedcom_id) ON DELETE CASCADE"
+				" ADD FOREIGN KEY `##news_fk1` (user_id  ) REFERENCES `##user`   (user_id)   ON DELETE CASCADE," .
+				" ADD FOREIGN KEY `##news_fk2` (gedcom_id) REFERENCES `##gedcom` (gedcom_id) ON DELETE CASCADE"
 			);
 		} catch (PDOException $ex) {
 			// Already updated?

--- a/app/Schema/Migration2.php
+++ b/app/Schema/Migration2.php
@@ -37,7 +37,7 @@ class Migration2 implements MigrationInterface {
 			" imported        BOOLEAN                NOT NULL DEFAULT FALSE," .
 			" PRIMARY KEY     (gedcom_chunk_id)," .
 			"         KEY ix1 (gedcom_id, imported)," .
-			" FOREIGN KEY fk1 (gedcom_id) REFERENCES `##gedcom` (gedcom_id)" .
+			" FOREIGN KEY `##gedcom_chunk_fk1` (gedcom_id) REFERENCES `##gedcom` (gedcom_id)" .
 			") COLLATE utf8_unicode_ci ENGINE=InnoDB"
 		);
 


### PR DESCRIPTION
If you do a second installation of webtrees in a database with an existing WT installation but with a different table prefix, the installation will fail with some MySQL servers (e.g. MariaDB 10.0.24) because some of the foreign key names don't include the table prefix.

The error message was something like: "Error 1005: Can't create table (errno: 121)" but I don't have it handy since I ran into this last weekend. I confirmed this patch solves the problem for a new installation in a DB with an existing install with a different table prefix.

`app/Schema/Migration2.php` was the main issue but I searched for other occurrences with:
`git grep "FOREIGN KEY" | grep -v -E "FOREIGN KEY[^(]+##[^(]+\("`