### PR TITLE
Check if sub-record instance has been retrieved

### DIFF
--- a/app/Fact.php
+++ b/app/Fact.php
@@ -438,7 +438,7 @@ class Fact
         $citations = [];
         foreach ($matches as $match) {
             $source = Source::getInstance($match[2], $this->getParent()->getTree());
-            if ($source->canShow()) {
+            if ($source && $source->canShow()) {
                 $citations[] = $match[1];
             }
         }
@@ -483,7 +483,7 @@ class Fact
         preg_match_all('/\n2 OBJE @(' . WT_REGEX_XREF . ')@/', $this->getGedcom(), $matches);
         foreach ($matches[1] as $match) {
             $obje = Media::getInstance($match, $this->getParent()->getTree());
-            if ($obje->canShow()) {
+            if ($obje && $obje->canShow()) {
                 $media[] = $obje;
             }
         }


### PR DESCRIPTION
```getInstance``` is used to retrieve Source / Media subrecords instances, but the code does not check an object has actually been  retrieved before invoking the ```canShow``` method on it.
That can cause an issue if the object reference is somehow corrupted, and is therefore not found.