### PR TITLE
A user registration fix

### DIFF
--- a/resources/views/emails/register-notify-html.php
+++ b/resources/views/emails/register-notify-html.php
@@ -4,7 +4,7 @@
 </p>
 
 <p>
-	<?= /* I18N: %s is a server name/URL */I18N::translate('A prospective user has registered with webtrees at %s.', WT_BASE_URL . ' ' . $tree->getTitleHtml()) ?>
+	<?= /* I18N: %s is a server name/URL */I18N::translate('A prospective user has registered with webtrees at %s.', WT_BASE_URL . ' ' . e($tree->getTitle())) ?>
 </p>
 
 <dl>

--- a/resources/views/emails/register-notify-text.php
+++ b/resources/views/emails/register-notify-text.php
@@ -1,7 +1,7 @@
 <?php namespace Fisharebest\Webtrees; ?>
 <?= I18N::translate('Hello administrator…') ?>
 
-<?= /* I18N: %s is a server name/URL */I18N::translate('A prospective user has registered with webtrees at %s.', WT_BASE_URL . ' ' . $tree->getTitleHtml()) ?>
+<?= /* I18N: %s is a server name/URL */I18N::translate('A prospective user has registered with webtrees at %s.', WT_BASE_URL . ' ' . e($tree->getTitle())) ?>
 
 <?= I18N::translate('Username') ?> - <?= e($user->getUserName()) ?>
 <?= I18N::translate('Real name') ?> - <?= e($user->getRealName()) ?>


### PR DESCRIPTION
While composing an e-mail, there occurs an exception:

Uncaught Error: Call to undefined method Fisharebest\Webtrees\Tree::getTitleHtml() in resources/views/emails/register-notify-text.php:4

So a user gets their e-mail, but the administrator doesn't. So does not `User::create` routinge get called, user e-mail verification fails; as a tip of the cake, the user gets «Hello administrator...»·on the screen.