### PR TITLE
Skip media objects without title while checking for duplicates

### DIFF
--- a/admin_trees_duplicates.php
+++ b/admin_trees_duplicates.php
@@ -119,7 +119,7 @@ $families = array_map(
 $media = Database::prepare(
     "SELECT GROUP_CONCAT(m_id) AS xrefs " .
     " FROM `##media`" .
-    " WHERE m_file = :tree_id" .
+    " WHERE m_file = :tree_id AND m_titl != ''" .
     " GROUP BY m_titl" .
     " HAVING COUNT(m_id) > 1"
 )->execute(array(


### PR DESCRIPTION
Hello,
this page crashes a little for me, given that I have 1395 media object, and none of them has a title.
I see that the same fix has been done in version 2!
