### PR TITLE
Pedigree map script changes

### DIFF
--- a/resources/views/modules/pedigree-map/chart.phtml
+++ b/resources/views/modules/pedigree-map/chart.phtml
@@ -1,12 +1,11 @@
 <?php
 
 use Fisharebest\Webtrees\I18N;
-use Fisharebest\Webtrees\Individual;
 use Fisharebest\Webtrees\View;
 
 /**
- * @var Individual $individual
- * @var int $generations
+ * @var array $data
+ * @var array $provider
  */
 ?>
 
@@ -34,143 +33,127 @@ use Fisharebest\Webtrees\View;
 
 <?php View::push('javascript') ?>
 <script type="application/javascript">
-  "use strict";
+"use strict";
 
-  window.WT_OSM = (function() {
-    let baseData = {
-      minZoom: 2,
-      providerName: "OpenStreetMap.Mapnik",
-      providerOptions: [],
-    };
+window.WT_OSM = (function() {
+    const minZoom = 2;
 
-    let map          = null;
-    let zoom         = null;
-    let sidebar      = $('.osm-sidebar');
-    let markers      = L.markerClusterGroup({
-      showCoverageOnHover: false
+    let map      = null;
+    let zoom     = null;
+    let sidebar  = $('.osm-sidebar');
+    let provider = <?= json_encode($provider) ?>;
+
+    // Map components
+    let markers = L.markerClusterGroup({
+        showCoverageOnHover: false
     });
 
     let resetControl = L.Control.extend({
-      options: {
-        position: 'topleft'
-      },
+        options: {
+            position: 'topleft'
+        },
+        onAdd: function(map) {
+            let container = L.DomUtil.create('div', 'leaflet-bar leaflet-control leaflet-control-custom');
+            container.onclick = function() {
+                if (zoom) {
+                    map.flyTo(markers.getBounds().getCenter(), zoom);
+                } else {
+                    map.flyToBounds(markers.getBounds().pad(0.2));
+                }
+                sidebar.scrollTo(sidebar.children(":first"));
 
-      onAdd: function (map) {
-        let container     = L.DomUtil.create('div', 'leaflet-bar leaflet-control leaflet-control-custom');
-        container.onclick = function () {
-          if (zoom) {
-            map.flyTo(markers.getBounds().getCenter(), zoom);
-          } else {
-            map.flyToBounds(markers.getBounds().pad(0.2));
-          }
-          sidebar.scrollTo(sidebar.children(":first"));
+                return false;
+            };
+            let reset    = <?= json_encode(I18N::translate('Reload map')) ?>;
+            let anchor   = L.DomUtil.create('a', 'leaflet-control-reset', container);
+            anchor.setAttribute('aria-label', reset);
+            anchor.href  = '#';
+            anchor.title = reset;
+            anchor.role  = 'button';
+            let image    = L.DomUtil.create('i', 'fas fa-redo', anchor);
+            image.alt    = reset;
 
-          return false;
-        };
-        let anchor   = L.DomUtil.create('a', 'leaflet-control-reset', container);
-        let reset = <?= json_encode(I18N::translate('Reset to initial map state')) ?>;
-        anchor.href  = '#';
-        anchor.title = reset;
-        anchor.role  = 'button';
-        $(anchor).attr('aria-label', 'reset');
-        let image = L.DomUtil.create('i', 'fas fa-redo', anchor);
-        image.alt = reset;
+            return container;
+        }
+    });
 
-        return container;
-      },
+    // Zoom control with localised text
+    let newZoomControl = new L.control.zoom({
+        zoomInTitle : <?= json_encode(I18N::translate('Zoom in')) ?>,
+        zoomOutTitle: <?= json_encode(I18N::translate('Zoom out')) ?>,
     });
 
     /**
      *
      * @private
      */
-    let _drawMap = function () {
-      map = L.map('osm-map', {
-        center     : [0, 0],
-        minZoom    : baseData.minZoom, // maxZoom set by leaflet-providers.js
-        zoomControl: false, // remove default
-      });
-      L.tileLayer.provider(baseData.providerName, baseData.providerOptions).addTo(map);
-      L.control.zoom({ // Add zoom with localised text
-        zoomInTitle : <?= json_encode(I18N::translate('Zoom in')) ?>,
-        zoomOutTitle: <?= json_encode(I18N::translate('Zoom out')) ?>,
-      }).addTo(map);
+    let _drawMap = function() {
+        map = L.map('osm-map', {
+            center     : [0, 0],
+            minZoom    : minZoom,   // maxZoom set by leaflet-providers.js
+            zoomControl: false,     // remove default
+        })
+        .addControl(new resetControl())
+        .addControl(newZoomControl)
+        .addLayer(L.tileLayer.provider(provider.name, provider.options))
     };
 
     /**
-     * @param Generations
      * @private
      */
-    let _addLayer = function (Generations) {
-        let geoJsonLayer;
+    let _buildMapData = function() {
         let sidebar_content = '';
+        let geoJson_data    = <?= json_encode($data) ?>;
 
-      $.getJSON(<?= json_encode(route('module', ['module' => 'pedigree-map', 'action' => 'MapData', 'tree' => $individual->tree()->name(), 'xref' => $individual->xref()])) ?>, {
-        generations: Generations
-      })
-        .done(function (data, textStatus, jqXHR) {
-          if (jqXHR.status === 200 && data.features.length === 1) {
-            zoom = data.features[0].properties.zoom;
-          }
-          geoJsonLayer = L.geoJson(data, {
-            pointToLayer : function (feature, latlng) {
-              return new L.Marker(latlng, {
-                icon : L.BeautifyIcon.icon({
-                  icon           : 'bullseye fas',
-                  borderColor    : 'transparent',
-                  backgroundColor: feature.properties.iconcolor,
-                  iconShape      : 'marker',
-                  textColor      : 'white',
-                }),
-                title: feature.properties.tooltip,
-                alt  : feature.properties.tooltip,
-                id   : feature.id
-              })
-                .on('popupopen', function (e) {
-                  let item  = sidebar.children(".gchart[data-id=" + e.target.feature.id + "]");
-                  item.addClass('messagebox');
-                  sidebar.scrollTo(item);
-                })
-                .on('popupclose', function () {
-                  sidebar.children(".gchart")
-                    .removeClass('messagebox');
-                });
-            },
-            onEachFeature: function (feature, layer) {
-              if (feature.properties.polyline) {
-                let pline = L.polyline(feature.properties.polyline.points, feature.properties.polyline.options);
-                markers.addLayer(pline);
-              }
-              layer.bindPopup(feature.properties.summary);
-              sidebar_content += `<li class="gchart px-md-2" data-id=${feature.id}>${feature.properties.summary}</li>`;
-            },
-          });
-        })
-        .fail(function (jqXHR, textStatus, errorThrown) {
-          console.log(jqXHR, textStatus, errorThrown);
-        })
-        .always(function (data_jqXHR, textStatus, jqXHR_errorThrown) {
-          switch (jqXHR_errorThrown.status) {
-            case 200: // Success
-              sidebar.append(sidebar_content);
-              markers.addLayer(geoJsonLayer);
-              map
-                .addControl(new resetControl())
-                .addLayer(markers)
-                .fitBounds(markers.getBounds().pad(0.2));
-              if (zoom) {
+        if (geoJson_data.features.length === 0) {
+            map.fitWorld();
+            sidebar_content += '<div class="bg-info text-white text-center">' + <?= json_encode(I18N::translate('Nothing to show')) ?> + '</div>';
+        } else {
+            if (geoJson_data.features.length === 1) {
+                //fudge factor - maps zooms to maximum permitted otherwise
+                zoom = geoJson_data.features[0].properties.zoom;
+            }
+            let geoJsonLayer = L.geoJson(geoJson_data, {
+                pointToLayer: function(feature, latlng) {
+                    return new L.Marker(latlng, {
+                            icon: L.BeautifyIcon.icon({
+                                icon           : 'bullseye fas',
+                                borderColor    : 'transparent',
+                                backgroundColor: feature.properties.iconcolor,
+                                iconShape      : 'marker',
+                                textColor      : 'white',
+                            }),
+                            title: feature.properties.tooltip,
+                            alt  : feature.properties.tooltip,
+                            id   : feature.id
+                        })
+                        .on('popupopen', function(e) {
+                            let item = sidebar.children(".gchart[data-id=" + e.target.feature.id + "]");
+                            item.addClass('messagebox');
+                            sidebar.scrollTo(item);
+                        })
+                        .on('popupclose', function() {
+                            sidebar.children(".gchart").removeClass('messagebox');
+                        });
+                },
+                onEachFeature: function(feature, layer) {
+                    if (feature.properties.polyline) {
+                        let pline = L.polyline(feature.properties.polyline.points, feature.properties.polyline.options);
+                        markers.addLayer(pline);
+                    }
+                    layer.bindPopup(feature.properties.summary);
+                    sidebar_content += `<li class="gchart px-md-2" data-id=${feature.id}>${feature.properties.summary}</li>`;
+                }
+            });
+            markers.addLayer(geoJsonLayer);
+            map.addLayer(markers);
+            if (zoom) {
                 map.setView(markers.getBounds().getCenter(), zoom);
-              }
-              break;
-            case 204: // No data
-              map.fitWorld();
-              sidebar.append('<div class="bg-info text-white">' + <?= json_encode(I18N::translate('No mappable items')) ?> + '</div>');
-              break;
-            default: // Anything else
-              map.fitWorld();
-              sidebar.append('<div class="bg-danger text-white">' + <?= json_encode(I18N::translate('An unknown error occurred')) ?> + '</div>');
-          }
-        });
+            } else {
+                map.fitBounds(markers.getBounds().pad(0.2));
+            }
+        }
+        sidebar.append(sidebar_content);
     };
 
     /**
@@ -179,59 +162,45 @@ use Fisharebest\Webtrees\View;
      * @returns {$}
      */
 
-    $.fn.scrollTo = function (elem) {
-      let _this = $(this);
-      _this.animate({
-        scrollTop: elem.offset().top - _this.offset().top + _this.scrollTop()
-      });
-      return this;
+    $.fn.scrollTo = function(elem) {
+        let _this = $(this);
+        _this.animate({
+            scrollTop: elem.offset().top - _this.offset().top + _this.scrollTop()
+        });
+        return this;
     };
 
-    /**
-     * @param generations integer
-     * @private
-     */
-    let _initialize = function (generations) {
-      // Activate marker popup when sidebar entry clicked
-      $(function () {
+    // Activate marker popup when sidebar entry clicked
+    $(function() {
         sidebar
-        // open marker popup if sidebar event is clicked
-          .on('click', '.gchart', function (e) {
-            // first close any existing
-            map.closePopup();
-            let eventId = $(this).data('id');
-            //find the marker corresponding to the clicked event
-            let mkrLayer = markers.getLayers().filter(function (v) {
-              return typeof(v.feature) !== 'undefined' && v.feature.id === eventId;
+            // open marker popup if sidebar event is clicked
+            .on('click', '.gchart', function(e) {
+                // first close any existing
+                map.closePopup();
+                let eventId = $(this).data('id');
+                //find the marker corresponding to the clicked event
+                let mkrLayer = markers.getLayers().filter(function(v) {
+                    return typeof(v.feature) !== 'undefined' && v.feature.id === eventId;
+                });
+                let mkr = mkrLayer.pop();
+                // Unfortunately zoomToShowLayer zooms to maxZoom
+                // when all marker in a cluster have exactly the
+                // same co-ordinates
+                markers.zoomToShowLayer(mkr, function(e) {
+                    mkr.openPopup();
+                });
+
+                return false;
+            })
+            .on('click', 'a', function(e) { // stop click on a person also opening the popup
+                e.stopPropagation();
             });
-            let mkr = mkrLayer.pop();
-            // Unfortunately zoomToShowLayer zooms to maxZoom
-            // when all marker in a cluster have exactly the
-            // same co-ordinates
-            markers.zoomToShowLayer(mkr, function (e) {
-              mkr.openPopup();
-            });
-            return false;
-          })
-          .on('click', 'a', function (e) { // stop click on a person also opening the popup
-            e.stopPropagation();
-          });
-      });
+    });
 
-      _drawMap();
-      _addLayer(generations);
-    };
+    _drawMap();
+    _buildMapData();
 
-    return {
-      /**
-       * @param generations integer
-       */
-      drawMap: function (generations) {
-        _initialize(generations);
-      }
-    };
-  })();
-
-    WT_OSM.drawMap(<?= json_encode($generations) ?>);
+    return "Leaflet map interface for webtrees-2";
+})();
 </script>
 <?php View::endpush() ?>


### PR DESCRIPTION
 Reformat and tidy script and remove need for json callback to collect data.

The diff comparison looks much more complex than it really is, Removing the json callback means
`public function PedigreeMapsModule::getMapDataAction() `becomes `private function PedigreeMapsModule::getMapData()` so I moved it down to keep public and private functions together but doing that confuses the diff generator