### PR TITLE
V2 Update views/admin/location-edit.phtml - replace Geosearch

### DIFF
--- a/app/Http/Controllers/Admin/LocationController.php
+++ b/app/Http/Controllers/Admin/LocationController.php
@@ -328,7 +328,6 @@ class LocationController extends AbstractAdminController
             'parent_id'   => $parent_id,
             'lat'         => $lat,
             'lng'         => $lng,
-            'ref'         => $id,
             'data'        => $this->mapLocationData($id),
             'provider'    => [
                 'url'     => 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "jquery": "^3.4.1",
     "jquery-colorbox": "^1.6.4",
     "leaflet": "^1.6.0",
-    "leaflet-geosearch": "^2.7.0",
+    "leaflet-control-geocoder": "^1.11.0",
     "leaflet.markercluster": "^1.4.1",
     "moment": "^2.24.0",
     "popper.js": "^1.16.1",

--- a/resources/js/vendor.js
+++ b/resources/js/vendor.js
@@ -118,6 +118,7 @@ import 'wheelzoom';
 import 'leaflet';
 import 'leaflet.markercluster';
 import 'beautifymarker';
+import 'leaflet-control-geocoder';
 
 window.$ = window.jQuery = $;
 
@@ -145,5 +146,3 @@ window.Bloodhound = require('corejs-typeahead/dist/bloodhound.min.js');
 // See https://github.com/RubaXa/Sortable/issues/1229
 // window.Sortable = require('sortablejs');
 window.Sortable = Sortable;
-
-window.GeoSearch = require('leaflet-geosearch');

--- a/resources/views/admin/location-edit.phtml
+++ b/resources/views/admin/location-edit.phtml
@@ -18,8 +18,6 @@ use Fisharebest\Webtrees\View;
 <form method="post">
     <?= csrf_field() ?>
     <input type="hidden" name="place_id" value="<?= e($place_id) ?>">
-    <input type="hidden" name="place_long" value="<?= e($lng) ?>">
-    <input type="hidden" name="place_lati" value="<?= e($lat) ?>">
 
     <div class="form-group row">
         <label class="col-form-label col-sm-1" for="new_place_name">
@@ -86,181 +84,146 @@ use Fisharebest\Webtrees\View;
 
 <?php View::push('styles') ?>
 <style>
-    .osm-wrapper, .osm-user-map {
-        height: 45vh
-    }
-
     .osm-admin-map {
         height: 55vh;
         border: 1px solid darkGrey
-    }
-
-    .osm-sidebar {
-        height: 100%;
-        overflow-y: auto;
-        padding: 0;
-        margin: 0;
-        border: 0;
-        display: none;
-        font-size: small;
-    }
-
-    .osm-sidebar .gchart {
-        margin: 1px;
-        padding: 2px
-    }
-
-    .osm-sidebar .gchart img {
-        height: 15px;
-        width: 25px
-    }
-
-    .osm-sidebar .border-danger:hover {
-        cursor: not-allowed
     }
 </style>
 <?php View::endpush() ?>
 
 <?php View::push('javascript') ?>
 <script>
-    "use strict";
+'use strict';
 
-    window.WT_OSM_ADMIN = (function () {
+window.WT_OSM_ADMIN = (function () {
+  const minZoom = 2;
 
+  let provider  = <?= json_encode($provider) ?>;
+  let data      = <?= json_encode($data) ?>;
+  let map       = null;
+  let add_place = <?= json_encode($place_id === 0) ?>;
 
-            let provider = <?= json_encode($provider) ?>;
+  // map components
 
-            let baseData = {
-            minZoom:         2,
-            I18N: {
-                zoomInTitle: <?= json_encode(I18N::translate('Zoom in')) ?>,
-                zoomOutTitle: <?= json_encode(I18N::translate('Zoom out')) ?>,
-                reset: <?= json_encode(I18N::translate('Reset to initial map state')) ?>,
-                noData: <?= json_encode(I18N::translate('No mappable items')) ?>,
-                error: <?= json_encode(I18N::translate('An unknown error occurred')) ?>
-            },
-        };
+  // postcss_image_inliner breaks the autodetection of image paths.
+  L.Icon.Default.imagePath = <?= json_encode(asset('css/images/')) ?>;
 
-        let map      = null;
-        let marker   = L.marker([0, 0], {
-            draggable: true,
-        });
-        /**
-         *
-         * @private
-         */
-        let _drawMap = function () {
-            map = L.map("osm-map", {
-                    center:      [0, 0],
-                    minZoom:     baseData.minZoom, // maxZoom set by leaflet-providers.js
-                    zoomControl: false, // remove default
-                },
-            );
-            L.tileLayer(provider.url, provider.options).addTo(map);
-            L.control.zoom({ // Add zoom with localised text
-                zoomInTitle:  baseData.I18N.zoomInTitle,
-                zoomOutTitle: baseData.I18N.zoomOutTitle,
-            }).addTo(map);
+  // draggable marker
+  let marker = L.marker(data.coordinates, {
+    draggable: true,
+  })
+ .on('dragend', function (e) {
+      let coords = marker.getLatLng();
+      map.panTo(coords);
+      _update_Controls({
+        place:  '',
+        coords: coords,
+        zoom:   map.getZoom(),
+      });
+  });
 
-            // postcss_image_inliner breaks the autodetection of image paths.
-            L.Icon.Default.imagePath = <?= json_encode(asset('css/images/')) ?>;
+  //reset map to initial state
+  let resetControl = L.Control.extend({
+    options: {
+      position: 'topleft'
+    },
+    onAdd: function (map) {
+      let container     = L.DomUtil.create('div', 'leaflet-bar leaflet-control leaflet-control-custom');
+      container.onclick = function () {
+        map.setView(data.coordinates, data.zoom);
+        marker.setLatLng(data.coordinates);
+        $('form').trigger('reset');
+        return false;
+      };
+      let reset    = <?= json_encode(I18N::translate('Reload map')) ?>;
+      let anchor   = L.DomUtil.create('a', 'leaflet-control-reset', container);
+      anchor.setAttribute('aria-label', reset);
+      anchor.href  = '#';
+      anchor.title = reset;
+      anchor.role  = 'button';
+      let image    = L.DomUtil.create('i', 'fas fa-redo', anchor);
+      image.alt    = reset;
 
-            marker
-                .on("dragend", function (e) {
-                    let coords = marker.getLatLng();
-                    map.panTo(coords);
-                    _update_Controls({
-                        place:  "",
-                        coords: coords,
-                        zoom:   map.getZoom(),
-                    });
-                })
-                .addTo(map);
-            let searchControl = new window.GeoSearch.GeoSearchControl({
-                provider:        new window.GeoSearch.OpenStreetMapProvider(),
-                retainZoomLevel: true,
-                autoClose:       true,
-                showMarker:      false,
-            });
+      return container;
+    }
+  });
 
-            map
-                .addControl(searchControl)
-                .on("geosearch/showlocation", function (result) {
-                    let lat   = result.location.y;
-                    let lng   = result.location.x;
-                    let place = result.location.label.split(",", 1);
+  // zoom control with localised text
+  let zoomCtl = new L.control.zoom({
+    zoomInTitle:  <?= json_encode(I18N::translate('Zoom in')) ?>,
+    zoomOutTitle: <?= json_encode(I18N::translate('Zoom out')) ?>,
+  });
 
-                    marker.setLatLng([lat, lng]);
-                    map.panTo([lat, lng]);
+  // Geocoder (place lookup)
+  let geocoder = new L.Control.geocoder({
+    defaultMarkGeocode: false,
+    showResultIcons:    true,
+    query       : '<?= e($location->locationName()) ?>',
+    placeholder : <?= json_encode(I18N::translate('Place')) ?>,
+    errorMessage: <?= json_encode(I18N::translate('Nothing found.')) ?>,
+    iconLabel   : <?= json_encode(I18N::translate('Place search')) ?>
+  })
+  .on('markgeocode', function(result) {
+    let coords = result.geocode.center;
+    let place  = result.geocode.name.split(',', 1);
+    marker.setLatLng(coords);
+    map.panTo(coords);
+    _update_Controls({
+      place:  place.shift(),
+      coords: coords,
+      zoom:   map.getZoom(),
+    });
+  });
 
-                    _update_Controls({
-                        place:  place.shift(),
-                        coords: {
-                            "lat": lat,
-                            "lng": lng,
-                        },
-                        zoom:   map.getZoom(),
-                    });
-                })
-                .on("zoomend", function (e) {
-                    $("#new_zoom_factor").val(map.getZoom());
-                    map.panTo(marker.getLatLng());
-                });
-        };
+  /**
+   *
+   * @param newData
+   * @private
+   */
+  let _update_Controls = function (newData) {
 
-        let data = <?= json_encode($data) ?>;
+    if (add_place) {
+      $('#new_place_name').val(newData.place);
+    }
+    $('#new_place_lati').val(Number(newData.coords.lat).toFixed(5)); // 5 decimal places (about 1 metre accuracy)
+    $('#new_place_long').val(Number(newData.coords.lng).toFixed(5));
+    $('#new_zoom_factor').val(Number(newData.zoom));
+  }
 
-        /**
-         *
-         * @param newData
-         * @private
-         */
-        let _update_Controls = function (newData) {
-            let placeEl = $("#new_place_name");
-            if (!placeEl.val().length && newData.place.length) {
-                placeEl.val(newData.place);
-            }
-            $("#new_place_lati").val(Number(newData.coords.lat).toFixed(5)); // 5 decimal places (about 1 metre accuracy)
-            $("#new_place_long").val(Number(newData.coords.lng).toFixed(5));
-            $("#new_zoom_factor").val(Number(newData.zoom));
-        };
+  /**
+   *
+   * @private
+   */
+  $(function () {
+    // geocoder button tooltip
+    $('.leaflet-control-geocoder-icon')
+      .attr('title', <?= json_encode(I18N::translate('Place search')) ?>);
 
-        $(function () {
-            $(".editable").on("change", function (e) {
-                let lat = $("#new_place_lati").val();
-                let lng = $("#new_place_long").val();
-                marker.setLatLng([lat, lng]);
-                map.panTo([lat, lng]);
-            });
-        });
+    $('.editable').on('change', function (e) {
+      let lat = $('#new_place_lati').val();
+      let lng = $('#new_place_long').val();
+      marker.setLatLng([lat, lng]);
+      map.panTo([lat, lng]);
+    });
+  });
 
-        /**
-         *
-         * @param id
-         */
-        let initialize = function (id) {
-            _drawMap();
+  // Create the map with all controls and layers
+  map = L.map('osm-map', {
+    minZoom:     minZoom, // maxZoom set by leaflet-providers.js
+    zoomControl: false,   // remove default
+  })
+  .addControl(new resetControl())
+  .addControl(zoomCtl)
+  .addControl(geocoder)
+  .addLayer(marker)
+  .addLayer(L.tileLayer(provider.url, provider.options))
+  .setView(data.coordinates, data.zoom)
+  .on('zoomend', function (e) {
+    $('#new_zoom_factor').val(map.getZoom());
+    map.panTo(marker.getLatLng());
+  });
 
-            marker.setLatLng(data.coordinates);
-
-            if (data.coordinates[0] === 0 && data.coordinates[1] === 0) {
-                map.fitWorld();
-            } else {
-                map.setView(data.coordinates, data.zoom);
-            }
-        };
-
-        return {
-            /**
-             *
-             * @param id
-             */
-            drawMap: function (id) {
-                initialize(id);
-            },
-        };
-    })();
-
-    WT_OSM_ADMIN.drawMap(<?= json_encode($ref) ?>);
+  return 'Leaflet map interface for webtrees-2';
+})();
 </script>
 <?php View::endpush() ?>

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -29,7 +29,7 @@ mix.styles([
     "node_modules/typeahead.js-bootstrap4-css/typeaheadjs.css",
     "node_modules/leaflet/dist/leaflet.css",
     "node_modules/beautifymarker/leaflet-beautify-marker-icon.css",
-    "node_modules/leaflet-geosearch/dist/style.css",
+    "node_modules/leaflet-control-geocoder/dist/Control.Geocoder.css",
     "node_modules/leaflet.markercluster/dist/MarkerCluster.Default.css",
     "node_modules/leaflet.markercluster/dist/MarkerCluster.css",
 ], "public/css/vendor.css");
@@ -43,6 +43,7 @@ mix
     .js("resources/js/vendor.js", "public/js/vendor.min.js")
     .babel(["resources/js/webtrees.js", "resources/js/statistics.js", "resources/js/treeview.js"], "public/js/webtrees.min.js")
     .copy("node_modules/leaflet/dist/images/*", "public/css/images/")
+    .copy("node_modules/leaflet-control-geocoder/dist/images/*", "public/css/images/")
     .copy("node_modules/dejavu-fonts-ttf/ttf/DejaVuSans.ttf", "resources/fonts/")
     .options({
             processCssUrls: false,


### PR DESCRIPTION
This should be installed after https://github.com/fisharebest/webtrees/pull/3088. as script in views/admin/location-edit would have changes introduced here over-written

- Replaced geosearch with leaflet-control-geocoder (Fixes issue https://github.com/fisharebest/webtrees/issues/2991)
- Added map reset button 
- Removed redundant code.
