### PR TITLE
Distinguish main blocks from side blocks for easy reference

### DIFF
--- a/index.php
+++ b/index.php
@@ -97,7 +97,7 @@ echo '<div class="row">';
 
 if ($blocks['main']) {
 	if ($blocks['side']) {
-		echo '<div class="col-sm-8">';
+		echo '<div class="col-sm-8 wt-main-blocks">';
 	} else {
 		echo '<div class="col-sm-12">';
 	}
@@ -119,7 +119,7 @@ if ($blocks['main']) {
 }
 if ($blocks['side']) {
 	if ($blocks['main']) {
-		echo '<div class="col-sm-4">';
+		echo '<div class="col-sm-4 wt-side-blocks">';
 	} else {
 		echo '<div class="col-sm-12">';
 	}


### PR DESCRIPTION
The new layout doesn't make it easy to distinguish the main part of the homepage/mypage from the side part. As a theme developer I need a reference to those parts for styling purposes (for example a smaller font for the side). At the moment the separate parts can only be referred to as .wt-main-container > row > col-sm-8 or .wt-main-container > row > col-sm-4 which is not very helpful and may lead to unwanted side effects. I don't think one should ever refer to grid classes directly for this kind of stuff.

I hope you will accept this change. Of course feel free to rename the classes to something else.

P.S. I am not sure if this is the way to go in this stage of development. If you rather want this kind of stuff just being reported as issue let me know.