### PR TITLE
Set Content-Disposition:attachment header if download is requested

### DIFF
--- a/mediafirewall.php
+++ b/mediafirewall.php
@@ -377,9 +377,11 @@ if ($if_modified_since === $filetimeHeader) {
     }
 }
 
+$disposition = (Filter::getBool('dl')) ? 'attachment' : 'inline';
+
 // send headers for the image
 header('Content-Type: ' . $mimetype);
-header('Content-Disposition: filename="' . addslashes(basename($media->getFilename())) . '"');
+header('Content-Disposition: ' . $disposition . '; filename="' . addslashes(basename($media->getFilename())) . '"');
 
 if ($generatewatermark) {
     // generate the watermarked image


### PR DESCRIPTION
I wanted to open a source (im my case a pdf file) on my phone. Unfortunately in Firefox for Android it is not possible to save a target of a link directly to the phone by holding long on a link. Instead Firefox will respect the `Content-Dispostion` header of the response. Because webtrees responses always with `Content-Disposition: filename="filename.pdf"` (which fallbacks to `Content-Disposition: inline; filename="filename.pdf"`, [see](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition#As_a_response_header_for_the_main_body)) Firefox directly forwards the link to the resource to Adobe reader which cannot download the file (I assume because of missing authorization).

This PR fixes this by setting the `Content-Disposition: attachment; filename="filename.pdf"` header which indicates the browser to save the file instead of open it directly. This header will only set if the GET parameter `dl=1` is set which is true if the text link "Download file" under a media is clicked. In all other cases `inline` will be set as it was before.