### PR TITLE
Do not try to format date if not in valid range

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -519,7 +519,7 @@ case 'month':
 				default:
 					break 2;
 				}
-				if (get_class($alt_date) !== get_class($cal_date)) {
+				if (get_class($alt_date) !== get_class($cal_date) && $alt_date->inValidRange()) {
 					echo '<span class="rtl_cal_day">' . $alt_date->format('%j %M') . '</span>';
 					// Just show the first conversion
 					break;


### PR DESCRIPTION
When using French calendar as an alternative calendar, calculation of months before the beginning of the calendar creation result in negative months, which causes an exception when trying to format it.
A similar logic exist in Date::display.