### PR TITLE
Stay in the current tree when logging out

### DIFF
--- a/logout.php
+++ b/logout.php
@@ -15,6 +15,13 @@
  */
 namespace Fisharebest\Webtrees;
 
+/**
+ * Defined in session.php
+ *
+ * @global Tree $WT_TREE
+ */
+global $WT_TREE;
+
 define('WT_SCRIPT_NAME', 'logout.php');
 require './includes/session.php';
 
@@ -24,4 +31,4 @@ if (Auth::id()) {
 	FlashMessages::addMessage(I18N::translate('You have signed out.'), 'info');
 }
 
-header('Location: ' . WT_BASE_URL);
+header('Location: ' . WT_BASE_URL . 'index.php?ged=' . $WT_TREE->getNameUrl());


### PR DESCRIPTION
When logging out a user is always redirected to the homepage of the default tree in stead of to the homepage of the tree the user logged out from. I think the latter should be the default behaviour.

Also see: https://www.webtrees.net/index.php/en/forum/help-for-ver-1-7-7/31527-solved-default-tree#60645