### PR TITLE
allow use of GedcomRecordFactory for specific types, cleaned up.

### DIFF
--- a/app/GedcomRecord.php
+++ b/app/GedcomRecord.php
@@ -67,10 +67,6 @@ class GedcomRecord
 
     protected const ROUTE_NAME = GedcomRecordPage::class;
 
-    /** @var GedcomRecord[][] Allow getInstance() to return references to existing objects */
-    public static $gedcom_record_cache;
-    /** @var stdClass[][] Fetch all pending edits in one database query */
-    public static $pending_record_cache;
     /** @var string The record identifier */
     protected $xref;
     /** @var Tree  The family tree to which this record belongs */
@@ -188,103 +184,13 @@ class GedcomRecord
      */
     public static function getInstance(string $xref, Tree $tree, string $gedcom = null)
     {
-        $tree_id = $tree->id();
+        $factories = app(GedcomRecordFactoriesInterface::class);
+        return $factories->getInstance($xref, $tree, $gedcom);      
+    }
 
-        // Is this record already in the cache?
-        if (isset(self::$gedcom_record_cache[$xref][$tree_id])) {
-            return self::$gedcom_record_cache[$xref][$tree_id];
-        }
-
-        // Do we need to fetch the record from the database?
-        if ($gedcom === null) {
-            $gedcom = static::fetchGedcomRecord($xref, $tree_id);
-        }
-
-        // If we can edit, then we also need to be able to see pending records.
-        if (Auth::isEditor($tree)) {
-            if (!isset(self::$pending_record_cache[$tree_id])) {
-                // Fetch all pending records in one database query
-                self::$pending_record_cache[$tree_id] = [];
-                $rows                                 = DB::table('change')
-                    ->where('gedcom_id', '=', $tree_id)
-                    ->where('status', '=', 'pending')
-                    ->orderBy('change_id')
-                    ->select(['xref', 'new_gedcom'])
-                    ->get();
-
-                foreach ($rows as $row) {
-                    self::$pending_record_cache[$tree_id][$row->xref] = $row->new_gedcom;
-                }
-            }
-
-            $pending = self::$pending_record_cache[$tree_id][$xref] ?? null;
-        } else {
-            // There are no pending changes for this record
-            $pending = null;
-        }
-
-        // No such record exists
-        if ($gedcom === null && $pending === null) {
-            return null;
-        }
-
-        // No such record, but a pending creation exists
-        if ($gedcom === null) {
-            $gedcom = '';
-        }
-
-        // Create the object
-        if (preg_match('/^0 @(' . Gedcom::REGEX_XREF . ')@ (' . Gedcom::REGEX_TAG . ')/', $gedcom . $pending, $match)) {
-            $xref = $match[1]; // Collation - we may have requested I123 and found i123
-            $type = $match[2];
-        } elseif (preg_match('/^0 (HEAD|TRLR)/', $gedcom . $pending, $match)) {
-            $xref = $match[1];
-            $type = $match[1];
-        } elseif ($gedcom . $pending) {
-            throw new Exception('Unrecognized GEDCOM record: ' . $gedcom);
-        } else {
-            // A record with both pending creation and pending deletion
-            $type = static::RECORD_TYPE;
-        }
-
-        switch ($type) {
-            case Individual::RECORD_TYPE:
-                $record = new Individual($xref, $gedcom, $pending, $tree);
-                break;
-
-            case Family::RECORD_TYPE:
-                $record = new Family($xref, $gedcom, $pending, $tree);
-                break;
-
-            case Source::RECORD_TYPE:
-                $record = new Source($xref, $gedcom, $pending, $tree);
-                break;
-
-            case Media::RECORD_TYPE:
-                $record = new Media($xref, $gedcom, $pending, $tree);
-                break;
-
-            case Repository::RECORD_TYPE:
-                $record = new Repository($xref, $gedcom, $pending, $tree);
-                break;
-
-            case Note::RECORD_TYPE:
-                $record = new Note($xref, $gedcom, $pending, $tree);
-                break;
-
-            case Submitter::RECORD_TYPE:
-                $record = new Submitter($xref, $gedcom, $pending, $tree);
-                break;
-
-            default:
-                $record = new self($xref, $gedcom, $pending, $tree);
-                break;
-        }
-
-        // Store it in the cache
-        self::$gedcom_record_cache[$xref][$tree_id] = $record;
-
-        return $record;
+    public static function retrieveGedcomRecord(string $xref, int $tree_id): ?string
+    {
+      return self::fetchGedcomRecord($xref, $tree_id);
     }
 
     /**
@@ -1187,8 +1093,8 @@ class GedcomRecord
         }
 
         // Clear the cache
-        self::$gedcom_record_cache  = [];
-        self::$pending_record_cache = [];
+        $factories = app(GedcomRecordFactoriesInterface::class);
+        $factories->clearCache();
 
         Log::addEditLog('Delete: ' . static::RECORD_TYPE . ' ' . $this->xref, $this->tree);
     }

--- a/app/GedcomRecordFactories.php
+++ b/app/GedcomRecordFactories.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2019 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Fisharebest\Webtrees;
+
+use Exception;
+use Fisharebest\Webtrees\Gedcom;
+use Fisharebest\Webtrees\GedcomRecord;
+use Fisharebest\Webtrees\Tree;
+use Illuminate\Database\Capsule\Manager as DB;
+use Fisharebest\Webtrees\Auth;
+use Fisharebest\Webtrees\Family;
+use Fisharebest\Webtrees\Individual;
+use Fisharebest\Webtrees\Media;
+use Fisharebest\Webtrees\Note;
+use Fisharebest\Webtrees\Repository;
+use Fisharebest\Webtrees\Source;
+use stdClass;
+
+class GedcomRecordFactories implements GedcomRecordFactoriesInterface {
+
+  /** @var GedcomRecord[][] Allow getInstance() to return references to existing objects */
+  protected $gedcom_record_cache;
+
+  /** @var stdClass[][] Fetch all pending edits in one database query */
+  protected $pending_record_cache;
+  
+  protected $factories = [];
+
+  public function __construct() {
+  }
+  
+  public function setFactory(string $type, GedcomRecordFactory $factory): void 
+  {
+      $this->factories[$type] = $factory;
+  }
+
+  /**
+   * Get an instance of a GedcomRecord object. For single records,
+   * we just receive the XREF. For bulk records (such as lists
+   * and search results) we can receive the GEDCOM data as well.
+   *
+   * @param string      $xref
+   * @param Tree        $tree
+   * @param string|null $gedcom
+   *
+   * @throws Exception
+   * @return GedcomRecord|Individual|Family|Source|Repository|Media|Note|null
+   */
+  public function getInstance(string $xref, Tree $tree, string $gedcom = null) {
+    $tree_id = $tree->id();
+
+    // Is this record already in the cache?
+    if (isset($this->gedcom_record_cache[$xref][$tree_id])) {
+      return $this->gedcom_record_cache[$xref][$tree_id];
+    }
+
+    // Do we need to fetch the record from the database?
+    if ($gedcom === null) {
+      $gedcom = GedcomRecord::retrieveGedcomRecord($xref, $tree_id);
+    }
+
+    // If we can edit, then we also need to be able to see pending records.
+    if (Auth::isEditor($tree)) {
+      if (!isset($this->pending_record_cache[$tree_id])) {
+        // Fetch all pending records in one database query
+        $this->pending_record_cache[$tree_id] = [];
+        $rows = DB::table('change')
+                ->where('gedcom_id', '=', $tree_id)
+                ->where('status', '=', 'pending')
+                ->orderBy('change_id')
+                ->select(['xref', 'new_gedcom'])
+                ->get();
+
+        foreach ($rows as $row) {
+          $this->pending_record_cache[$tree_id][$row->xref] = $row->new_gedcom;
+        }
+      }
+
+      $pending = $this->pending_record_cache[$tree_id][$xref] ?? null;
+    } else {
+      // There are no pending changes for this record
+      $pending = null;
+    }
+
+    // No such record exists
+    if ($gedcom === null && $pending === null) {
+      return null;
+    }
+
+    // No such record, but a pending creation exists
+    if ($gedcom === null) {
+      $gedcom = '';
+    }
+
+    // Create the object
+    if (preg_match('/^0 @(' . Gedcom::REGEX_XREF . ')@ (' . Gedcom::REGEX_TAG . ')/', $gedcom . $pending, $match)) {
+      $xref = $match[1]; // Collation - we may have requested I123 and found i123
+      $type = $match[2];
+    } elseif (preg_match('/^0 (HEAD|TRLR)/', $gedcom . $pending, $match)) {
+      $xref = $match[1];
+      $type = $match[1];
+    } elseif ($gedcom . $pending) {
+      throw new Exception('Unrecognized GEDCOM record: ' . $gedcom);
+    } else {
+      // A record with both pending creation and pending deletion
+      $type = static::RECORD_TYPE;
+    }
+
+    $factory = $this->factories[$type] ?? null;
+    if ($factory !== null) {
+      $record = $factory->createRecord($xref, $gedcom, $pending, $tree);
+
+      // Store it in the cache
+      $this->gedcom_record_cache[$xref][$tree_id] = $record;
+
+      return $record;
+    }
+
+    switch ($type) {
+      case 'INDI':
+        $record = new Individual($xref, $gedcom, $pending, $tree);
+        break;
+      case 'FAM':
+        $record = new Family($xref, $gedcom, $pending, $tree);
+        break;
+      case 'SOUR':
+        $record = new Source($xref, $gedcom, $pending, $tree);
+        break;
+      case 'OBJE':
+        $record = new Media($xref, $gedcom, $pending, $tree);
+        break;
+      case 'REPO':
+        $record = new Repository($xref, $gedcom, $pending, $tree);
+        break;
+      case 'NOTE':
+        $record = new Note($xref, $gedcom, $pending, $tree);
+        break;
+      default:
+        $record = new GedcomRecord($xref, $gedcom, $pending, $tree);
+        break;
+    }
+
+    // Store it in the cache
+    $this->gedcom_record_cache[$xref][$tree_id] = $record;
+
+    return $record;
+  }
+
+  public function clearCache(): void {
+    // Clear the cache
+    $this->gedcom_record_cache = [];
+    $this->pending_record_cache = [];
+  }
+
+}

