### PR TITLE
Adjust css classes for pending edits

### DIFF
--- a/app/Http/Controllers/IndividualController.php
+++ b/app/Http/Controllers/IndividualController.php
@@ -228,9 +228,9 @@ class IndividualController extends AbstractBaseController
             $aria          = 'true';
         }
         if ($fact->isPendingDeletion()) {
-            $container_class .= ' old';
+            $container_class .= ' wt-old';
         } elseif ($fact->isPendingAddition()) {
-            $container_class .= ' new';
+            $container_class .= ' wt-new';
         }
 
         ob_start();
@@ -323,9 +323,9 @@ class IndividualController extends AbstractBaseController
 
         $container_class = 'card';
         if ($fact->isPendingDeletion()) {
-            $container_class .= ' old';
+            $container_class .= ' wt-old';
         } elseif ($fact->isPendingAddition()) {
-            $container_class .= ' new';
+            $container_class .= ' wt-new';
         }
 
         if ($individual->canEdit()) {


### PR DESCRIPTION
When editing names and gender of an individual, the pending changes are not highlighted, because there is no css for "old" and "new". I assume "wt-old" and "wt-new" is intended here?