### PR TITLE
Update I18N.php

### DIFF
--- a/app/I18N.php
+++ b/app/I18N.php
@@ -385,7 +385,7 @@ class I18N
         $rebuild_cache = time() > $filemtime + 3600;
         // Rebuild files if any translation file has been updated
         foreach ($translation_files as $translation_file) {
-            if (filemtime($translation_file) > $filemtime) {
+            if (file_exists($translation_file) && filemtime($translation_file) > $filemtime) {
                 $rebuild_cache = true;
                 break;
             }
@@ -394,8 +394,10 @@ class I18N
         if ($rebuild_cache) {
             $translations = [];
             foreach ($translation_files as $translation_file) {
-                $translation  = new Translation($translation_file);
-                $translations = array_merge($translations, $translation->asArray());
+                if (file_exists($translation_file)) {
+                    $translation = new Translation($translation_file);
+                    $translations = array_merge($translations, $translation->asArray());
+                }
             }
             try {
                 File::mkdir($cache_dir);


### PR DESCRIPTION
Check that language files exists, otherwise exception will be thrown.

ErrorException: filemtime(): stat failed for /resources/lang/de/messages.mo in file /app/I18N.php on line 388
Stack trace:
  1. ErrorException->() /app/I18N.php:388
  2. filemtime() /app/I18N.php:388
  3. Fisharebest\Webtrees\I18N->init() /app/Http/Middleware/UseLocale.php:47
  4. Fisharebest\Webtrees\Http\Middleware\UseLocale->handle() /index.php:161
  5. {closure}() /app/Http/Middleware/UseTree.php:58
  6. Fisharebest\Webtrees\Http\Middleware\UseTree->handle() /index.php:161
  7. {closure}() /app/Http/Middleware/UseSession.php:59
  8. Fisharebest\Webtrees\Http\Middleware\UseSession->handle() /index.php:161
  9. {closure}() /app/Http/Middleware/UseFilesystem.php:50
 10. Fisharebest\Webtrees\Http\Middleware\UseFilesystem->handle() /index.php:161
 11. {closure}() /app/Http/Middleware/CheckForMaintenanceMode.php:48
 12. Fisharebest\Webtrees\Http\Middleware\CheckForMaintenanceMode->handle() /index.php:161
 13. {closure}() /index.php:178