--- a/app/GedcomRecordFactories.php
+++ b/app/GedcomRecordFactories.php
@@ -31,6 +31,7 @@ use Fisharebest\Webtrees\Media;
 use Fisharebest\Webtrees\Note;
 use Fisharebest\Webtrees\Repository;
 use Fisharebest\Webtrees\Source;
+use Fisharebest\Webtrees\Submitter;
 use stdClass;
 
 class GedcomRecordFactories implements GedcomRecordFactoriesInterface {
@@ -134,24 +135,34 @@ class GedcomRecordFactories implements GedcomRecordFactoriesInterface {
     }
 
     switch ($type) {
-      case 'INDI':
-        $record = new Individual($xref, $gedcom, $pending, $tree);
-        break;
-      case 'FAM':
-        $record = new Family($xref, $gedcom, $pending, $tree);
-        break;
-      case 'SOUR':
-        $record = new Source($xref, $gedcom, $pending, $tree);
-        break;
-      case 'OBJE':
-        $record = new Media($xref, $gedcom, $pending, $tree);
-        break;
-      case 'REPO':
-        $record = new Repository($xref, $gedcom, $pending, $tree);
-        break;
-      case 'NOTE':
-        $record = new Note($xref, $gedcom, $pending, $tree);
-        break;
+      case Individual::RECORD_TYPE:
+          $record = new Individual($xref, $gedcom, $pending, $tree);
+          break;
+
+      case Family::RECORD_TYPE:
+          $record = new Family($xref, $gedcom, $pending, $tree);
+          break;
+
+      case Source::RECORD_TYPE:
+          $record = new Source($xref, $gedcom, $pending, $tree);
+          break;
+
+      case Media::RECORD_TYPE:
+          $record = new Media($xref, $gedcom, $pending, $tree);
+          break;
+
+      case Repository::RECORD_TYPE:
+          $record = new Repository($xref, $gedcom, $pending, $tree);
+          break;
+
+      case Note::RECORD_TYPE:
+          $record = new Note($xref, $gedcom, $pending, $tree);
+          break;
+
+      case Submitter::RECORD_TYPE:
+          $record = new Submitter($xref, $gedcom, $pending, $tree);
+          break;
+        
       default:
         $record = new GedcomRecord($xref, $gedcom, $pending, $tree);
         break;

--- a/app/GedcomRecordFactoriesInterface.php
+++ b/app/GedcomRecordFactoriesInterface.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2019 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Fisharebest\Webtrees;
+
+use Exception;
+use Fisharebest\Webtrees\GedcomRecord;
+use Fisharebest\Webtrees\Tree;
+use Fisharebest\Webtrees\Family;
+use Fisharebest\Webtrees\Individual;
+use Fisharebest\Webtrees\Media;
+use Fisharebest\Webtrees\Note;
+use Fisharebest\Webtrees\Repository;
+use Fisharebest\Webtrees\Source;
+
+interface GedcomRecordFactoriesInterface {
+
+  /**
+   * Add (or replace) a factory for a specific type, e.g. 'INDI', 'FAM' ...
+   */
+  public function setFactory(string $type, GedcomRecordFactory $factory): void;
+
+  /**
+   * Get an instance of a GedcomRecord object. For single records,
+   * we just receive the XREF. For bulk records (such as lists
+   * and search results) we can receive the GEDCOM data as well.
+   *
+   * @param string      $xref
+   * @param Tree        $tree
+   * @param string|null $gedcom
+   *
+   * @throws Exception
+   * @return GedcomRecord|Individual|Family|Source|Repository|Media|Note|null
+   */
+  public function getInstance(string $xref, Tree $tree, string $gedcom = null);
+
+  public function clearCache(): void;
+
+}

--- a/app/GedcomRecordFactory.php
+++ b/app/GedcomRecordFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2019 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Fisharebest\Webtrees;
+
+use Fisharebest\Webtrees\GedcomRecord;
+use Fisharebest\Webtrees\Tree;
+
+interface GedcomRecordFactory {
+
+  public function createRecord(string $xref, string $gedcom, ?string $pending, Tree $tree): GedcomRecord;
+  
+}

--- a/app/Http/Middleware/RegisterFactories.php
+++ b/app/Http/Middleware/RegisterFactories.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2019 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Fisharebest\Webtrees\Http\Middleware;
+
+use Fisharebest\Webtrees\GedcomRecordFactories;
+use Fisharebest\Webtrees\GedcomRecordFactoriesInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use function app;
+
+class RegisterFactories implements MiddlewareInterface
+{
+ 
+    /**
+     * @param ServerRequestInterface  $request
+     * @param RequestHandlerInterface $handler
+     *
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        //GedcomRecordFactories currently has state (which shouöld probably be moved to cache),
+        //so we have to use a singleton here
+        app()->instance(GedcomRecordFactoriesInterface::class, new GedcomRecordFactories());
+
+        return $handler->handle($request);
+    }
+}

--- a/app/Http/RequestHandlers/IndividualPage.php
+++ b/app/Http/RequestHandlers/IndividualPage.php
@@ -27,6 +27,7 @@ use Fisharebest\Webtrees\Functions\FunctionsDate;
 use Fisharebest\Webtrees\Functions\FunctionsPrint;
 use Fisharebest\Webtrees\Functions\FunctionsPrintFacts;
 use Fisharebest\Webtrees\GedcomCode\GedcomCodeName;
+use Fisharebest\Webtrees\GedcomRecord;
 use Fisharebest\Webtrees\GedcomTag;
 use Fisharebest\Webtrees\Http\ViewResponseTrait;
 use Fisharebest\Webtrees\I18N;
@@ -245,11 +246,10 @@ class IndividualPage implements RequestHandlerInterface
         $individual = $fact->record();
 
         // Create a dummy record, so we can extract the formatted NAME value from it.
-        $dummy = new Individual(
+        $dummy = GedcomRecord::getInstance(
             'xref',
-            "0 @xref@ INDI\n1 DEAT Y\n" . $fact->gedcom(),
-            null,
-            $individual->tree()
+            $individual->tree(),
+            "0 @xref@ INDI\n1 DEAT Y\n" . $fact->gedcom()
         );
         $dummy->setPrimaryName(0); // Make sure we use the name from "1 NAME"
 

--- a/app/Webtrees.php
+++ b/app/Webtrees.php
@@ -32,6 +32,7 @@ use Fisharebest\Webtrees\Http\Middleware\LoadRoutes;
 use Fisharebest\Webtrees\Http\Middleware\NoRouteFound;
 use Fisharebest\Webtrees\Http\Middleware\PhpEnvironment;
 use Fisharebest\Webtrees\Http\Middleware\ReadConfigIni;
+use Fisharebest\Webtrees\Http\Middleware\RegisterFactories;
 use Fisharebest\Webtrees\Http\Middleware\Router;
 use Fisharebest\Webtrees\Http\Middleware\SecurityHeaders;
 use Fisharebest\Webtrees\Http\Middleware\UpdateDatabaseSchema;
@@ -123,6 +124,7 @@ class Webtrees
         UseTheme::class,
         DoHousekeeping::class,
         UseTransaction::class,
+        RegisterFactories::class,
         LoadRoutes::class,
         BootModules::class,
         Router::class,


### PR DESCRIPTION
again, see #3073 (also #3085).

Use of internal cache in GedcomRecordFactories (taken from GedcomRecord) should probably be refactored to use main cache.