### PR TITLE
Fix for #1377, second attempt

### DIFF
--- a/resources/views/edit/add-fact.phtml
+++ b/resources/views/edit/add-fact.phtml
@@ -12,6 +12,20 @@
 
     <?php FunctionsEdit::createAddForm($tree, $fact) ?>
 
+    <?php 
+      if (($record::RECORD_TYPE === 'SOUR') && ($fact === 'DATA')) {
+        // SOUR:DATA facts may take a NOTE
+        echo view('cards/add-note', [
+            'level' => 2,
+            'tree' => $tree,
+        ]);
+        echo view('cards/add-shared-note', [
+            'level' => 2,
+            'tree' => $tree,
+        ]);
+      }
+    ?>
+
     <?php if (($record::RECORD_TYPE === 'INDI' || $record::RECORD_TYPE === 'FAM') && $fact !== 'OBJE' && $fact !== 'NOTE' && $fact !== 'SHARED_NOTE' && $fact !== 'REPO' && $fact !== 'SOUR' && $fact !== 'SUBM' && $fact !== 'ASSO' && $fact !== 'ALIA' && $fact !== 'SEX') : ?>
         <?= view('cards/add-source-citation', [
             'level'          => 2,

--- a/resources/views/edit/edit-fact.phtml
+++ b/resources/views/edit/edit-fact.phtml
@@ -14,6 +14,25 @@
     <?php
     $level1type = $edit_fact->getTag();
     switch ($record::RECORD_TYPE) {
+        case 'SOUR':
+            // SOUR:DATA facts may take a NOTE (but the SOUR record may not).
+            if ($level1type === 'DATA') {
+                echo view('cards/add-note', [
+                    'level' => 2,
+                    'tree' => $tree,
+                ]);
+                echo view('cards/add-shared-note', [
+                    'level' => 2,
+                    'tree' => $tree,
+                ]);
+            }
+            // SOUR:DATA facts may also take multiple EVEN.
+            if ($level1type === 'DATA') {
+                echo view('cards/add-sour-data-even', [
+                    'tree' => $tree,
+                ]);              
+            }
+            break;
         case 'FAM':
         case 'INDI':
             // FAM and INDI records have real facts. They can take NOTE/SOUR/OBJE/etc.


### PR DESCRIPTION
Allows adding multiple EVENs and NOTEs, when editing a SOUR:DATA fact.
Allows adding NOTE when adding a SOUR:DATA fact.

The changes in `edit-fact.phtml` are from a previous pull request (they had not been merged).
On this occasion, I have adjusted `add-fact.phtml` accordingly.
I'm aware all of this (SOUR:DATA:EVEN) is a rather exotic part of the specification, and probably doesn't have high priority - I think after this we'll be done with this finally.
