### PR TITLE
Incorrect famid used in getPrimaryChildFamily

### DIFF
--- a/app/Individual.php
+++ b/app/Individual.php
@@ -881,19 +881,22 @@ class Individual extends GedcomRecord {
 			default:
 				// If there is more than one FAMC record, choose the preferred parents:
 				// a) records with '2 _PRIMARY'
-				foreach ($families as $famid => $fam) {
+				foreach ($families as $fam) {
+					$famid = $fam->getXref();
 					if (preg_match("/\n1 FAMC @{$famid}@\n(?:[2-9].*\n)*(?:2 _PRIMARY Y)/", $this->getGedcom())) {
 						return $fam;
 					}
 				}
 				// b) records with '2 PEDI birt'
-				foreach ($families as $famid => $fam) {
+				foreach ($families as $fam) {
+					$famid = $fam->getXref();
 					if (preg_match("/\n1 FAMC @{$famid}@\n(?:[2-9].*\n)*(?:2 PEDI birth)/", $this->getGedcom())) {
 						return $fam;
 					}
 				}
 				// c) records with no '2 PEDI'
-				foreach ($families as $famid => $fam) {
+				foreach ($families as $fam) {
+					$famid = $fam->getXref();
 					if (!preg_match("/\n1 FAMC @{$famid}@\n(?:[2-9].*\n)*(?:2 PEDI)/", $this->getGedcom())) {
 						return $fam;
 					}


### PR DESCRIPTION
The logic in `getPrimaryChildFamily` wrongly assumes that the key of the returned array from `getChildFamilies` is the Family Xref (whereas it is just the numercal index). As a consequence, `$famid` does not contain the correct value, and the checks are flawed (and will certainly fall back to the first family).

Looking at the code history, the bug seems quite old, but I guess that it has been a case rare enough for an individual to have multiple FAMC records, and the first not being the primary one, that it has not been reported before.