### PR TITLE
Show old style sources in facts

### DIFF
--- a/app/Functions/FunctionsPrintFacts.php
+++ b/app/Functions/FunctionsPrintFacts.php
@@ -590,11 +590,14 @@ class FunctionsPrintFacts {
 		$nlevel = $level + 1;
 
 		// -- Systems not using source records [ 1046971 ]
+		// -- The old style is not supported when entering sources, but if found in the GEDCOM then display them fully
+		// -- Also, the old style sources allow histo.* files to use tree independent source citations, which
+		// -- will display nicely when markdown is used
 		$ct = preg_match_all("/$level SOUR (.*)/", $factrec, $match, PREG_SET_ORDER);
 		for ($j = 0; $j < $ct; $j++) {
 			if (strpos($match[$j][1], '@') === false) {
-				$data .= '<div class="fact_SOUR"><span class="label">' . I18N::translate('Old Source') . ': </span>';
-				$data .= '<span class="field" dir="auto">' . Filter::escapeHtml($match[$j][1]) . '</span></div>';
+				$source = Filter::escapeHtml($match[$j][1]) . Filter::escapeHtml(Functions::getCont(3, Functions::getSubRecord(2, "2 SOUR", $factrec, $j+1)));
+				$data .= '<div class="fact_SOUR"><span class="label">' . I18N::translate('Source') . ': </span><span class="field" dir="auto">' . Filter::formatText($source, $WT_TREE) . '</span></div>';
 			}
 		}
 		// -- find source for each fact

--- a/app/Functions/FunctionsPrintFacts.php
+++ b/app/Functions/FunctionsPrintFacts.php
@@ -597,7 +597,7 @@ class FunctionsPrintFacts {
 		for ($j = 0; $j < $ct; $j++) {
 			if (strpos($match[$j][1], '@') === false) {
 				$source = Filter::escapeHtml($match[$j][1]) . Filter::escapeHtml(Functions::getCont(3, Functions::getSubRecord(2, "2 SOUR", $factrec, $j+1)));
-				$data .= '<div class="fact_SOUR"><span class="label">' . I18N::translate('Source') . ': </span><span class="field" dir="auto">' . Filter::formatText($source, $WT_TREE) . '</span></div>';
+				$data .= '<div class="fact_SOUR"><span class="label">' . I18N::translate('Source') . ':</span> <span class="field" dir="auto">' . Filter::formatText($source, $WT_TREE) . '</span></div>';
 			}
 		}
 		// -- find source for each fact

--- a/app/Functions/FunctionsPrintFacts.php
+++ b/app/Functions/FunctionsPrintFacts.php
@@ -593,7 +593,8 @@ class FunctionsPrintFacts {
 		$ct = preg_match_all("/$level SOUR (.*)/", $factrec, $match, PREG_SET_ORDER);
 		for ($j = 0; $j < $ct; $j++) {
 			if (strpos($match[$j][1], '@') === false) {
-				$data .= '<div class="fact_SOUR"><span class="label">' . I18N::translate('Source') . ':</span> <span class="field" dir="auto">' . Filter::escapeHtml($match[$j][1]) . '</span></div>';
+				$data .= '<div class="fact_SOUR"><span class="label">' . I18N::translate('Old Source') . ': </span>';
+				$data .= '<span class="field" dir="auto">' . Filter::escapeHtml($match[$j][1]) . '</span></div>';
 			}
 		}
 		// -- find source for each fact


### PR DESCRIPTION
This attempts two things:

1. If any old style sources to facts were imported from a GEDCOM file, this will display the complete source_description record. Currently only the first line (level 2) is used.

2. The source_description is filtered through formatText to allow markdown. This is important to those who implement history files across multiple trees. In this case it is not guaranteed that sources have the same reference number or even that they exist. The latter case results in a page load error just due to the presence of another tree's histo file. One solution would be to use old style source citations. Even though they are not encouraged in the GEDCOM speciication this would be acceptable as they will not form part of a GEDCOM export.  Allowing markdown with old style sources in history files will make it possible, for example, to use clickable links to sources.

The only drawback of my implementation (2) is that it results in the source details being displayed on a new line underneath the "Source:" label.
