### PR TITLE
Improve method of selecting persons to appear on the pedigree map

### DIFF
--- a/app/Module/PedigreeMapModule.php
+++ b/app/Module/PedigreeMapModule.php
@@ -26,6 +26,7 @@ use Fisharebest\Webtrees\Auth;
 use Fisharebest\Webtrees\Fact;
 use Fisharebest\Webtrees\Family;
 use Fisharebest\Webtrees\Functions\Functions;
+use Fisharebest\Webtrees\Gedcom;
 use Fisharebest\Webtrees\GedcomTag;
 use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\Individual;
@@ -325,9 +326,11 @@ class PedigreeMapModule extends AbstractModule implements ModuleChartInterface, 
         $facts       = [];
         foreach ($ancestors as $sosa => $person) {
             if ($person->canShow()) {
-                $birth = $person->facts(['BIRT'])->first();
-                if ($birth instanceof Fact && $birth->place()->gedcomName() !== '') {
-                    $facts[$sosa] = $birth;
+                foreach ($person->facts(Gedcom::BIRTH_EVENTS, true) as $event) {
+                    if ($event->place()->gedcomName() !== '') {
+                        $facts[$sosa] = $event;
+                        break;
+                    }
                 }
             }
         }
@@ -377,6 +380,7 @@ class PedigreeMapModule extends AbstractModule implements ModuleChartInterface, 
             'date'   => $fact->date()->display(true),
             'place'  => $fact->place(),
             'addtag' => $addbirthtag,
+            'etag'   => $fact->getTag()
         ];
     }
 

--- a/resources/views/modules/pedigree-map/events.phtml
+++ b/resources/views/modules/pedigree-map/events.phtml
@@ -21,7 +21,7 @@ use Fisharebest\Webtrees\GedcomTag;
 
 <div>
     <?php if ($addtag) : ?>
-        <?= GedcomTag::getLabel('BIRT') ?>:
+        <?= GedcomTag::getLabel($etag) ?>:
     <?php endif ?>
     <?= $date ?>
 </div>


### PR DESCRIPTION
Imagine a father has a birth event but his son only has a baptism, with the current code we only select by `'BIRT' `event so the father will appear on the map but his son won't and because of this there can be no connecting line therefore the father appears in isolation.

This PR selects events by `Gedcom::BIRTH_EVENTS`

BTW PedigreeMapModule::summaryData() seems to have some redundant code (checking for instanceof Family when we're only passing in birth events) but I'm not confident that I'm seeing this correctly!!