### PR TITLE
Google maps - simplify HTML on individual tab

### DIFF
--- a/app/Module/GoogleMapsModule.php
+++ b/app/Module/GoogleMapsModule.php
@@ -162,45 +162,25 @@ class GoogleMapsModule extends AbstractModule implements ModuleConfigInterface, 
 
 		if ($this->checkMapData($controller->record)) {
 			ob_start();
-			echo '<table style="border:none; width:100%; margin-bottom: 10px;"><tr><td>';
-			echo '<table style="border:none" class="facts_table">';
-			echo '<tr><td>';
-			echo '<div id="map_pane" style="height: ', $this->getSetting('GM_YSIZE'), 'px"></div>';
-			if (Auth::isAdmin()) {
-				echo '<table width="100%"><tr class="noprint">';
-				echo '<td>';
-				echo'<a href="module.php?mod=' . $this->getName() . '&amp;mod_action=admin_config">' . I18N::translate('Google Maps™ preferences') . '</a>';
-				echo '</td>';
-				echo '<td "style=text-align:center;">';
-				echo '<a href="module.php?mod=' . $this->getName() . '&amp;mod_action=admin_places">' . I18N::translate('Geographic data') . '</a>';
-				echo '</td>';
-				echo '<td style="text-align:end;">';
-				echo '<a href="module.php?mod=' . $this->getName() . '&amp;mod_action=admin_placecheck">' . I18N::translate('Place check') . '</a>';
-				echo '</td>';
-				echo '</tr></table>';
-			}
-			echo '</td>';
-			echo '<td width="30%">';
-			echo '<div id="map_content">';
-
+			echo '<div id="wrapper" style="height:' . $this->getSetting('GM_YSIZE') . 'px;">';
+			echo '<div id="map_pane"></div>';
 			$this->buildIndividualMap($controller->record);
 			echo '</div>';
-			echo '</td>';
-			echo '</tr></table>';
-			echo '</td></tr></table>';
-			echo '<script>loadMap();</script>';
-
-			return '<div id="' . $this->getName() . '_content">' . ob_get_clean() . '</div>';
-		} else {
-			$html = '<table class="facts_table">';
-			$html .= '<tr><td colspan="2" class="facts_value">' . I18N::translate('No map data exists for this individual');
-			$html .= '</td></tr>';
 			if (Auth::isAdmin()) {
-				$html .= '<tr><td class="center" colspan="2">';
-				$html .= '<a href="module.php?mod=googlemap&amp;mod_action=admin_config">' . I18N::translate('Google Maps™ preferences') . '</a>';
-				$html .= '</td></tr>';
+				echo '<div class="gmoptions noprint">';
+				echo '<a href="module.php?mod=' . $this->getName() . '&amp;mod_action=admin_config">' . I18N::translate('Google Maps™ preferences') . '</a>';
+				echo ' | <a href="module.php?mod=' . $this->getName() . '&amp;mod_action=admin_places">' . I18N::translate('Geographic data') . '</a>';
+				echo ' | <a href="module.php?mod=' . $this->getName() . '&amp;mod_action=admin_placecheck">' . I18N::translate('Place check') . '</a>';
+				echo '</div>';
 			}
-
+			echo '<script>loadMap();</script>';
+			return '<div id="' . $this->getName() . '_content" class="facts_table">' . ob_get_clean() . '</div>';
+		} else {
+			$html = '<div class="facts_value noprint">';
+			$html .= I18N::translate('No map data exists for this individual');
+			if (Auth::isAdmin()) {
+				$html .= '<div style="text-align: center;"><a href="module.php?mod=googlemap&amp;mod_action=admin_config">' . I18N::translate('Google Maps™ preferences') . '</a></div>';
+			}
 			return $html;
 		}
 	}
@@ -2048,6 +2028,31 @@ class GoogleMapsModule extends AbstractModule implements ModuleConfigInterface, 
 			);
 		}
 
