### PR TITLE
Fixes for #2665 #2664

### DIFF
--- a/app/Helpers/functions.php
+++ b/app/Helpers/functions.php
@@ -158,10 +158,11 @@ function response($content = '', $code = StatusCodeInterface::STATUS_OK, $header
  *
  * @param string  $route_name
  * @param mixed[] $parameters
+ * @param bool    $skip_url Flag for rendering routes without absolute URL - for usage in GET forms
  *
  * @return string
  */
-function route(string $route_name, array $parameters = []): string
+function route(string $route_name, array $parameters = [], $skip_url = false): string
 {
     $request          = app(ServerRequestInterface::class);
     $router_container = app(RouterContainer::class);
@@ -187,13 +188,14 @@ function route(string $route_name, array $parameters = []): string
     // Generate the URL.
     $url = $router_container->getGenerator()->generate($route_name, $parameters);
 
+
     // Aura ignores parameters that are not tokens.  We need to add them as query parameters.
     $parameters = array_filter($parameters, static function (string $key) use ($route): bool {
         return strpos($route->path, '{' . $key . '}') === false && strpos($route->path, '{/' . $key . '}') === false;
     }, ARRAY_FILTER_USE_KEY);
 
     // Turn the pretty URL into an ugly one.
-    if ($request->getAttribute('rewrite_urls') !== '1') {
+    if (!$skip_url && $request->getAttribute('rewrite_urls') !== '1') {
         $path       = parse_url($url, PHP_URL_PATH);
         $parameters = ['route' => $path] + $parameters;
         $base_url   = $request->getAttribute('base_url');

--- a/resources/views/layouts/default.phtml
+++ b/resources/views/layouts/default.phtml
@@ -85,7 +85,7 @@ use Psr\Http\Message\ServerRequestInterface;
 
                         <div class="col wt-header-search">
                             <form method="get" action="<?= e(route('search-quick', ['tree' => $tree->name()])) ?>" class="wt-header-search-form" role="search">
-                                <input type="hidden" name="route" value="<?= e(route('search-quick', ['tree' => $tree->name()])) ?>">
+                                <input type="hidden" name="route" value="<?= e(route('search-quick', ['tree' => $tree->name()], true)) ?>">
                                 <input type="hidden" name="tree" value="<?= e($tree->name()) ?>">
                                 <div class="input-group">
                                     <label class="sr-only" for="quick-search"><?= I18N::translate('Search') ?></label>

--- a/resources/views/modules/statistics-chart/custom.phtml
+++ b/resources/views/modules/statistics-chart/custom.phtml
@@ -11,7 +11,7 @@ use Fisharebest\Webtrees\View;
     </h4>
 
     <form method="get" action="<?= e(route('module', ['module' => $module->name(), 'action' => 'CustomChart'])) ?>" id="own-stats-form" class="wt-page-options wt-page-options-statistics">
-        <input type="hidden" name="route" value="<?= e(route('module', ['module' => $module->name(), 'action' => 'CustomChart'])) ?>">
+        <input type="hidden" name="route" value="<?= e(route('module', ['module' => $module->name(), 'action' => 'CustomChart'], true)) ?>">
         <input type="hidden" name="tree" value="<?= e($tree->name()) ?>">
         <div class="form-group row">
             <div class="col-sm-2 wt-page-options-label">

--- a/resources/views/report-select-page.phtml
+++ b/resources/views/report-select-page.phtml
@@ -5,7 +5,7 @@
 </h2>
 
 <form method="get" action="<?= e(route('report-setup', ['tree' => $tree->name()])) ?>" class="wt-page-options wt-page-options-report-select">
-    <input type="hidden" name="route" value="<?= e(route('report-setup', ['tree' => $tree->name()])) ?>">
+    <input type="hidden" name="route" value="<?= e(route('report-setup', ['tree' => $tree->name()], true)) ?>">
     <input type="hidden" name="tree" value="<?= e($tree->name()) ?>">
     <div class="row form-group">
         <label class="col-sm-3 col-form-label wt-page-options-label" for="report">

--- a/resources/views/report-setup-page.phtml
+++ b/resources/views/report-setup-page.phtml
@@ -5,7 +5,7 @@
 </h2>
 
 <form method="get" action="<?= e(route('report-run', ['tree' => $tree->name()])) ?>" class="wt-page-options wt-page-options-report-setup">
-    <input type="hidden" name="route" value="report-run">
+    <input type="hidden" name="route" value="<?= e(route('report-run', ['tree' => $tree->name()], true)) ?>">
     <input type="hidden" name="tree" value="<?= e($tree->name()) ?>">
     <input type="hidden" name="report" value="<?= e($report) ?>">
 

--- a/resources/views/search-advanced-page.phtml
+++ b/resources/views/search-advanced-page.phtml
@@ -6,7 +6,7 @@
 
 <div id="advanced-search-page">
     <form method="get" action="<?= e(route('search-advanced', ['tree' => $tree->name()])) ?>" class="wt-page-options wt-page-options-search-advanced hidden-print mb-4">
-        <input type="hidden" name="route" value="<?= e(route('search-advanced', ['tree' => $tree->name()])) ?>">
+        <input type="hidden" name="route" value="<?= e(route('search-advanced', ['tree' => $tree->name()], true)) ?>">
         <input type="hidden" name="tree" value="<?= e($tree->name()) ?>">
 
         <div class="row form-group wt-page-options-label mt-4">

--- a/resources/views/search-general-page.phtml
+++ b/resources/views/search-general-page.phtml
@@ -5,7 +5,7 @@
 </h2>
 
 <form method="get" action="<?= e(route('search-general', ['tree' => $tree->name()])) ?>" class="wt-page-options wt-page-options-search hidden-print mb-4" name="searchform">
-    <input type="hidden" name="route" value="<?= e(route('search-general', ['tree' => $tree->name()])) ?>">
+    <input type="hidden" name="route" value="<?= e(route('search-general', ['tree' => $tree->name()], true)) ?>">
     <input type="hidden" name="tree" value="<?= e($tree->name()) ?>">
     <div class="row form-group">
         <label class="col-sm-3 col-form-label wt-page-options-label" for="query">

--- a/resources/views/search-phonetic-page.phtml
+++ b/resources/views/search-phonetic-page.phtml
@@ -5,7 +5,7 @@
 </h2>
 
 <form method="get" action="<?= e(route('search-phonetic', ['tree' => $tree->name()])) ?>" class="wt-page-options wt-page-options-ancestors-chart hidden-print mb-4" name="searchform">
-    <input type="hidden" name="route" value="<?= e(route('search-phonetic', ['tree' => $tree->name()])) ?>">
+    <input type="hidden" name="route" value="<?= e(route('search-phonetic', ['tree' => $tree->name()], true)) ?>">
     <input type="hidden" name="tree" value="<?= e($tree->name()) ?>">
     <div class="row form-group">
         <label class="col-sm-3 col-form-label wt-page-options-label" for="firstname">


### PR DESCRIPTION
Fixes for issue in forms with GET (#2665 and #2664)

In the case of 'action' that has additional GET parameters, it was overridden by form data. In forms there is a hidden input 'route' which should work when route was defined without `route()` method. When we are using `route()` with parameters, and placing it into value of that input, and we don't have pretty URLs, than `route()` can add additional 'index.php` to final URL.

Solution prepared, was additional, optional parameter for `route()` method, to get just raw route, without domains/index.php etc.