### PR TITLE
Fatal error: Uncaught TypeError: Argument 1 passed I18N::init() must …

### DIFF
--- a/app/Http/Controllers/SetupController.php
+++ b/app/Http/Controllers/SetupController.php
@@ -256,7 +256,7 @@ class SetupController extends AbstractBaseController
     private function checkLanguage(Request $request): bool
     {
         try {
-            I18N::init($request->get('lang'));
+            I18N::init($request->get('lang', ''));
         } catch (Exception $ex) {
             DebugBar::addThrowable($ex);
 


### PR DESCRIPTION
… be of the type string, null given, called in \app\Http\Controllers\SetupController.php on line 259