### PR TITLE
Show configured family events in the individual box in pedigree chart…

### DIFF
--- a/app/Theme/AbstractTheme.php
+++ b/app/Theme/AbstractTheme.php
@@ -886,11 +886,17 @@ abstract class AbstractTheme {
 		}
 		// Show optional events (before death)
 		foreach ($opt_tags as $key => $tag) {
+			$events = array();
 			if (!preg_match('/^(' . WT_EVENTS_DEAT . ')$/', $tag)) {
-				$event = $individual->getFirstFact($tag);
-				if (!is_null($event)) {
-					$html .= $event->summary();
-					unset($opt_tags[$key]);
+				$events[] = $individual->getFirstFact($tag);
+				foreach ($individual->getSpouseFamilies() as $family) {
+					$events[] = $family->getFirstFact($tag);
+				}
+				foreach ($events as $event) {
+					if (!is_null($event)) {
+						$html .= $event->summary();
+						unset($opt_tags[$key]);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
I wanted to be able to check if I already have a marriage record directly in the pedigree charts. Unfortunately even adding "MARR" to the "Other facts to show in charts" settings in admin_trees_config.php didn't display anything.

This is because, the MARR event actually belongs to the individual's family and not to the Individual object. I have added some code to add family events for these $opt_tags in the individualBoxFacts() function.

This code is working fine with webtrees 1.7.9, other than the fact that it often exceeds the individual's box max-height attribute. But this already happens anyway if you have multiple events in the WT_EVENTS_BIRT and WT_EVENTS_DEAT lists.