### PR TITLE
Fixes issue #1150

### DIFF
--- a/app/Module/GoogleMapsModule.php
+++ b/app/Module/GoogleMapsModule.php
@@ -2491,6 +2491,7 @@ class GoogleMapsModule extends AbstractModule implements ModuleConfigInterface, 
 
 			// Create the map and mapOptions
 			var mapOptions = {
+				minZoom: ' . $this->getSetting('GM_MIN_ZOOM') . ',
 				zoom: 8,
 				center: map_center,
 				mapTypeId: google.maps.MapTypeId.' . $this->getSetting('GM_MAP_TYPE') . ',


### PR DESCRIPTION
Min zoom level for place hierarchy map set by the parameter in module preferences (value of 1 restricts zoom to "one earth")

BTW Assuming you accept this, do you manage the 1.7 branch or do I need to do something 