### PR TITLE
Tree error check message fix

### DIFF
--- a/resources/views/admin/trees-check.php
+++ b/resources/views/admin/trees-check.php
@@ -18,6 +18,6 @@
 	<?php endforeach ?>
 
 	<?php if (empty($errors) && empty($warnings)): ?>
-		<li class="list-group-item">', I18N::translate('No errors have been found.'), '</li>
+		<li class="list-group-item"><?= I18N::translate('No errors have been found.') ?></li>
 	<?php endif ?>
 </ul>


### PR DESCRIPTION
If there are no errors have been found during the tree check, a creepy message «', I18N::translate('No errors have been found.'), '» appears.