### PR TITLE
Feature/proposal census

### DIFF
--- a/app/Census/CensusColumnNationality.php
+++ b/app/Census/CensusColumnNationality.php
@@ -17,6 +17,7 @@ namespace Fisharebest\Webtrees\Census;
 
 use Fisharebest\Webtrees\Date;
 use Fisharebest\Webtrees\Individual;
+use Fisharebest\Webtrees\I18N;
 
 /**
  * The nationality of the individual.
@@ -40,9 +41,11 @@ class CensusColumnNationality extends AbstractCensusColumn implements CensusColu
 			}
 		}
 
-		$place = explode(', ', $place);
-		$place = end($place);
-
+		// By default, we can assume the nationality is the census's one
+		if(empty($place)) $place = $this->place();
+		
+		$place = $this->lastPartOfPlace($place);
+		
 		if ($place === 'England' || $place === 'Scotland' || $place === 'Wales') {
 			return 'British';
 		} else {

--- a/app/Census/CensusColumnRelationToHead.php
+++ b/app/Census/CensusColumnRelationToHead.php
@@ -17,6 +17,7 @@ namespace Fisharebest\Webtrees\Census;
 
 use Fisharebest\Webtrees\Functions\Functions;
 use Fisharebest\Webtrees\Individual;
+use Fisharebest\Webtrees\I18N;
 
 /**
  * Relationshiop to head of household.
@@ -34,7 +35,7 @@ class CensusColumnRelationToHead extends AbstractCensusColumn implements CensusC
 		if ($head === null) {
 			return '';
 		} elseif ($individual == $head) {
-			return 'head';
+			return /* I18N: head of family */ I18N::translate('head');
 		} else {
 			return Functions::getCloseRelationshipName($head, $individual);
 		}

--- a/tests/app/Census/CensusColumnNationalityTest.php
+++ b/tests/app/Census/CensusColumnNationalityTest.php
@@ -29,6 +29,23 @@ class CensusColumnNationalityTest extends \PHPUnit_Framework_TestCase {
 	public function tearDown() {
 		Mockery::close();
 	}
+	
+	/**
+	 * @covers Fisharebest\Webtrees\Census\CensusColumnNationality
+	 * @covers Fisharebest\Webtrees\Census\AbstractCensusColumn
+	 */
+	public function testNoBirthPlace() {
+	    $individual = Mockery::mock('Fisharebest\Webtrees\Individual');
+	    $individual->shouldReceive('getBirthPlace')->andReturn('');
+	    $individual->shouldReceive('getFacts')->andReturn(array());
+	    
+	    $census = Mockery::mock('Fisharebest\Webtrees\Census\CensusInterface');
+	    $census->shouldReceive('censusPlace')->andReturn('France');
+	    
+	    $column = new CensusColumnNationality($census, '', '');
+	    
+	    $this->assertSame('France', $column->generate($individual));
+	}
 
 	/**
 	 * @covers Fisharebest\Webtrees\Census\CensusColumnNationality


### PR DESCRIPTION
2 proposals:

- In `CensusColumnNationality`, add a suggested nationality rule if no birth place is found: use the census country as a default (+ small improvement to reuse an existing function to extract the country from the place). I appreciate this rule may work better for populations that do not have an important international immigration history (like Europe), maybe not so for countries like US.

- In `CensusColumnRelationToHead`, translate the term _head_ (otherwise it display in English, whereas other relationships to the head are translated in the user's locale). I noted that for German Census used a derived class `CensusColumnRelationToHeadGerman` to translate the term (but it is fixed as well). I am not sure what is the best approach: consistency of the language between _head_ and other relationships, or use of the local Census language term for _head of family_ (but there may be a better way than rewriting the whole `generate` method in sub classes).
(As an aside note, I tried to incorporate better coverage for the `CensusColumnRelationToHeadTest`, but PhpUnit does not play well with the I18N implementation, as we cannot mock static class, and it does not have a bootstrap script to load the minimal session data)