### PR TITLE
Varius fixes to the statistics

### DIFF
--- a/app/Statistics/Google/ChartBirth.php
+++ b/app/Statistics/Google/ChartBirth.php
@@ -53,7 +53,7 @@ class ChartBirth extends AbstractGoogle
     private function queryRecords(): array
     {
         $query = DB::table('dates')
-            ->selectRaw('ROUND((d_year - 50) / 100) AS century')
+            ->selectRaw('ROUND((d_year + 49) / 100) AS century')
             ->selectRaw('COUNT(*) AS total')
             ->where('d_file', '=', $this->tree->id())
             ->where('d_year', '<>', 0)

--- a/app/Statistics/Google/ChartChildren.php
+++ b/app/Statistics/Google/ChartChildren.php
@@ -55,7 +55,7 @@ class ChartChildren extends AbstractGoogle
     {
         $query = DB::table('families')
             ->selectRaw('ROUND(AVG(f_numchil), 2) AS num')
-            ->selectRaw('ROUND((d_year - 50) / 100) AS century')
+            ->selectRaw('ROUND((d_year + 49) / 100) AS century')
             ->join('dates', function (JoinClause $join) {
                 $join->on('d_file', '=', 'f_file')
                     ->on('d_gid', '=', 'f_id');

--- a/app/Statistics/Google/ChartDeath.php
+++ b/app/Statistics/Google/ChartDeath.php
@@ -53,7 +53,7 @@ class ChartDeath extends AbstractGoogle
     private function queryRecords(): array
     {
         $query = DB::table('dates')
-            ->selectRaw('ROUND((d_year - 50) / 100) AS century')
+            ->selectRaw('ROUND((d_year + 49) / 100) AS century')
             ->selectRaw('COUNT(*) AS total')
             ->where('d_file', '=', $this->tree->id())
             ->where('d_year', '<>', 0)

--- a/app/Statistics/Google/ChartDivorce.php
+++ b/app/Statistics/Google/ChartDivorce.php
@@ -53,7 +53,7 @@ class ChartDivorce extends AbstractGoogle
     private function queryRecords(): array
     {
         $query = DB::table('dates')
-            ->selectRaw('ROUND((d_year - 50) / 100) AS century')
+            ->selectRaw('ROUND((d_year + 49) / 100) AS century')
             ->selectRaw('COUNT(*) AS total')
             ->where('d_file', '=', $this->tree->id())
             ->where('d_year', '<>', 0)

--- a/app/Statistics/Google/ChartMarriage.php
+++ b/app/Statistics/Google/ChartMarriage.php
@@ -53,7 +53,7 @@ class ChartMarriage extends AbstractGoogle
     private function queryRecords(): array
     {
         $query = DB::table('dates')
-            ->selectRaw('ROUND((d_year - 50) / 100) AS century')
+            ->selectRaw('ROUND((d_year + 49) / 100) AS century')
             ->selectRaw('COUNT(*) AS total')
             ->where('d_file', '=', $this->tree->id())
             ->where('d_year', '<>', 0)

--- a/app/Statistics/Google/ChartNoChildrenFamilies.php
+++ b/app/Statistics/Google/ChartNoChildrenFamilies.php
@@ -57,7 +57,7 @@ class ChartNoChildrenFamilies extends AbstractGoogle
     private function queryRecords(int $year1, int $year2): array
     {
         $query = DB::table('families')
-            ->selectRaw('ROUND((d_year - 50) / 100) AS century')
+            ->selectRaw('ROUND((d_year + 49) / 100) AS century')
             ->selectRaw('COUNT(*) AS total')
             ->join('dates', function (JoinClause $join) {
                 $join->on('d_file', '=', 'f_file')

--- a/app/Statistics/Repository/FamilyRepository.php
+++ b/app/Statistics/Repository/FamilyRepository.php
@@ -254,6 +254,7 @@ class FamilyRepository
 
         $top10 = [];
 
+        /** @var Family $family */
         foreach ($families as $family) {
             if ($type === 'list') {
                 $top10[] = '<li><a href="' . e($family->url()) . '">' . $family->fullName() . '</a></li>';
@@ -854,7 +855,8 @@ class FamilyRepository
             ->join('dates AS childbirth', function (JoinClause $join): void {
                 $join
                     ->on('childbirth.d_file', '=', 'parentfamily.l_file')
-                    ->on('childbirth.d_gid', '=', 'childfamily.l_to');
+                    ->on('childbirth.d_gid', '=', 'childfamily.l_to')
+                    ->where('childbirth.d_fact', '=', 'BIRT');
             })
             ->where('childfamily.l_file', '=', $this->tree->id())
             ->where('parentfamily.l_type', '=', $sex_field)

--- a/app/Statistics/Repository/IndividualRepository.php
+++ b/app/Statistics/Repository/IndividualRepository.php
@@ -109,9 +109,9 @@ class IndividualRepository implements IndividualRepositoryInterface
                 // Exclude initials and particles.
                 if (!preg_match('/^([A-Z]|[a-z]{1,3})$/', $given)) {
                     if (\array_key_exists($given, $nameList)) {
-                        $nameList[$given] += $count;
+                        $nameList[$given] += (int) $count;
                     } else {
-                        $nameList[$given] = $count;
+                        $nameList[$given] = (int) $count;
                     }
                 }
             }


### PR DESCRIPTION
Due the recent changes to use the illuminate db component, some statistics have been broken.

I changed calculating the century from:

    ROUND((d_year - 50) / 100) AS century

back to:

    FLOOR((d_year / 100) + 1) AS century

as the rounding was faulty and the 21st century was missing.

FLOOR seems to be a valid standard SQL method according to the following page:
https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators?hl=de#floor