### PR TITLE
Fix reselecting batch update plugin.

### DIFF
--- a/resources/views/modules/batch_update/admin.phtml
+++ b/resources/views/modules/batch_update/admin.phtml
@@ -27,7 +27,7 @@
                 <?php endif ?>
 
                 <?php foreach ($plugins as $key => $value) : ?>
-                    <option value="<?= $key ?>" <?= ($plugin ? '\\' . get_class($plugin) : null) === $key ? 'selected' : '' ?>>
+                    <option value="<?= $key ?>" <?= ($plugin ? get_class($plugin) : null) === $key ? 'selected' : '' ?>>
                         <?= $value->getName() ?>
                     </option>
                 <?php endforeach ?>


### PR DESCRIPTION
Hello,

When you change option of a batch update plugin, the page reload but the plugin isn't correctly reselected because of a \ in excess. And if you reselect plugin, you loose the chosen option. Making plugins' option unusable.