### PR TITLE
Error reporting tweaks

### DIFF
--- a/includes/session.php
+++ b/includes/session.php
@@ -152,10 +152,11 @@ define('WT_ROOT', realpath(dirname(__DIR__)) . DIRECTORY_SEPARATOR);
 define('WT_START_TIME', microtime(true));
 
 // We want to know about all PHP errors during development, and fewer in production.
+// In production, do not overwrite server-defined error reporting.
 if (WT_DEBUG) {
-	error_reporting(E_ALL | E_STRICT | E_NOTICE | E_DEPRECATED);
+	error_reporting(-1);
 } else {
-	error_reporting(E_ALL);
+	error_reporting(error_reporting() & E_ALL & ~E_DEPRECATED);
 }
 
 require WT_ROOT . 'vendor/autoload.php';
@@ -234,7 +235,7 @@ set_exception_handler(function ($ex) {
 		}
 	}
 
-	if (true || error_reporting() & $ex->getCode()) {
+	if (error_reporting() & $ex->getCode()) {
 		echo $message;
 	}
 


### PR DESCRIPTION
Two suggestions:

- First, not sure why the message of an exception should always be shown, even if above the error_reporting level: hence removed the `true ||` line 237

- webtrees is explicitly setting the error_reporting. There is a good reason to do so in development, but I am a bit bothered by overwriting the setting set by the server administrator in production. It can be a good practice to capture all errors, but this is usually done in order to handle them later (typically log them in a back-end), then hide them from the end-user (both for user-experience and security reasons). But here, we are actually displaying all errors. 
  - The PR contains an approach where we use PHP recommended Production value (`E_ALL & ~E_DEPRECATED`), and make sure that we do not overwrite the already set value for error_reporting. There could be another approach where the `set_exception_handler` is reviewed to log all errors, but output only some levels to the user.
  - I have as well used the -1 value for development, as it is future-proof for all error levels (`| E_NOTICE | E_DEPRECATED` is useless anyway with `E_ALL`).

The second suggestion is a bit controversial, so feel free to merge only the first one.