### PR TITLE
Standardise xxxController->getEditMenu logic

### DIFF
--- a/app/Controller/FamilyController.php
+++ b/app/Controller/FamilyController.php
@@ -90,10 +90,8 @@ class FamilyController extends GedcomRecordController {
 					'onclick' => 'return reorder_children("' . $this->record->getXref() . '");',
 				)));
 			}
-		}
 
-		// delete
-		if (Auth::isEditor($this->record->getTree())) {
+			// delete
 			$menu->addSubmenu(new Menu(I18N::translate('Delete'), '#', 'menu-fam-del', array(
 				'onclick' => 'return delete_record("' . I18N::translate('Deleting the family will unlink all of the individuals from each other but will leave the individuals in place. Are you sure you want to delete this family?') . '", "' . $this->record->getXref() . '");',
 			)));
@@ -104,18 +102,6 @@ class FamilyController extends GedcomRecordController {
 			$menu->addSubmenu(new Menu(I18N::translate('Edit raw GEDCOM'), '#', 'menu-fam-editraw', array(
 				'onclick' => 'return edit_raw("' . $this->record->getXref() . '");',
 			)));
-		}
-
-		// add to favorites
-		if (Module::getModuleByName('user_favorites')) {
-			$menu->addSubmenu(new Menu(
-				/* I18N: Menu option. Add [the current page] to the list of favorites */ I18N::translate('Add to favorites'),
-				'#',
-				'menu-fam-addfav',
-				array(
-					'onclick' => 'jQuery.post("module.php?mod=user_favorites&mod_action=menu-add-favorite",{xref:"' . $this->record->getXref() . '"},function(){location.reload();})',
-				)
-			));
 		}
 
 		// Get the link for the first submenu and set it as the link for the main menu

--- a/app/Controller/GedcomRecordController.php
+++ b/app/Controller/GedcomRecordController.php
@@ -119,18 +119,6 @@ class GedcomRecordController extends PageController {
 			)));
 		}
 
-		// add to favorites
-		if (Module::getModuleByName('user_favorites')) {
-			$menu->addSubmenu(new Menu(
-				/* I18N: Menu option. Add [the current page] to the list of favorites */ I18N::translate('Add to favorites'),
-				'#',
-				'menu-record-addfav',
-				array(
-					'onclick' => 'jQuery.post("module.php?mod=user_favorites&mod_action=menu-add-favorite" ,{xref:"' . $this->record->getXref() . '"},function(){location.reload();})',
-				)
-			));
-		}
-
 		// Get the link for the first submenu and set it as the link for the main menu
 		if ($menu->getSubmenus()) {
 			$submenus = $menu->getSubmenus();

--- a/app/Controller/IndividualController.php
+++ b/app/Controller/IndividualController.php
@@ -268,19 +268,14 @@ class IndividualController extends GedcomRecordController {
 			return null;
 		}
 		// edit menu
-		$menu = new Menu(I18N::translate('Edit'), '#', 'menu-indi', array(
-			'onclick' => 'return false;',
-		));
+		$menu = new Menu(I18N::translate('Edit'), '#', 'menu-indi');
 
-		// What behaviour shall we give the main menu? If we leave it blank, the framework
-		// will copy the first submenu - which may be edit-raw or delete.
-		// As a temporary solution, make it edit the name
 		if (Auth::isEditor($this->record->getTree())) {
 			foreach ($this->record->getFacts() as $fact) {
 				if ($fact->getTag() === 'NAME' && $fact->canEdit()) {
-					$menu->setAttrs(array(
+					$menu->addSubmenu( new Menu(I18N::translate('Edit name'), '#', 'menu-indi-editname', array(
 						'onclick' => 'return edit_name("' . $this->record->getXref() . '", "' . $fact->getFactId() . '");',
-					));
+					)));
 					break;
 				}
 			}
@@ -310,10 +305,8 @@ class IndividualController extends GedcomRecordController {
 					'onclick' => 'return reorder_families("' . $this->record->getXref() . '");',
 				)));
 			}
-		}
 
-		// delete
-		if (Auth::isEditor($this->record->getTree())) {
+			// delete
 			$menu->addSubmenu(new Menu(I18N::translate('Delete'), '#', 'menu-indi-del', array(
 				'onclick' => 'return delete_record("' . I18N::translate('Are you sure you want to delete “%s”?', Filter::escapeJs(Filter::unescapeHtml($this->record->getFullName()))) . '", "' . $this->record->getXref() . '");',
 			)));
@@ -326,14 +319,11 @@ class IndividualController extends GedcomRecordController {
 			)));
 		}
 
