### PR TITLE
fix user admin page link in the user verify notification letter

### DIFF
--- a/resources/views/emails/verify-notify-html.php
+++ b/resources/views/emails/verify-notify-html.php
@@ -12,8 +12,8 @@
 	<?= I18N::translate('You need to review the account details.') ?>
 </p>
 
-<a href="<?= e(route('admin_users-edit', ['user_id' => $user->getUserId()])) ?>">
-	<?= e(route('admin_users-edit', ['user_id' => $user->getUserId()])) ?>
+<a href="<?= e(route('admin-users-edit', ['user_id' => $user->getUserId()])) ?>">
+	<?= e(route('admin-users-edit', ['user_id' => $user->getUserId()])) ?>
 </a>
 
 <ul>

--- a/resources/views/emails/verify-notify-text.php
+++ b/resources/views/emails/verify-notify-text.php
@@ -6,7 +6,7 @@
 
 <?= I18N::translate('You need to review the account details.') ?>
 
-<?= route('admin_users-edit', ['user_id' => $user->getUserId()]) ?>
+<?= route('admin-users-edit', ['user_id' => $user->getUserId()]) ?>
 
 <?= /* I18N: You need to: */ I18N::translate('Set the status to “approved”.') ?>
 <?= /* I18N: You need to: */ I18N::translate('Set the access level for each tree.') ?>


### PR DESCRIPTION
In the letter a moderator gets to review new user's profile there is a typo in the url so they can't get to the page unless manually fix `admin_users-edit` to `admin-users-edit`.