### PR TITLE
Add "id" attribute to radio buttons

### DIFF
--- a/resources/views/admin/map-provider.phtml
+++ b/resources/views/admin/map-provider.phtml
@@ -11,9 +11,9 @@
                 <?= I18N::translate('Map provider') ?>
             </div>
             <div class="col-sm-9">
-                <?= view('components/radio', ['name' => 'provider', 'value' => '', 'checked' => $provider === '', 'text' => 'Do not use maps']) ?>
+                <?= view('components/radio', ['id' => 'provider-default', 'name' => 'provider', 'value' => '', 'checked' => $provider === '', 'text' => 'Do not use maps']) ?>
                 <hr>
-                <?= view('components/radio', ['name' => 'provider', 'value' => 'OpenStreetMap.Mapnik', 'checked' => $provider === 'OpenStreetMap.Mapnik', 'text' => 'OpenStreetMap']) ?>
+                <?= view('components/radio', ['id' => 'provider-openstreetmap', 'name' => 'provider', 'value' => 'OpenStreetMap.Mapnik', 'checked' => $provider === 'OpenStreetMap.Mapnik', 'text' => 'OpenStreetMap']) ?>
                 <hr>
                 <!-- @TODO - other mapping providers (may need API keys, etc.) -->
             </div>

--- a/resources/views/components/radio.phtml
+++ b/resources/views/components/radio.phtml
@@ -1,6 +1,6 @@
 <div class="form-check">
-	<input class="form-check-input" type="radio" name="<?= e($name) ?>" id="radio-<?= e($name) ?>-no" value="<?= $value ?>" <?= $checked ? 'checked' : '' ?>>
-	<label class="form-check-label" for="radio-<?= e($name) ?>-no">
+	<input class="form-check-input" type="radio" name="<?= e($name) ?>" id="radio-<?= e($id ?? $name) ?>-no" value="<?= $value ?>" <?= $checked ? 'checked' : '' ?>>
+	<label class="form-check-label" for="radio-<?= e($id ?? $name) ?>-no">
     <?= $text ?>
 	</label>
 </div>


### PR DESCRIPTION
Allows to specify an "id" attribute while creating a radio button. If "id" is not provided the "name" will be used.