### PR TITLE
Activate datatable for module table

### DIFF
--- a/admin_modules.php
+++ b/admin_modules.php
@@ -110,8 +110,7 @@ $controller
 					value.value = index+1;
 				});
 		}
-		$("#installed_table").dataTable( {
-			paging: false,
+		$(".table-module-administration").dataTable( {
 			' . I18N::datatablesI18N() . ',
 			sorting: [[ 1, "asc" ]],
 			columns : [


### PR DESCRIPTION
The module table wasn't functioning as datatable. This changes fixes that. It also uses default paging and filter mode. 

There is a script available to get bootstrap4 layout in datatables, see:

https://datatables.net/examples/styling/bootstrap4.html

I think you should implement that.