### PR TITLE
Fix 'Check for errors' for trees with _LOC records.

### DIFF
--- a/app/Http/Controllers/AdminTreesController.php
+++ b/app/Http/Controllers/AdminTreesController.php
@@ -221,6 +221,7 @@ class AdminTreesController extends AbstractBaseController
                 'SOUR',
                 'OBJE',
                 '_LOC',
+                'NOTE',
             ],
         ];
 


### PR DESCRIPTION
This was already partially supported, now extended to linked NOTE records (which otherwise caused error: '_LOC L1 has a NOTE link to N1. This type of link is not allowed here.')