-		// add to favorites
-		if (Module::getModuleByName('user_favorites')) {
-			$menu->addSubmenu(new Menu(
-			/* I18N: Menu option. Add [the current page] to the list of favorites */ I18N::translate('Add to favorites'),
-				'#',
-				'menu-indi-addfav', array(
-					'onclick' => 'jQuery.post("module.php?mod=user_favorites&mod_action=menu-add-favorite",{xref:"' . $this->record->getXref() . '"},function(){location.reload();})',
-				)));
+		// Get the link for the first submenu and set it as the link for the main menu
+		if ($menu->getSubmenus()) {
+			$submenus = $menu->getSubmenus();
+			$menu->setLink($submenus[0]->getLink());
+			$menu->setAttrs($submenus[0]->getAttrs());
 		}
 
 		return $menu;

--- a/app/Controller/MediaController.php
+++ b/app/Controller/MediaController.php
@@ -62,10 +62,8 @@ class MediaController extends GedcomRecordController {
 					'onclick' => 'return ilinkitem("' . $this->record->getXref() . '","source");',
 				)));
 			}
-		}
 
-		// delete
-		if (Auth::isEditor($this->record->getTree())) {
+			// delete
 			$menu->addSubmenu(new Menu(I18N::translate('Delete'), '#', 'menu-obje-del', array(
 				'onclick' => 'return delete_record("' . I18N::translate('Are you sure you want to delete “%s”?', Filter::escapeJs(Filter::unescapeHtml($this->record->getFullName()))) . '", "' . $this->record->getXref() . '");',
 			)));
@@ -76,18 +74,6 @@ class MediaController extends GedcomRecordController {
 			$menu->addSubmenu(new Menu(I18N::translate('Edit raw GEDCOM'), '#', 'menu-obje-editraw', array(
 				'onclick' => 'return edit_raw("' . $this->record->getXref() . '");',
 			)));
-		}
-
-		// add to favorites
-		if (Module::getModuleByName('user_favorites')) {
-			$menu->addSubmenu(new Menu(
-			/* I18N: Menu option. Add [the current page] to the list of favorites */
-				I18N::translate('Add to favorites'),
-				'#',
-				'menu-obje-addfav',
-				array(
-					'onclick' => 'jQuery.post("module.php?mod=user_favorites&mod_action=menu-add-favorite",{xref:"' . $this->record->getXref() . '"},function(){location.reload();})',
-				)));
 		}
 
 		// Get the link for the first submenu and set it as the link for the main menu

--- a/app/Controller/NoteController.php
+++ b/app/Controller/NoteController.php
@@ -40,25 +40,11 @@ class NoteController extends GedcomRecordController {
 			$menu->addSubmenu(new Menu(I18N::translate('Edit note'), '#', 'menu-note-edit', array(
 				'onclick' => 'return edit_note("' . $this->record->getXref() . '");',
 			)));
-		}
 
-		// delete
-		if (Auth::isEditor($this->record->getTree())) {
+			// delete
 			$menu->addSubmenu(new Menu(I18N::translate('Delete'), '#', 'menu-note-del', array(
 				'onclick' => 'return delete_record("' . I18N::translate('Are you sure you want to delete “%s”?', Filter::escapeJs(Filter::unescapeHtml($this->record->getFullName()))) . '", "' . $this->record->getXref() . '");',
 			)));
-		}
-
-		// add to favorites
-		if (Module::getModuleByName('user_favorites')) {
-			$menu->addSubmenu(new Menu(
-				/* I18N: Menu option. Add [the current page] to the list of favorites */ I18N::translate('Add to favorites'),
-				'#',
-				'menu-note-addfav',
-				array(
-					'onclick' => 'jQuery.post("module.php?mod=user_favorites&mod_action=menu-add-favorite",{xref:"' . $this->record->getXref() . '"},function(){location.reload();})',
-				)
-			));
 		}
 
 		// Get the link for the first submenu and set it as the link for the main menu

--- a/app/Controller/SourceController.php
+++ b/app/Controller/SourceController.php
@@ -49,10 +49,8 @@ class SourceController extends GedcomRecordController {
 					'onclick' => 'return add_fact("' . $this->record->getXref() . '", "TITL");',
 				)));
 			}