+		$places = array_keys($unique_places);
+		// Create the normal googlemap sidebar of events and children
+		echo '<div id="map_events" class="optionbox"><table class="facts_table">';
+
+		foreach ($events as $event) {
+			$index = array_search($event['placeid'], $places);
+			echo '<tr>';
+			echo '<td class="facts_label">';
+			echo '<a href="#" onclick="return openInfowindow(\'', $index, '\')">', $event['fact_label'], '</a></td>';
+			echo '<td class="', $event['class'], '">';
+			if ($event['info']) {
+				echo '<div><span class="field">', Filter::escapeHtml($event['info']), '</span></div>';
+			}
+			if ($event['name']) {
+				echo '<div>', $event['name'], '</div>';
+			}
+			echo '<div>', $event['place'], '</div>';
+			if ($event['date']) {
+				echo '<div>', $event['date'], '</div>';
+			}
+			echo '</td>';
+			echo '</tr>';
+		}
+		echo '</table></div>';
+
 		// *** ENABLE STREETVIEW ***
 		$STREETVIEW = (bool) $this->getSetting('GM_USE_STREETVIEW');
 		?>
@@ -2290,7 +2295,7 @@ class GoogleMapsModule extends AbstractModule implements ModuleConfigInterface, 
 					streetViewControl:        true,
 					scrollwheel:              true
 				};
-				map            = new google.maps.Map(document.getElementById('map_pane'), mapOptions);
+				map = new google.maps.Map(document.getElementById('map_pane'), mapOptions);
 
 				// Close any infowindow when map is clicked
 				google.maps.event.addListener(map, 'click', function() {
@@ -2371,30 +2376,6 @@ class GoogleMapsModule extends AbstractModule implements ModuleConfigInterface, 
 
 		</script>
 		<?php
-		$places = array_keys($unique_places);
-		// Create the normal googlemap sidebar of events and children
-		echo '<div style="overflow-x: hidden; overflow-y: auto; height:', $this->getSetting('GM_YSIZE'), 'px;"><table class="facts_table">';
-
-		foreach ($events as $event) {
-			$index = array_search($event['placeid'], $places);
-			echo '<tr>';
-			echo '<td class="facts_label">';
-			echo '<a href="#" onclick="return openInfowindow(\'', $index, '\')">', $event['fact_label'], '</a></td>';
-			echo '<td class="', $event['class'], '">';
-			if ($event['info']) {
-				echo '<div><span class="field">', Filter::escapeHtml($event['info']), '</span></div>';
-			}
-			if ($event['name']) {
-				echo '<div>', $event['name'], '</div>';
-			}
-			echo '<div>', $event['place'], '</div>';
-			if ($event['date']) {
-				echo '<div>', $event['date'], '</div>';
-			}
-			echo '</td>';
-			echo '</tr>';
-		}
-		echo '</table></div><br>';
 	}
 
 	/**

--- a/modules_v3/googlemap/css/wt_v3_googlemap.css
+++ b/modules_v3/googlemap/css/wt_v3_googlemap.css
@@ -17,10 +17,28 @@
 	margin-top: 10px;
 }
 
+#wrapper {
+	border: 1px solid #888;
+	margin: 2px;
+	display: flex;
+}
+
 #map_pane {
-	border: 1px solid gray;
-	color: black;
-	width: 100%;
+	width: 70%;
+	height: 100%;
+}
+
+#map_events {
+	width: 30%;
+	height: 100%;
+	padding: 0;
+	overflow-y: auto;
+}
+
+.gmoptions {
+	width: 70%;
+	margin: 2px;
+	text-align: center;
 }
 
 div.infowindow {


### PR DESCRIPTION
Uses "display: flex" - tested on Firefox & Chrome latest versions, IE 8 to 11 & edge (desktop & mobile versions using edge's emulation function - thought IE 8&9 should fail but they don't - maybe emulator is faulty) - Also note IE 8 & 9 display a Googlemaps api warning about unsupported browser.

Quite easy to revert to floats if preferred.