### PR TITLE
Update TopSurnamesModule.php

### DIFF
--- a/app/Module/TopSurnamesModule.php
+++ b/app/Module/TopSurnamesModule.php
@@ -103,9 +103,11 @@ class TopSurnamesModule extends AbstractModule implements ModuleBlockInterface
                 $content = FunctionsPrintLists::surnameTagCloud($all_surnames, 'individual-list', true, $tree);
                 break;
             case 'list':
+                uasort($all_surnames,  array($this, 'surnameCountSort'));
                 $content = FunctionsPrintLists::surnameList($all_surnames, 1, true, 'individual-list', $tree);
                 break;
             case 'array':
+                uasort($all_surnames,  array($this, 'surnameCountSort'));
                 $content = FunctionsPrintLists::surnameList($all_surnames, 2, true, 'individual-list', $tree);
                 break;
             case 'table':
@@ -215,5 +217,18 @@ class TopSurnamesModule extends AbstractModule implements ModuleBlockInterface
             'infoStyle'   => $infoStyle,
             'info_styles' => $info_styles,
         ]);
+    }
+
+    /**
+     * Sort (lists of counts of similar) surname by total count.
+     *
+     * @param string[] $a
+     * @param string[] $b
+     *
+     * @return int
+     */
+    private function surnameCountSort(array $a, array $b): int
+    {
+        return array_sum($b) - array_sum($a);
     }
 }


### PR DESCRIPTION
This fixes to sorting of the surnames module. Currently the surnames are not sorted in list/array view in the right way.

Or is in the second SQL only the part `AND n_type != '_MARNM' AND n_surn NOT IN ('@N.N.', '')"` missing?

Compare 1.7.10 (https://dev.webtrees.net/demo-stable/index.php?ctype=user&ged=demo) with 2.0.0 (https://dev.webtrees.net/demo-dev/index.php?route=user-page&ged=demo).