### PR TITLE
Adjust order of facts

### DIFF
--- a/resources/views/edit/new-individual.phtml
+++ b/resources/views/edit/new-individual.phtml
@@ -240,8 +240,13 @@ $bdm = ''; // used to copy '1 SOUR' to '2 SOUR' for BIRT DEAT MARR
         }
         $bdm = 'BD';
         if (preg_match_all('/(' . Gedcom::REGEX_TAG . ')/', $tree->getPreference('QUICK_REQUIRED_FACTS'), $matches)) {
+            foreach (Gedcom::BIRTH_EVENTS as $match) {
+                if (in_array($match, $matches[1], true)) {
+                    FunctionsEdit::addSimpleTags($tree, $match);
+                }
+            }
             foreach ($matches[1] as $match) {
-                if (!in_array($match, Gedcom::DEATH_EVENTS, true)) {
+                if (!in_array($match, Gedcom::BIRTH_EVENTS, true) && !in_array($match, Gedcom::DEATH_EVENTS, true)) {
                     FunctionsEdit::addSimpleTags($tree, $match);
                 }
             }
@@ -256,8 +261,8 @@ $bdm = ''; // used to copy '1 SOUR' to '2 SOUR' for BIRT DEAT MARR
             }
         }
         if (preg_match_all('/(' . Gedcom::REGEX_TAG . ')/', $tree->getPreference('QUICK_REQUIRED_FACTS'), $matches)) {
-            foreach ($matches[1] as $match) {
-                if (in_array($match, Gedcom::DEATH_EVENTS, true)) {
+            foreach (Gedcom::DEATH_EVENTS as $match) {
+                if (in_array($match, $matches[1], true)) {
                     FunctionsEdit::addSimpleTags($tree, $match);
                 }
             }


### PR DESCRIPTION
The order of facts for a new individual is currently mainly alphabetic (with death events coming last).

If e.g. in tree preferences, Facts for new individuals are set to:
ALIA,BAPM,BIRT,BURI,DEAT
we get the facts in the edit dialog in exactly this order, which isn't nice.

This PR adjusts this order to:
1. Birth events, in the order [BIRT, others]
2. Other non-birth non-death events
(3. marriage fact, as before)
4. Death events, in the order [DEATH, others]