### PR TITLE
Missing tree parameter

### DIFF
--- a/app/Http/Controllers/EditIndividualController.php
+++ b/app/Http/Controllers/EditIndividualController.php
@@ -521,6 +521,7 @@ class EditIndividualController extends AbstractEditController
         return $this->viewResponse('edit/link-child-to-family', [
             'individual' => $individual,
             'title'      => $title,
+            'tree'       => $tree,
         ]);
     }
 
@@ -601,6 +602,7 @@ class EditIndividualController extends AbstractEditController
             'individual' => $individual,
             'label'      => $label,
             'title'      => $title,
+            'tree'       => $tree,
         ]);
     }
 


### PR DESCRIPTION
Individual page - family tab
Fixes errors with
Link this individual to an existing family as a child &
Link spouse to individual
may fix https://github.com/fisharebest/webtrees/issues/2708