### PR TITLE
Let themes use their own menu properties

### DIFF
--- a/app/Controller/FanchartController.php
+++ b/app/Controller/FanchartController.php
@@ -348,7 +348,7 @@ class FanchartController extends ChartController {
 					$html .= '</a>';
 					$html .= '<ul class="charts">';
 					foreach (Theme::theme()->individualBoxMenu($person) as $menu) {
-						$html .= '<li><a href="' . $menu->getLink() . '">' . $menu->getLabel() . '</a></li>';
+						$html .= $menu->getMenuAsList();
 					}
 					$html .= '</ul>';
 					$html .= '</div></div>';


### PR DESCRIPTION
At the Fanchart page menu classes for styling the menu items are no longer used inside the boxes. This code fixes that.