-		}
 
-		// delete
-		if (Auth::isEditor($this->record->getTree())) {
+			// delete
 			$menu->addSubmenu(new Menu(I18N::translate('Delete'), '#', 'menu-sour-del', array(
 				'onclick' => "return delete_record('" . I18N::translate('Are you sure you want to delete “%s”?', Filter::escapeJs(Filter::unescapeHtml($this->record->getFullName()))) . "', '" . $this->record->getXref() . "');",
 			)));
@@ -63,18 +61,6 @@ class SourceController extends GedcomRecordController {
 			$menu->addSubmenu(new Menu(I18N::translate('Edit raw GEDCOM'), '#', 'menu-sour-editraw', array(
 				'onclick' => 'return edit_raw("' . $this->record->getXref() . '");',
 			)));
-		}
-
-		// add to favorites
-		if (Module::getModuleByName('user_favorites')) {
-			$menu->addSubmenu(new Menu(
-				/* I18N: Menu option. Add [the current page] to the list of favorites */ I18N::translate('Add to favorites'),
-				'#',
-				'menu-sour-addfav',
-				array(
-					'onlick' => 'jQuery.post("module.php?mod=user_favorites&amp;mod_action=menu-add-favorite",{xref:"' . $this->record->getXref() . '"},function(){location.reload();})',
-				)
-			));
 		}
 
 		// Get the link for the first submenu and set it as the link for the main menu

--- a/themes/clouds/css-1.7.4/style.css
+++ b/themes/clouds/css-1.7.4/style.css
@@ -4558,6 +4558,14 @@ footer .error {
 	background-position: 0 -261px;
 }
 
+.menu-indi-orderfam {
+	background-position: left 0;
+}
+
+[dir=rtl] .menu-indi-orderfam {
+	background-position: right 0;
+}
+
 .menu-sour {
 	background-position: 0 -320px;
 }
@@ -4854,6 +4862,14 @@ footer .error {
 [dir=rtl] .menu-indi-addfav,
 [dir=rtl] .menu-record-addfav {
 	background-position: right -736px;
+}
+
+.menu-indi-editname {
+	background-position: left -598px;
+}
+
+[dir=rtl] .menu-indi-editname {
+	background-position: right -598px;
 }
 
 .menu-indi-addname {

--- a/themes/colors/css-1.7.4/style.css
+++ b/themes/colors/css-1.7.4/style.css
@@ -4841,6 +4841,14 @@ footer {
 	background-position: right -832px;
 }
 
+.menu-indi-editname {
+	background-position: left -836px;
+}
+
+[dir=rtl] .menu-indi-editname {
+	background-position: right -836px;
+}
+
 .menu-indi-addname {
 	background-position: left -780px;
 }

--- a/themes/webtrees/css-1.7.4/style.css
+++ b/themes/webtrees/css-1.7.4/style.css
@@ -4721,6 +4721,14 @@ footer {
 	background-position: right -870px;
 }
 
+.menu-indi-editname {
+	background-position: left -120px;
+}
+
+[dir=rtl] .menu-indi-editname {
+	background-position: right -120px;
+}
+
 .menu-indi-addname {
 	background-position: left -780px;
 }

--- a/themes/xenea/css-1.7.4/style.css
+++ b/themes/xenea/css-1.7.4/style.css
@@ -4427,6 +4427,14 @@ footer {
 	background-position:center -261px;
 }
 
+.menu-indi-orderfam {
+	background-position: left 0;
+}
+
+[dir=rtl] .menu-indi-orderfam {
+	background-position: right 0;
+}
+
 .menu-sour {
 	background-position:center -319px;
 }
@@ -4724,6 +4732,14 @@ footer {
 [dir=rtl] .menu-indi-addfav,
 [dir=rtl] .menu-record-addfav {
 	background-position: right -736px;
+}
+
+.menu-indi-editname {
+	background-position: left -690px;
+}
+
+[dir=rtl] .menu-indi-editname {
+	background-position: right -690px;
 }
 
 .menu-indi-addname {


### PR DESCRIPTION
1. Copy functionality of other controllers to IndividualController->getEditMenu()
2. Remove "Add to favourites" from the edit menu as this functionality also appears as a menu item in the secondary menu (which to my mind is it's logical home)
3. Fixed various RTL icon problems on the edit menu

Theme owners may like to review my choice of icons for the "Edit names" and "Re-order families" menu options