### PR TITLE
Search forms additional styling

### DIFF
--- a/search.php
+++ b/search.php
@@ -39,14 +39,14 @@ function checknames(frm) {
 		lname = frm.lastname.value;
 		place = frm.place.value;
 
-		if (year == "") {
+		if (year === "") {
 			if (fname.length < 2 && lname.length < 2 && place.length < 2) {
 				alert("<?= I18N::translate('Please enter more than one character.') ?>");
 				return false;
 			}
 		}
 
-		if (year != "") {
+		if (year !== "") {
 			if (fname === "" && lname === "" && place === "") {
 				alert("<?= I18N::translate('Please enter a given name, surname, or place in addition to the year') ?>");
 				frm.firstname.focus();
@@ -60,9 +60,9 @@ function checknames(frm) {
 </script>
 
 <div id="search-page">
-<h2><?= $controller->getPageTitle() ?></h2>
-<?php if ($controller->action === 'general'): ?>
-	<form class="wt-page-options wt-page-options-ancestors-chart hidden-print" name="searchform" onsubmit="return checknames(this);">
+	<h2 class="wt-page-title"><?= $controller->getPageTitle() ?></h2>
+	<?php if ($controller->action === 'general'): ?>
+	<form class="wt-page-options wt-page-options-search hidden-print" name="searchform" onsubmit="return checknames(this);">
 		<input type="hidden" name="action" value="general">
 		<input type="hidden" name="isPostBack" value="true">
 		<div class="row form-group">
@@ -70,8 +70,10 @@ function checknames(frm) {
 			<?= I18N::translate('Search for') ?>
 			</label>
 			<div class="col-sm-9 wt-page-options-value">
-				<input id="query" type="text" name="query" value="<?= Html::escape($controller->query) ?>" autofocus>
-			<?= FunctionsPrint::printSpecialCharacterLink('query') ?>
+				<div class="input-group input-group-sm">
+					<input id="query" class="form-control form-control-sm" type="text" name="query" value="<?= Html::escape($controller->query) ?>" autofocus>
+					<span class="input-group-addon"><?= FunctionsPrint::printSpecialCharacterLink('query') ?></span>
+				</div>
 			</div>
 		</div>
 		<fieldset class="form-group">
@@ -111,47 +113,53 @@ function checknames(frm) {
 			<label class="col-sm-3 col-form-label wt-page-options-label">
 			<?= I18N::translate('Associates') ?>
 			</label>
-			<div class="col-sm-9 wt-page-options-value wt-page-options-size">
-				<input id="showasso" name="showasso" value="1" type="checkbox">
-				<label for="showasso">
-				<?= I18N::translate('Show related individuals/families') ?>
-				</label>
+			<div class="col-sm-9 wt-page-options-value">
+				<div class="form-check">
+					<label class="form-check-label">
+					<input class="form-check-input" name="showasso" value="checked" type="checkbox">
+					<?= I18N::translate('Show related individuals/families') ?>
+					</label>
+				</div>
 			</div>
 		</div>
-			<?php if (count(Tree::getAll()) > 1 && Site::getPreference('ALLOW_CHANGE_GEDCOM') === '1'): ?>
-			<?php if (count(Tree::getAll()) > 3): ?>
-				<div class="label"></div>
-				<div class="value">
-					<input type="button" value="<?= /* I18N: select all (of the family trees) */ I18N::translate('select all') ?>" onclick="$('#search_trees :checkbox').each(function(){$(this).attr('checked', true);});return false;">
-					<input type="button" value="<?= /* I18N: select none (of the family trees) */ I18N::translate('select none') ?>" onclick="$('#search_trees :checkbox').each(function(){$(this).attr('checked', false);});return false;">
-					<?php if (count(Tree::getAll()) > 10): ?>
-						<input type="button" value="<?= I18N::translate('invert selection') ?>" onclick="$('#search_trees :checkbox').each(function(){$(this).attr('checked', !$(this).attr('checked'));});return false;">
-					<?php endif ?>
-				</div>
-			<?php endif ?>
+		
+		<?php if (count(Tree::getAll()) > 1 && Site::getPreference('ALLOW_CHANGE_GEDCOM') === '1'): ?>			
 		<fieldset class="form-group">
 			<div class="row">
 				<label class="col-sm-3 col-form-label wt-page-options-label">
 					<?= I18N::translate('Family trees') ?>
 				</label>
-				<div class="col-sm-9 wt-page-options-value">
-					<div class="form-check form-check-inline">
-						<?php foreach (Tree::getAll() as $tree): ?>
-						<label class="form-check-label">
-							<input class="form-check form-check-input" type="checkbox" <?= in_array($tree, $controller->search_trees) ? 'checked' : '' ?> value="yes" id="tree_<?= $tree->getTreeId() ?>" name="tree_<?= $tree->getTreeId() ?>">
-							<?= $tree->getTitleHtml() ?>
-						</label>
-						<br>
-						<?php endforeach ?>
+				<div class="col-sm-9 wt-page-options-value pt-2">
+					<div class="d-flex justify-content-between">
+						<div id="search-trees" class="form-check">
+							<?php foreach (Tree::getAll() as $tree): ?>
+							<div class="col px-0">
+								<label class="form-check-label">
+									<input class="form-check form-check-input" type="checkbox" <?= in_array($tree, $controller->search_trees) ? 'checked' : '' ?> value="yes" id="tree_<?= $tree->getTreeId() ?>" name="tree_<?= $tree->getTreeId() ?>">
+									<?= $tree->getTitleHtml() ?>
+								</label>
+							</div>
+							<?php endforeach ?>
+						</div>
+						<?php if (count(Tree::getAll()) > 3): ?>
+						<div class="d-row align-self-end mb-2">
+							<input type="button" class="btn btn-sm btn-secondary mx-1" value="<?= /* I18N: select all (of the family trees) */ I18N::translate('select all') ?>" onclick="$('#search-trees :checkbox').each(function(){$(this).attr('checked', true);});return false;">
+							<input type="button" class="btn btn-sm btn-secondary mx-1" value="<?= /* I18N: select none (of the family trees) */ I18N::translate('select none') ?>" onclick="$('#search-trees :checkbox').each(function(){$(this).attr('checked', false);});return false;">
+							<?php if (count(Tree::getAll()) > 10): ?>
+								<input type="button" value="<?= I18N::translate('invert selection') ?>" onclick="$('#search_trees :checkbox').each(function(){$(this).attr('checked', !$(this).attr('checked'));});return false;">
+							<?php endif ?>
+							<?php endif ?>
+						</div>
 					</div>
 				</div>
 			</div>
-		<?php endif ?>
 		</fieldset>
+		<?php endif ?>
+		
 		<div class="row form-group">
 			<label class="col-sm-3 col-form-label wt-page-options-label"></label>
 			<div class="col-sm-9 wt-page-options-value">
-				<input type="submit" value="<?=  /* I18N: A button label. */ I18N::translate('search') ?>">
+				<input type="submit" class="btn btn-primary" value="<?=  /* I18N: A button label. */ I18N::translate('search') ?>">
 			</div>
 		</div>
 	</form>
@@ -166,7 +174,7 @@ function checknames(frm) {
 				<?= I18N::translate('Search for') ?>
 			</label>
 			<div class="col-sm-9 wt-page-options-value">
-				<input name="query" value="<?= Html::escape($controller->query) ?>" type="text" autofocus>
+				<input class="form-control form-control-sm" name="query" value="<?= Html::escape($controller->query) ?>" type="text" autofocus>
 			</div>
 		</div>
 		<div class="row form-group">
@@ -174,7 +182,7 @@ function checknames(frm) {
 				<?= I18N::translate('Replace with') ?>
 			</label>
 			<div class="col-sm-9 wt-page-options-value">
-				<input name="replace" value="<?= Html::escape($controller->replace) ?>" type="text">
+				<input class="form-control form-control-sm" name="replace" value="<?= Html::escape($controller->replace) ?>" type="text">
 			</div>
 		</div>
 			<script>
@@ -198,34 +206,38 @@ function checknames(frm) {
 			<label class="col-sm-3 col-form-label wt-page-options-label">
 			<?= /* I18N: A button label. */ I18N::translate('Search') ?>
 			</label>
-			<div class="col-sm-9 wt-page-options-value wt-page-options-replace ">
-				<input <?= $controller->replaceAll ?> onclick="checkAll(this);" value="checked" name="replaceAll" type="checkbox">
-				<label>
-					<?= I18N::translate('Entire record') ?>
-				</label>
+			<div class="col-sm-9 wt-page-options-value">
+				<div class="form-check mt-2">
+					<label class="form-check-label">
+						<input class="form-check-input" <?= $controller->replaceAll ?> onclick="checkAll(this);" value="checked" name="replaceAll" type="checkbox">
+						<?= I18N::translate('Entire record') ?>
+					</label>
+				</div>
 				<hr>
-				<div class="form-check form-check-inline wt-page-options-size ">
-					<label>
-						<input <?= $controller->replaceNames ?> <?= $controller->replaceAll ? 'disabled' : '' ?> value="checked" name="replaceNames" type="checkbox">
+				<div class="form-check">
+					<label class="form-check-label">
+						<input class="form-check-input" <?= $controller->replaceNames ?> <?= $controller->replaceAll ? 'disabled' : '' ?> value="checked" name="replaceNames" type="checkbox">
 						<?= I18N::translate('Names') ?>
 					</label>
-					<br>
-					<label>
-						<input <?= $controller->replacePlaces ?> <?= $controller->replaceAll ? 'disabled' : '' ?> value="checked" name="replacePlaces" type="checkbox">
+				</div>
+				<div class="form-check">
+					<label class="form-check-label">
+						<input class="form-check-input" <?= $controller->replacePlaces ?> <?= $controller->replaceAll ? 'disabled' : '' ?> value="checked" name="replacePlaces" type="checkbox">
 						<?= I18N::translate('Places') ?>
 					</label>
-					<br>
-					<label>
-						<input <?= $controller->replacePlacesWord ?> <?= $controller->replaceAll ? 'disabled' : '' ?> value="checked" name="replacePlacesWord" type="checkbox">
+				</div>
+				<div class="form-check">
+					<label class="form-check-label">
+						<input class="form-check-input" <?= $controller->replacePlacesWord ?> <?= $controller->replaceAll ? 'disabled' : '' ?> value="checked" name="replacePlacesWord" type="checkbox">
 						<?= I18N::translate('Whole words only') ?>
 					</label>
 				</div>
 			</div>
 		</div>
-			<div class="row form-group">
+		<div class="row form-group">
 			<label class="col-sm-3 col-form-label wt-page-options-label"></label>
-				<div class="col-sm-9 wt-page-options-value">
-				<input type="submit" value="<?= /* I18N: A button label. */ I18N::translate('replace') ?>">
+			<div class="col-sm-9 wt-page-options-value">
+				<input class="btn btn-primary" type="submit" value="<?= /* I18N: A button label. */ I18N::translate('replace') ?>">
 			</div>
 		</div>
 	</form>
@@ -239,7 +251,10 @@ function checknames(frm) {
 				<?= I18N::translate('Given name') ?>
 			</label>
 			<div class="col-sm-9 wt-page-options-value">
-				<input type="text" data-autocomplete-type="GIVN" name="firstname" id="firstname" value="<?= Html::escape($controller->firstname) ?>" autofocus>
+				<div class="input-group input-group-sm">
+					<input class= "form-control form-control-sm" type="text" name="firstname" id="firstname" value="<?= Html::escape($controller->firstname) ?>" autofocus>
+					<span class="input-group-addon"><?= FunctionsPrint::printSpecialCharacterLink('query') ?></span>
+				</div>
 			</div>
 		</div>
 		<div class="row form-group">
@@ -247,7 +262,10 @@ function checknames(frm) {
 				<?= I18N::translate('Surname') ?>
 			</label>
 			<div class="col-sm-9 wt-page-options-value">
-				<input type="text" data-autocomplete-type="SURN" name="lastname" id="lastname" value="<?= Html::escape($controller->lastname) ?>">
+				<div class="input-group input-group-sm">
+					<input class="form-control form-control-sm" type="text" name="lastname" id="lastname" value="<?= Html::escape($controller->lastname) ?>">
+					<span class="input-group-addon"><?= FunctionsPrint::printSpecialCharacterLink('query') ?></span>
+				</div>
 			</div>
 		</div>
 		<div class="row form-group">
@@ -255,7 +273,7 @@ function checknames(frm) {
 				<?= I18N::translate('Place') ?>
 			</label>
 			<div class="col-sm-9 wt-page-options-value">
-				<input type="text"  data-autocomplete-type="PLAC2" name="place" id="place" value="<?= Html::escape($controller->place) ?>">
+				<input class="form-control form-control-sm" type="text" name="place" id="place" value="<?= Html::escape($controller->place) ?>">
 			</div>
 		</div>
 		<div class="row form-group">
@@ -263,7 +281,7 @@ function checknames(frm) {
 				<?= I18N::translate('Year') ?>
 			</label>
 			<div class="col-sm-9 wt-page-options-value">
-				<input type="text" name="year" id="year" value="<?= Html::escape($controller->year) ?>">
+				<input class="form-control form-control-sm" type="text" name="year" id="year" value="<?= Html::escape($controller->year) ?>">
 			</div>
 		</div>
 		<fieldset class="form-group">
@@ -291,47 +309,52 @@ function checknames(frm) {
 				<label class="col-sm-3 col-form-label wt-page-options-label">
 				<?= I18N::translate('Associates') ?>
 				</label>
-				<div class="col-sm-9 wt-page-options-value wt-page-options-size">
-					<input id="showasso" name="showasso" value="1" type="checkbox">
-					<label for="showasso">
-					<?= I18N::translate('Show related individuals/families') ?>
-					</label>
+				<div class="col-sm-9 wt-page-options-value">
+					<div class="form-check">
+						<label class="form-check-label">
+						<input class="form-check-input" id="showasso" name="showasso" value="1" type="checkbox">
+						<?= I18N::translate('Show related individuals/families') ?>
+						</label>
+					</div>
 				</div>
 			</div>
+
 			<?php if (count(Tree::getAll()) > 1 && Site::getPreference('ALLOW_CHANGE_GEDCOM') === '1'): ?>
-			<?php if (count(Tree::getAll()) > 3): ?>
-					<div class="label"></div>
-					<div class="value">
-						<input type="button" value="<?= /* I18N: select all (of the family trees) */ I18N::translate('select all') ?>" onclick="$('#search_trees :checkbox').each(function(){$(this).attr('checked', true);});return false;">
-						<input type="button" value="<?= /* I18N: select none (of the family trees) */ I18N::translate('select none') ?>" onclick="$('#search_trees :checkbox').each(function(){$(this).attr('checked', false);});return false;">
-						<?php if (count(Tree::getAll()) > 10): ?>
-							<input type="button" value="<?= I18N::translate('invert selection') ?>" onclick="$('#search_trees :checkbox').each(function(){$(this).attr('checked', !$(this).attr('checked'));});return false;">
-						<?php endif ?>
-					</div>
-				<?php endif ?>
 			<fieldset class="form-group">
 				<div class="row">
 					<label class="col-sm-3 col-form-label wt-page-options-label">
 						<?= I18N::translate('Family trees') ?>
 					</label>
-					<div class="col-sm-9 wt-page-options-value">
-						<div class="form-check form-check-inline">
-							<?php foreach (Tree::getAll() as $tree): ?>
-							<label class="form-check-label">
-								<input class="form-check form-check-input" type="checkbox" <?= in_array($tree, $controller->search_trees) ? 'checked' : '' ?> value="yes" id="tree_<?= $tree->getTreeId() ?>" name="tree_<?= $tree->getTreeId() ?>">
-								<?= $tree->getTitleHtml() ?>
-							</label>
-							<br>
-							<?php endforeach ?>
+					<div class="col-sm-9 wt-page-options-value pt-2">
+						<div class="d-flex justify-content-between">
+							<div id="search-trees" class="form-check">
+								<?php foreach (Tree::getAll() as $tree): ?>
+								<div class="col px-0">
+									<label class="form-check-label">
+										<input class="form-check form-check-input" type="checkbox" <?= in_array($tree, $controller->search_trees) ? 'checked' : '' ?> value="yes" id="tree_<?= $tree->getTreeId() ?>" name="tree_<?= $tree->getTreeId() ?>">
+										<?= $tree->getTitleHtml() ?>
+									</label>
+								</div>
+								<?php endforeach ?>
+							</div>
+							<?php if (count(Tree::getAll()) > 3): ?>
+							<div class="d-row align-self-end mb-2">
+								<input type="button" class="btn btn-sm btn-secondary mx-1" value="<?= /* I18N: select all (of the family trees) */ I18N::translate('select all') ?>" onclick="$('#search-trees :checkbox').each(function(){$(this).attr('checked', true);});return false;">
+								<input type="button" class="btn btn-sm btn-secondary mx-1" value="<?= /* I18N: select none (of the family trees) */ I18N::translate('select none') ?>" onclick="$('#search-trees :checkbox').each(function(){$(this).attr('checked', false);});return false;">
+								<?php if (count(Tree::getAll()) > 10): ?>
+									<input type="button" value="<?= I18N::translate('invert selection') ?>" onclick="$('#search_trees :checkbox').each(function(){$(this).attr('checked', !$(this).attr('checked'));});return false;">
+								<?php endif ?>
+								<?php endif ?>
+							</div>
 						</div>
 					</div>
 				</div>
-			<?php endif ?>
 			</fieldset>
+			<?php endif ?>
 			<div class="row form-group">
 				<label class="col-sm-3 col-form-label wt-page-options-label"></label>
 				<div class="col-sm-9 wt-page-options-value">
-					<input type="submit" value="<?=  /* I18N: A button label. */ I18N::translate('search') ?>">
+					<input type="submit" class="btn btn-primary" value="<?=  /* I18N: A button label. */ I18N::translate('search') ?>">
 				</div>
 			</div>
 	</form>

--- a/search_advanced.php
+++ b/search_advanced.php
@@ -37,11 +37,12 @@ $controller->pageHeader();
 	 */
 	function addFields() {
 		var tbl         = document.getElementById('div-holder');
-		var trow        = document.createElement('dir');
-		trow.className      = 'row form-group';
+		var trow        = document.createElement('div');
+		trow.className	= 'row form-group';
 		var label       = document.createElement('div');
-		label.className = 'col-sm-3-add col-form-label wt-page-options-label';
+		label.className = 'col-sm-3 wt-page-options-label py-1';
 		var sel         = document.createElement('select');
+		sel.className	= 'form-control form-control-sm';
 		sel.name        = 'fields[' + numfields + ']';
 		sel.rownum      = numfields;
 		sel.onchange    = function () {
@@ -58,15 +59,16 @@ $controller->pageHeader();
 		label.appendChild(sel);
 		trow.appendChild(label);
 		// create the new value cell
-		var val       = document.createElement('div');
-		val.id        = 'vcell' + numfields;
-		val.className = 'col-sm-9-add wt-page-options-value';
+		var val			= document.createElement('div');
+		val.id			= 'vcell' + numfields;
+		val.className	= 'col-sm-9 wt-page-options-value form-row py-1';
 
-		var inp      = document.createElement('input');
-		inp.name     = 'values[' + numfields + ']';
-		inp.type     = 'text';
-		inp.id       = 'value' + numfields;
-		inp.tabindex = numfields + 1;
+		var inp			= document.createElement('input');
+		inp.name		= 'values[' + numfields + ']';
+		inp.className	= 'form-control form-control-sm col-9';
+		inp.type		= 'text';
+		inp.id			= 'value' + numfields;
+		inp.tabindex	= numfields + 1;
 		val.appendChild(inp);
 		trow.appendChild(val);
 		var lastRow = tbl.lastChild.previousSibling;
@@ -88,25 +90,26 @@ $controller->pageHeader();
 		}
 		// if it is a date and the plusminus is already show, then leave
 		if (pm) return;
-		var elm   = document.getElementById('vcell' + row);
-		var sel   = document.createElement('select');
-		sel.id    = 'plusminus' + row;
-		sel.name  = 'plusminus[' + row + ']';
-		var opt   = document.createElement('option');
-		opt.value = '';
-		opt.text  = '<?= I18N::translate('Exact date') ?>';
+		var elm			= document.getElementById('vcell' + row);
+		var sel			= document.createElement('select');
+		sel.id			= 'plusminus' + row;
+		sel.name		= 'plusminus[' + row + ']';
+		sel.className	= 'form-control form-control-sm col-3';
+		var opt			= document.createElement('option');
+		opt.value		= '';
+		opt.text		= '<?= I18N::translate('Exact date') ?>';
 		sel.appendChild(opt);
-		opt       = document.createElement('option');
-		opt.value = '';
-		opt.text  = '<?= I18N::plural('±%s year', '±%s years', 2, I18N::number(2)) ?>';
+		opt				= document.createElement('option');
+		opt.value		= '';
+		opt.text		= '<?= I18N::plural('±%s year', '±%s years', 2, I18N::number(2)) ?>';
 		sel.appendChild(opt);
-		opt       = document.createElement('option');
-		opt.value = '5';
-		opt.text  = '<?= I18N::plural('±%s year', '±%s years', 5, I18N::number(5)) ?>';
+		opt				= document.createElement('option');
+		opt.value		= '5';
+		opt.text		= '<?= I18N::plural('±%s year', '±%s years', 5, I18N::number(5)) ?>';
 		sel.appendChild(opt);
-		opt       = document.createElement('option');
-		opt.value = '10';
-		opt.text  = '<?= I18N::plural('±%s year', '±%s years', 10, I18N::number(10)) ?>';
+		opt				= document.createElement('option');
+		opt.value		= '10';
+		opt.text		= '<?= I18N::plural('±%s year', '±%s years', 10, I18N::number(10)) ?>';
 		sel.appendChild(opt);
 		var spc = document.createTextNode(' ');
 		elm.appendChild(spc);
@@ -116,123 +119,123 @@ $controller->pageHeader();
 
 <div id="advanced-search-page">
 	<h2 class="wt-page-title"><?= $controller->getPageTitle() ?></h2>
-	<form class="wt-page-options wt-page-options-ancestors-chart hidden-print" name="searchform" onsubmit="return checknames(this);">
+	<form class="wt-page-options wt-page-options-search-advanced hidden-print" name="searchform" onsubmit="return checknames(this);">
 		<input type="hidden" name="action" value="<?= $controller->action ?>">
 		<input type="hidden" name="isPostBack" value="true">
-			<div id="div-holder">
+		<div id="div-holder">
 			<?php
-				$fct = count($controller->fields);
-					for ($i = 0; $i < $fct; $i++) {
-						if (strpos($controller->getField($i), 'FAMC:HUSB:NAME') === 0) {
-						continue;
-						}
-						if (strpos($controller->getField($i), 'FAMC:WIFE:NAME') === 0) {
-						continue;
-						}
-						?>
-					<div class="row form-group">
-						<label class="col-sm-3 col-form-label wt-page-options-label">
-						<?= $controller->getLabel($controller->getField($i)) ?>
-						</label>
+			$fct = count($controller->fields);
+			for ($i = 0; $i < $fct; $i++):
+				if (strpos($controller->getField($i), 'FAMC:HUSB:NAME') === 0) {
+					continue;
+				}
+				if (strpos($controller->getField($i), 'FAMC:WIFE:NAME') === 0) {
+					continue;
+				}
+				?>
+				<div class="row form-group">
+					<label class="col-sm-3 col-form-label wt-page-options-label">
+					<?= $controller->getLabel($controller->getField($i)) ?>
+					</label>
 					<?php
 					$currentFieldSearch = $controller->getField($i); // Get this field’s name and the search criterion
 					$currentField       = substr($currentFieldSearch, 0, strrpos($currentFieldSearch, ':')); // Get the actual field name
 					?>
-						<div class="col-sm-9 wt-page-options-value">
-						<input type="text" id="value<?= $i ?>" name="values[<?= $i ?>]"
-						value="<?= Html::escape($controller->getValue($i)) ?>"<?= substr($controller->getField($i), -4) == 'PLAC' ? ' data-autocomplete-type="PLAC"' : '' ?>>
-						<?php if (preg_match('/^NAME:/', $currentFieldSearch) > 0) { ?>
-								<select name="fields[<?= $i ?>]">
-									<option value="<?= $currentField ?>:EXACT" <?php if (preg_match('/:EXACT$/', $currentFieldSearch) > 0) echo 'selected' ?>>
-										<?= I18N::translate('Exact') ?>
-									</option>
-									<option value="<?= $currentField ?>:BEGINS" <?php if (preg_match('/:BEGINS$/', $currentFieldSearch) > 0) echo 'selected' ?>>
-										<?= I18N::translate('Begins with') ?>
-									</option>
-									<option value="<?= $currentField ?>:CONTAINS" <?php if (preg_match('/:CONTAINS$/', $currentFieldSearch) > 0) echo 'selected' ?>>
-										<?= I18N::translate('Contains') ?>
-									</option>
-									<option value="<?= $currentField ?>:SDX" <?php if (preg_match('/:SDX$/', $currentFieldSearch) > 0) echo 'selected' ?>><?= I18N::translate('Sounds like') ?>
-									</option>
-								</select>
-							<?php } else { ?>
-								<input type="hidden" name="fields[<?= $i ?>]" value="<?= $controller->getField($i) ?>">
-							<?php }
-							if (preg_match('/:DATE$/', $currentFieldSearch) > 0) {
-								?>
-								<select name="plusminus[<?= $i ?>]">
-									<option value="">
-										<?= I18N::translate('Exact date') ?>
-									</option>
-									<option value="2" <?php if (!empty($controller->plusminus[$i]) && $controller->plusminus[$i] == 2) echo 'selected' ?>>
-										<?= I18N::plural('±%s year', '±%s years', 2, I18N::number(2)) ?>
-									</option>
-									<option value="5" <?php if (!empty($controller->plusminus[$i]) && $controller->plusminus[$i] == 5) echo 'selected' ?>>
-										<?= I18N::plural('±%s year', '±%s years', 5, I18N::number(5)) ?>
-									</option>
-									<option value="10" <?php if (!empty($controller->plusminus[$i]) && $controller->plusminus[$i] == 10) echo 'selected' ?>>
-										<?= I18N::plural('±%s year', '±%s years', 10, I18N::number(10)) ?>
-									</option>
-								</select>
-							<?php } ?>
-						</div>
-						<?php
-						//-- relative fields
-						if ($i == 0 && $fct > 4) {
-							$j = $fct;
-							// Get the current options for Father’s and Mother’s name searches
-							$fatherGivnOption = 'SDX';
-							$fatherSurnOption = 'SDX';
-							$motherGivnOption = 'SDX';
-							$motherSurnOption = 'SDX';
-							for ($k = 0; $k < $fct; $k++) {
-								$searchField  = $controller->getField($k);
-								$searchOption = substr($searchField, 20); // Assume we have something like "FAMC:HUSB:NAME:GIVN:foo"
-								switch (substr($searchField, 0, 20)) {
-								case 'FAMC:HUSB:NAME:GIVN:':
-									$fatherGivnOption = $searchOption;
-									break;
-								case 'FAMC:HUSB:NAME:SURN:':
-									$fatherSurnOption = $searchOption;
-									break;
-								case 'FAMC:WIFE:NAME:GIVN:':
-									$motherGivnOption = $searchOption;
-									break;
-								case 'FAMC:WIFE:NAME:SURN:':
-									$motherSurnOption = $searchOption;
-									break;
-								}
-							}
+					<div class="col-sm-9 wt-page-options-value form-row mx-0">
+						<input class="form-control form-control-sm col-9" type="text" id="value<?= $i ?>" name="values[<?= $i ?>]"
+					value="<?= Html::escape($controller->getValue($i)) ?>">
+						<?php if (preg_match('/^NAME:/', $currentFieldSearch) > 0): ?>
+							<select class="form-control form-control-sm col-3" name="fields[<?= $i ?>]">
+								<option value="<?= $currentField ?>:EXACT" <?php if (preg_match('/:EXACT$/', $currentFieldSearch) > 0) echo 'selected' ?>>
+									<?= I18N::translate('Exact') ?>
+								</option>
+								<option value="<?= $currentField ?>:BEGINS" <?php if (preg_match('/:BEGINS$/', $currentFieldSearch) > 0) echo 'selected' ?>>
+									<?= I18N::translate('Begins with') ?>
+								</option>
+								<option value="<?= $currentField ?>:CONTAINS" <?php if (preg_match('/:CONTAINS$/', $currentFieldSearch) > 0) echo 'selected' ?>>
+									<?= I18N::translate('Contains') ?>
+								</option>
+								<option value="<?= $currentField ?>:SDX" <?php if (preg_match('/:SDX$/', $currentFieldSearch) > 0) echo 'selected' ?>><?= I18N::translate('Sounds like') ?>
+								</option>
+							</select>
+						<?php else: ?>
+							<input type="hidden" name="fields[<?= $i ?>]" value="<?= $controller->getField($i) ?>">
+						<?php endif;
+						if (preg_match('/:DATE$/', $currentFieldSearch) > 0) {
 							?>
+							<select class="form-control form-control-sm col-3" name="plusminus[<?= $i ?>]">
+								<option value="">
+									<?= I18N::translate('Exact date') ?>
+								</option>
+								<option value="2" <?php if (!empty($controller->plusminus[$i]) && $controller->plusminus[$i] == 2) echo 'selected' ?>>
+									<?= I18N::plural('±%s year', '±%s years', 2, I18N::number(2)) ?>
+								</option>
+								<option value="5" <?php if (!empty($controller->plusminus[$i]) && $controller->plusminus[$i] == 5) echo 'selected' ?>>
+									<?= I18N::plural('±%s year', '±%s years', 5, I18N::number(5)) ?>
+								</option>
+								<option value="10" <?php if (!empty($controller->plusminus[$i]) && $controller->plusminus[$i] == 10) echo 'selected' ?>>
+									<?= I18N::plural('±%s year', '±%s years', 10, I18N::number(10)) ?>
+								</option>
+							</select>
 						<?php } ?>
 					</div>
-			<?php } ?>
+					<?php
+					//-- relative fields
+					if ($i == 0 && $fct > 4) {
+						$j = $fct;
+						// Get the current options for Father’s and Mother’s name searches
+						$fatherGivnOption = 'SDX';
+						$fatherSurnOption = 'SDX';
+						$motherGivnOption = 'SDX';
+						$motherSurnOption = 'SDX';
+						for ($k = 0; $k < $fct; $k++) {
+							$searchField  = $controller->getField($k);
+							$searchOption = substr($searchField, 20); // Assume we have something like "FAMC:HUSB:NAME:GIVN:foo"
+							switch (substr($searchField, 0, 20)) {
+							case 'FAMC:HUSB:NAME:GIVN:':
+								$fatherGivnOption = $searchOption;
+								break;
+							case 'FAMC:HUSB:NAME:SURN:':
+								$fatherSurnOption = $searchOption;
+								break;
+							case 'FAMC:WIFE:NAME:GIVN:':
+								$motherGivnOption = $searchOption;
+								break;
+							case 'FAMC:WIFE:NAME:SURN:':
+								$motherSurnOption = $searchOption;
+								break;
+							}
+						}
+					}
+					?>
+				</div>
+			<?php endfor; ?>
 			<!--  father -->
-			<div class="row form-group">
-				<div class="width100 center details_label form-label wt-page-options-label">
-			<?= I18N::translate('Father') ?>
+			<div class="row form-group wt-page-options-label">
+				<div class="form-row mx-auto">
+					<?= I18N::translate('Father') ?>
 				</div>
 			</div>
 			<div class="row form-group">
 				<label class="col-sm-3 col-form-label wt-page-options-label">
 					<?= I18N::translate('Given names') ?>
 				</label>
-				<div class="col-sm-9 wt-page-options-value">
-					<input type="text" name="values[<?= $j ?>]" value="<?= $controller->getValue($controller->getIndex('FAMC:HUSB:NAME:GIVN:' . $fatherGivnOption)) ?>">
-						<select name="fields[<?= $j ?>]">
-							<option value="FAMC:HUSB:NAME:GIVN:EXACT" <?php if ($fatherGivnOption == 'EXACT') echo 'selected' ?>>
-								<?= I18N::translate('Exact') ?>
-							</option>
-							<option value="FAMC:HUSB:NAME:GIVN:BEGINS" <?php if ($fatherGivnOption == 'BEGINS') echo 'selected' ?>>
-								<?= I18N::translate('Begins with') ?>
-							</option>
-							<option value="FAMC:HUSB:NAME:GIVN:CONTAINS" <?php if ($fatherGivnOption == 'CONTAINS') echo 'selected' ?>>
-								<?= I18N::translate('Contains') ?>
-							</option>
-							<option value="FAMC:HUSB:NAME:GIVN:SDX" <?php if ($fatherGivnOption == 'SDX') echo 'selected' ?>>
-								<?= I18N::translate('Sounds like') ?>
-							</option>
-						</select>
+				<div class="col-sm-9 wt-page-options-value form-row mx-0">
+					<input class="form-control form-control-sm col-9" type="text" name="values[<?= $j ?>]" value="<?= $controller->getValue($controller->getIndex('FAMC:HUSB:NAME:GIVN:' . $fatherGivnOption)) ?>">
+					<select class="form-control form-control-sm col-3" name="fields[<?= $j ?>]">
+						<option value="FAMC:HUSB:NAME:GIVN:EXACT" <?php if ($fatherGivnOption == 'EXACT') echo 'selected' ?>>
+							<?= I18N::translate('Exact') ?>
+						</option>
+						<option value="FAMC:HUSB:NAME:GIVN:BEGINS" <?php if ($fatherGivnOption == 'BEGINS') echo 'selected' ?>>
+							<?= I18N::translate('Begins with') ?>
+						</option>
+						<option value="FAMC:HUSB:NAME:GIVN:CONTAINS" <?php if ($fatherGivnOption == 'CONTAINS') echo 'selected' ?>>
+							<?= I18N::translate('Contains') ?>
+						</option>
+						<option value="FAMC:HUSB:NAME:GIVN:SDX" <?php if ($fatherGivnOption == 'SDX') echo 'selected' ?>>
+							<?= I18N::translate('Sounds like') ?>
+						</option>
+					</select>
 				</div>
 			</div>
 			<?php $j++ ?>
@@ -240,91 +243,89 @@ $controller->pageHeader();
 				<label class="col-sm-3 col-form-label wt-page-options-label">
 					<?= I18N::translate('Surname') ?>
 				</label>
-				<div class="col-sm-9 wt-page-options-value">
-					<input type="text" name="values[<?= $j ?>]" value="<?= $controller->getValue($controller->getIndex('FAMC:HUSB:NAME:SURN:' . $fatherSurnOption)) ?>">
-						<select name="fields[<?= $j ?>]">
-							<option value="FAMC:HUSB:NAME:SURN:EXACT" <?php if ($fatherSurnOption == 'EXACT') echo 'selected' ?>>
-								<?= I18N::translate('Exact') ?>
-							</option>
-							<option value="FAMC:HUSB:NAME:SURN:BEGINS" <?php if ($fatherSurnOption == 'BEGINS') echo 'selected' ?>>
-								<?= I18N::translate('Begins with') ?>
-							</option>
-							<option value="FAMC:HUSB:NAME:SURN:CONTAINS" <?php if ($fatherSurnOption == 'CONTAINS') echo 'selected' ?>>
-								<?= I18N::translate('Contains') ?>
-							</option>
-							<option value="FAMC:HUSB:NAME:SURN:SDX" <?php if ($fatherSurnOption == 'SDX') echo 'selected' ?>>
-								<?= I18N::translate('Sounds like') ?>
-							</option>
-						</select>
+				<div class="col-sm-9 wt-page-options-value form-row mx-0">
+					<input class="form-control form-control-sm col-9" type="text" name="values[<?= $j ?>]" value="<?= $controller->getValue($controller->getIndex('FAMC:HUSB:NAME:SURN:' . $fatherSurnOption)) ?>">
+					<select class="form-control form-control-sm col-3" name="fields[<?= $j ?>]">
+						<option value="FAMC:HUSB:NAME:SURN:EXACT" <?php if ($fatherSurnOption == 'EXACT') echo 'selected' ?>>
+							<?= I18N::translate('Exact') ?>
+						</option>
+						<option value="FAMC:HUSB:NAME:SURN:BEGINS" <?php if ($fatherSurnOption == 'BEGINS') echo 'selected' ?>>
+							<?= I18N::translate('Begins with') ?>
+						</option>
+						<option value="FAMC:HUSB:NAME:SURN:CONTAINS" <?php if ($fatherSurnOption == 'CONTAINS') echo 'selected' ?>>
+							<?= I18N::translate('Contains') ?>
+						</option>
+						<option value="FAMC:HUSB:NAME:SURN:SDX" <?php if ($fatherSurnOption == 'SDX') echo 'selected' ?>>
+							<?= I18N::translate('Sounds like') ?>
+						</option>
+					</select>
 				</div>
 			</div>
 			<!--  mother -->
 			<?php $j++ ?>
-			<div class="row form-group">
-				<div class="width100 center details_label form-label wt-page-options-label">
-			<?= I18N::translate('Mother') ?>
+			<div class="row form-group wt-page-options-label">
+				<div class="form-row mx-auto">
+					<?= I18N::translate('Mother') ?>
 				</div>
 			</div>
 			<div class="row form-group">
 				<label class="col-sm-3 col-form-label wt-page-options-label">
 					<?= I18N::translate('Given names') ?>
 				</label>
-				<div class="col-sm-9 wt-page-options-value">
-					<input type="text" name="values[<?= $j ?>]" value="<?= $controller->getValue($controller->getIndex('FAMC:WIFE:NAME:GIVN:' . $motherGivnOption)) ?>">
-						<select name="fields[<?= $j ?>]">
-							<option value="FAMC:WIFE:NAME:GIVN:EXACT" <?php if ($motherGivnOption == 'EXACT') echo 'selected' ?>>
-								<?= I18N::translate('Exact') ?>
-							</option>
-							<option value="FAMC:WIFE:NAME:GIVN:BEGINS" <?php if ($motherGivnOption == 'BEGINS') echo 'selected' ?>>
-								<?= I18N::translate('Begins with') ?>
-							</option>
-							<option value="FAMC:WIFE:NAME:GIVN:CONTAINS" <?php if ($motherGivnOption == 'CONTAINS') echo 'selected' ?>>
-								<?= I18N::translate('Contains') ?>
-							</option>
-							<option value="FAMC:WIFE:NAME:GIVN:SDX" <?php if ($motherGivnOption == 'SDX') echo 'selected' ?>>
-								<?= I18N::translate('Sounds like') ?>
-							</option>
-						</select>
-					</div>
+				<div class="col-sm-9 wt-page-options-value form-row mx-0">
+					<input class="form-control form-control-sm col-9" type="text" name="values[<?= $j ?>]" value="<?= $controller->getValue($controller->getIndex('FAMC:WIFE:NAME:GIVN:' . $motherGivnOption)) ?>">
+					<select class="form-control form-control-sm col-3" name="fields[<?= $j ?>]">
+						<option value="FAMC:WIFE:NAME:GIVN:EXACT" <?php if ($motherGivnOption == 'EXACT') echo 'selected' ?>>
+							<?= I18N::translate('Exact') ?>
+						</option>
+						<option value="FAMC:WIFE:NAME:GIVN:BEGINS" <?php if ($motherGivnOption == 'BEGINS') echo 'selected' ?>>
+							<?= I18N::translate('Begins with') ?>
+						</option>
+						<option value="FAMC:WIFE:NAME:GIVN:CONTAINS" <?php if ($motherGivnOption == 'CONTAINS') echo 'selected' ?>>
+							<?= I18N::translate('Contains') ?>
+						</option>
+						<option value="FAMC:WIFE:NAME:GIVN:SDX" <?php if ($motherGivnOption == 'SDX') echo 'selected' ?>>
+							<?= I18N::translate('Sounds like') ?>
+						</option>
+					</select>
 				</div>
-				<?php $j++ ?>
+			</div>
+			<?php $j++ ?>
 			<div class="row form-group">
 				<label class="col-sm-3 col-form-label wt-page-options-label">
 					<?= I18N::translate('Surname') ?>
 				</label>
-				<div class="col-sm-9 wt-page-options-value">
-					<input type="text" name="values[<?= $j ?>]" value="<?= $controller->getValue($controller->getIndex('FAMC:WIFE:NAME:GIVN:' . $motherGivnOption)) ?>">
-						<select name="fields[<?= $j ?>]">
-							<option value="FAMC:WIFE:NAME:GIVN:EXACT" <?php if ($motherGivnOption == 'EXACT') echo 'selected' ?>>
-								<?= I18N::translate('Exact') ?>
-							</option>
-							<option value="FAMC:WIFE:NAME:GIVN:BEGINS" <?php if ($motherGivnOption == 'BEGINS') echo 'selected' ?>>
-								<?= I18N::translate('Begins with') ?>
-							</option>
-							<option value="FAMC:WIFE:NAME:GIVN:CONTAINS" <?php if ($motherGivnOption == 'CONTAINS') echo 'selected' ?>>
-								<?= I18N::translate('Contains') ?>
-							</option>
-							<option value="FAMC:WIFE:NAME:GIVN:SDX" <?php if ($motherGivnOption == 'SDX') echo 'selected' ?>>
-								<?= I18N::translate('Sounds like') ?>
-							</option>
-						</select>
+				<div class="col-sm-9 wt-page-options-value form-row mx-0">
+					<input class="form-control form-control-sm col-9" type="text" name="values[<?= $j ?>]" value="<?= $controller->getValue($controller->getIndex('FAMC:WIFE:NAME:GIVN:' . $motherGivnOption)) ?>">
+					<select class="form-control form-control-sm col-3" name="fields[<?= $j ?>]">
+						<option value="FAMC:WIFE:NAME:GIVN:EXACT" <?php if ($motherGivnOption == 'EXACT') echo 'selected' ?>>
+							<?= I18N::translate('Exact') ?>
+						</option>
+						<option value="FAMC:WIFE:NAME:GIVN:BEGINS" <?php if ($motherGivnOption == 'BEGINS') echo 'selected' ?>>
+							<?= I18N::translate('Begins with') ?>
+						</option>
+						<option value="FAMC:WIFE:NAME:GIVN:CONTAINS" <?php if ($motherGivnOption == 'CONTAINS') echo 'selected' ?>>
+							<?= I18N::translate('Contains') ?>
+						</option>
+						<option value="FAMC:WIFE:NAME:GIVN:SDX" <?php if ($motherGivnOption == 'SDX') echo 'selected' ?>>
+							<?= I18N::translate('Sounds like') ?>
+						</option>
+					</select>
 				</div>
 			</div>
 			<?php $j++ ?>
-			<div>
-				<div>
-					<div class="center" style="margin-top:10px;">
-							<a href="#" onclick="addFields();"><?= I18N::translate('Add more fields') ?></a>
-					</div>
+			<div class="row form-group my-3">
+				<div class="form-row mx-auto">
+					<a href="#" onclick="addFields();return false;"><?= I18N::translate('Add more fields') ?></a>
 				</div>
 			</div>
-			<?php $j++ ?>
-		</div>
-		<div class="center" style="margin-top:10px;">
-			<p><input type="submit" value="<?= /* I18N: A button label. */
-				I18N::translate('search') ?>"></p>
-		</div>
-
-	</form>
 		</div> <!-- Close of div-holder -->
-		<?php $controller->printResults() ?>
+		<?php $j++ ?>
+		<div class="row form-group my-3">
+			<div class="form-row mx-auto">
+				<input type="submit" class="btn btn-primary" value="<?=  /* I18N: A button label. */ I18N::translate('search') ?>">
+			</div>
+		</div>
+	</form>
+	<?php $controller->printResults() ?>
+</div>

--- a/themes/_common/css-2.0.0/style.css
+++ b/themes/_common/css-2.0.0/style.css
@@ -223,16 +223,6 @@
     flex-flow: row;
 }
 
- /* advanced search enhancements */
-.col-sm-3-add {
-	flex: 0 0 50%;
-	max-width: 50%;
-}
-.col-sm-9-add{
-	flex: 0 0 50%;
-	max-width: 50%;
-}
-
 /*
  * Any element that is loaded dynamically has the class wt-ajax-load.
  * We can provide a "loading" placeholder for empty elements with this class.
@@ -497,25 +487,6 @@
  *
  * wt-search-page, wt-general-serach-page/wt-phonetic-search-page/wt-advanced-search-page/wt-search-replace-page
  */
-/* ===== search.php ===== */
- #search-page h2 {
-	margin: 20px;
-	text-align: center;
- }
- 
-#div-holder .row {
-	padding: 0;
-}
-.wt-page-options-value > input {
-	width: 300px;
-}
-.wt-page-options-size > input {
-	width: 0px;
-}
-
-.wt-page-options-replace > input {
-	width: auto;
-}
 
 /* Some menus (e.g. languages) can be longer than a page */
 .dropdown-menu {
@@ -633,7 +604,7 @@ fieldset.row > legend, fieldset.row > div {
 	#individual-tabs .nav-link {
 		padding: .5em;
 	}
-	
+
 .col-form-label,
 .col-form-legend {
 	text-align: center;


### PR DESCRIPTION
I did some additional styling on the search forms. Added the bootstrap form-controls to the fields and made input-groups where necessary (general form and replace form).

Further I've moved the buttons select all/select nothing to a imho better position. Placing them in the box with the tree selection makes it more clear these buttons belong to these checkboxes. See the preview below:

**Old**:
![9-9-2017 10-04-30](https://user-images.githubusercontent.com/5641963/30243515-56fef9a4-95ab-11e7-8c4a-6a6402407720.jpg)

**New**:
![9-9-2017 11-04-25](https://user-images.githubusercontent.com/5641963/30243516-62af76e8-95ab-11e7-9a4f-eb992a9fdbd4.jpg)

I've also found some validation errors in the advanced search form (missing closing div and a closing div placed at the wrong position) which I've fixed.
Further I've removed all references to the old autocomplete function. I wasn't sure whether to implement select2 fields or not, so I haven't done that at the moment.

Another issue is the keyboard icon is not functioning. I don't know how to solve it.
