### PR TITLE
Pedigree chart arrows

### DIFF
--- a/app/Controller/PedigreeController.php
+++ b/app/Controller/PedigreeController.php
@@ -102,20 +102,20 @@ class PedigreeController extends ChartController {
 		case self::PORTRAIT:
 			//drop through
 		case self::LANDSCAPE:
-			$this->arrows->prevGen = I18N::direction() === 'rtl' ? 'icon-larrow' : 'icon-rarrow';
-			$this->arrows->menu    = I18N::direction() === 'rtl' ? 'icon-rarrow' : 'icon-larrow';
+			$this->arrows->prevGen = 'fa fa-arrow-end wt-icon-arrow-end';
+			$this->arrows->menu    = 'fa fa-arrow-start wt-icon-arrow-start';
 			$addoffset['x']        = $this->chartHasAncestors ? self::ARROW_SIZE : 0;
 			$addoffset['y']        = 0;
 			break;
 		case self::OLDEST_AT_TOP:
-			$this->arrows->prevGen = 'icon-uarrow';
-			$this->arrows->menu    = 'icon-darrow';
+			$this->arrows->prevGen = 'fa fa-arrow-up wt-icon-arrow-up';
+			$this->arrows->menu    = 'fa fa-arrow-down wt-icon-arrow-down';
 			$addoffset['x']        = 0;
 			$addoffset['y']        = $this->root->getSpouseFamilies() ? self::ARROW_SIZE : 0;
 			break;
 		case self::OLDEST_AT_BOTTOM:
-			$this->arrows->prevGen = 'icon-darrow';
-			$this->arrows->menu    = 'icon-uarrow';
+			$this->arrows->prevGen = 'fa fa-arrow-down wt-icon-arrow-down';
+			$this->arrows->menu    = 'fa fa-arrow-up wt-icon-arrow-up';
 			$addoffset['x']        = 0;
 			$addoffset['y']        = $this->chartHasAncestors ? self::ARROW_SIZE : 0;
 			break;

--- a/pedigree.php
+++ b/pedigree.php
@@ -34,10 +34,10 @@ if (Filter::getBool('ajax') && Session::has('initiated')) {
 	//Output the chart
 	foreach ($controller->nodes as $i => $node) {
 		// -- draw the box
-    $flex_direction = '';
-    if ($controller->orientation === $controller::OLDEST_AT_TOP || $controller->orientation === $controller::OLDEST_AT_BOTTOM) {
-      $flex_direction = ' flex-column';
-    }
+		$flex_direction = '';
+		if ($controller->orientation === $controller::OLDEST_AT_TOP || $controller->orientation === $controller::OLDEST_AT_BOTTOM) {
+			$flex_direction = ' flex-column';
+		}
 		printf('<div id="sosa_%s" class="shadow d-flex align-items-center'. $flex_direction . '" style="%s:%spx; top:%spx; position:absolute;">', $i + 1, $posn, $node['x'], $node['y']);
 
 		if ($controller->orientation === $controller::OLDEST_AT_TOP) {

--- a/pedigree.php
+++ b/pedigree.php
@@ -34,7 +34,11 @@ if (Filter::getBool('ajax') && Session::has('initiated')) {
 	//Output the chart
 	foreach ($controller->nodes as $i => $node) {
 		// -- draw the box
-		printf('<div id="sosa_%s" class="shadow" style="%s:%spx; top:%spx; position:absolute;">', $i + 1, $posn, $node['x'], $node['y']);
+    $flex_direction = '';
+    if ($controller->orientation === $controller::OLDEST_AT_TOP || $controller->orientation === $controller::OLDEST_AT_BOTTOM) {
+      $flex_direction = ' flex-column';
+    }
+		printf('<div id="sosa_%s" class="shadow d-flex align-items-center'. $flex_direction . '" style="%s:%spx; top:%spx; position:absolute;">', $i + 1, $posn, $node['x'], $node['y']);
 
 		if ($controller->orientation === $controller::OLDEST_AT_TOP) {
 			if ($i >= $lastgenStart) {


### PR DESCRIPTION
This commit adds the arrows back into the pedigree chart. The placement of the arrows is done by using some bootstrap flexbox classes. Therefore I needed an extra variable to determine if the arrow should be placed next to, below or at the top of the person box.  I am not sure if the naming of this variable is correct according to webtrees standards, but you can rename it of course.

With this solution no extra css is required. However, I didn't remove the current styles from css because I am not sure if this will give conflicts elsewhere.