### PR TITLE
GoogleMaps pedigree map chart bug fixes

### DIFF
--- a/modules_v3/googlemap/css/wt_v3_googlemap.css
+++ b/modules_v3/googlemap/css/wt_v3_googlemap.css
@@ -248,6 +248,10 @@ ul.tabs a.current {
 	color: #f00;
 }
 
+.list_table {
+	width: 500px;
+}
+
 .optionbox #gname {
 	white-space: normal;
 }
@@ -261,6 +265,22 @@ ul.tabs a.current {
 	font-size: 0.85em;
 	overflow-x: hidden;
 	overflow-y: auto;
+}
+
+.link {
+	min-height: 50px;
+	margin: 5px 0;
+	padding: 0!important;
+	border: 1px solid transparent;
+}
+
+.link_visited {
+	background-color: #ffc;
+	border: 1px solid #ffdd00;
+}
+
+#side_bar .relation {
+	cursor: pointer;
 }
 
 #side_bar .gallery img,
@@ -301,10 +321,6 @@ ul.tabs a.current {
 
 #pedigreemap_chart {
 	margin: 20px;
-}
-
-#side_bar .NAME {
-	padding-left: 5px;
 }
 
 #side_bar img {


### PR DESCRIPTION
- incorrect zoom level when only one place
- sidebar click on "view the individual" goes to wrong destination (bubbles up the DOM to parent click event)

Further - just noticed that ~ lines 1438 to 1499 implement a right click context menu - trouble is it uses googlemaps apiv2 calls which no longer exist. It seems to be a reasonably long winded process to write something new and as it only provides zooming & positioning facilities which can be easily replaced by dragging & (mouse zoom or zoom buttons) I wonder if it's worth it. My vote is to remove it

Later - I've removed it