### PR TITLE
Update Geocoder providers

### DIFF
--- a/app/Http/Controllers/Admin/LocationController.php
+++ b/app/Http/Controllers/Admin/LocationController.php
@@ -27,6 +27,7 @@ use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\Location;
 use Fisharebest\Webtrees\Services\GedcomService;
 use Fisharebest\Webtrees\Services\TreeService;
+use Fisharebest\Webtrees\Site;
 use Fisharebest\Webtrees\Tree;
 use Illuminate\Database\Capsule\Manager as DB;
 use Illuminate\Database\Eloquent\Collection;
@@ -321,15 +322,16 @@ class LocationController extends AbstractAdminController
         }
 
         return $this->viewResponse('admin/location-edit', [
-            'breadcrumbs' => $breadcrumbs,
-            'title'       => $title,
-            'location'    => $location,
-            'place_id'    => $place_id,
-            'parent_id'   => $parent_id,
-            'lat'         => $lat,
-            'lng'         => $lng,
-            'data'        => $this->mapLocationData($id),
-            'provider'    => [
+            'breadcrumbs'  => $breadcrumbs,
+            'title'        => $title,
+            'location'     => $location,
+            'place_id'     => $place_id,
+            'parent_id'    => $parent_id,
+            'lat'          => $lat,
+            'lng'          => $lng,
+            'data'         => $this->mapLocationData($id),
+            'opencage_key' => Site::getPreference('opencage'),
+            'provider'     => [
                 'url'     => 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
                 'options' => [
                     'attribution' => '<a href="https://www.openstreetmap.org/copyright">&copy; OpenStreetMap</a> contributors',

--- a/app/Http/Controllers/Admin/MapProviderController.php
+++ b/app/Http/Controllers/Admin/MapProviderController.php
@@ -38,9 +38,10 @@ class MapProviderController extends AbstractAdminController
     public function mapProviderEdit(ServerRequestInterface $request): ResponseInterface
     {
         return $this->viewResponse('admin/map-provider', [
-            'title'    => I18N::translate('Map provider'),
-            'provider' => Site::getPreference('map-provider'),
-            'geonames' => Site::getPreference('geonames'),
+            'title'         => I18N::translate('Map provider'),
+            'provider'      => Site::getPreference('map-provider'),
+            'use_gazetteer' => Site::getPreference('use_gazetteer'),
+            'opencage'      => Site::getPreference('opencage'),
         ]);
     }
 
@@ -54,7 +55,8 @@ class MapProviderController extends AbstractAdminController
         $settings = (array) $request->getParsedBody();
 
         Site::setPreference('map-provider', $settings['provider']);
-        Site::setPreference('geonames', $settings['geonames']);
+        Site::setPreference('use_gazetteer', $settings['use_gazetteer']);
+        Site::setPreference('opencage', $settings['opencage']);
 
         return redirect(route(ControlPanel::class));
     }

--- a/app/Schema/Migration44.php
+++ b/app/Schema/Migration44.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2019 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Fisharebest\Webtrees\Schema;
+
+use Illuminate\Database\Capsule\Manager as DB;
+
+/**
+ * Upgrade the database schema from version 43 to version 44.
+ */
+class Migration44 implements MigrationInterface
+{
+    /**
+     * Upgrade to to the next version
+     *
+     * @return void
+     */
+    public function upgrade(): void
+    {
+        // Cleanup
+        DB::table('site_setting')
+        ->where('setting_name', '=', 'geonames')
+        ->delete();
+    }
+}

--- a/app/Schema/Migration44.php
+++ b/app/Schema/Migration44.php
@@ -22,7 +22,7 @@ namespace Fisharebest\Webtrees\Schema;
 use Illuminate\Database\Capsule\Manager as DB;
 
 /**
- * Upgrade the database schema from version 43 to version 44.
+ * Upgrade the database schema from version 44 to version 45.
  */
 class Migration44 implements MigrationInterface
 {

--- a/app/Webtrees.php
+++ b/app/Webtrees.php
@@ -89,7 +89,7 @@ class Webtrees
     public const NAME = 'webtrees';
 
     // Required version of database tables/columns/indexes/etc.
-    public const SCHEMA_VERSION = 44;
+    public const SCHEMA_VERSION = 45;
 
     // e.g. "dev", "alpha", "beta", etc.
     public const STABILITY = 'dev';

--- a/resources/views/admin/location-edit.phtml
+++ b/resources/views/admin/location-edit.phtml
@@ -155,7 +155,10 @@ window.WT_OSM_ADMIN = (function () {
   });
 
   // Geocoder (place lookup)
+  let opencage_key = <?= json_encode($opencage_key) ?>;
+
   let geocoder = new L.Control.geocoder({
+    geocoder:           (opencage_key === '') ? new L.Control.Geocoder.Nominatim() : new L.Control.Geocoder.OpenCage(opencage_key),
     defaultMarkGeocode: false,
     expand:             'click',
     showResultIcons:    true,

--- a/resources/views/admin/map-provider.phtml
+++ b/resources/views/admin/map-provider.phtml
@@ -26,22 +26,37 @@ use Fisharebest\Webtrees\I18N;
 
     <hr>
 
+        <div class="form-group">
+          <div class="form-row">
+            <legend class="col-form-label col-sm-3">
+                <?= /* I18N: A configuration setting */ I18N::translate('Use a gazetteer to provide autocomplete suggestions for places') ?>
+            </legend>
+            <div class="col-sm-9">
+                <?= view('components/radios-inline', ['name' => 'use_gazetteer', 'options' => [I18N::translate('no'), I18N::translate('yes')], 'selected' => (int) $use_gazetteer]) ?>
+                <p class="small text-muted">
+                    <?= /* I18N: Help text for the “Use a gazetteer to provide autocomplete suggestions for places” configuration setting */
+                    I18N::translate('This option controls whether or not to use a gazetteer to provide autocomplete suggestions for places. When this is enabled, the default is Nominatim the free search engine provided by OpenStreetMap, however if a key for OpenCage is provided then that is used instead.') ?>
+                </p>
+            </div>
+          </div>
+        </div>
+
     <div class="row form-group">
-        <label class="col-sm-3 col-form-label" for="geonames">
-            <?= I18N::translate('Use the GeoNames database for autocomplete on places') ?>
+        <label class="col-sm-3 col-form-label" for="opencage">
+            <?= I18N::translate('OpenCage key') ?>
         </label>
         <div class="col-sm-9">
             <input
             class="form-control"
             dir="ltr"
-            id="geonames"
+            id="opencage"
             maxlength="255"
-            name="geonames"
+            name="opencage"
             type="text"
-            value="<?= e($geonames) ?>"
+            value="<?= e($opencage) ?>"
             >
             <p class="small text-muted">
-                <?= /* I18N: Help text for the “Use GeoNames database for autocomplete on places” configuration setting */ I18N::translate('The website www.geonames.org provides a large database of place names. This can be searched when entering new places. To use this feature, you must register for a free account at www.geonames.org and provide the username.') ?>
+                <?= /* I18N: Help text for the “Use OpenCage database for autocomplete on places” configuration setting */ I18N::translate('The OpenCage geocoder searches a number of databases (including Geonames and Nominatim) in order to provide autocomplete options for new places. To use this feature, you must register for an account at %s and obtain a key. A free account allows 2500 searches per day.', '<a href="https://opencagedata.com/users/sign_up">OpenCage</a>') ?>
             </p>
         </div>
     </div>

--- a/tests/app/Http/Controllers/Admin/MapProviderControllerTest.php
+++ b/tests/app/Http/Controllers/Admin/MapProviderControllerTest.php
@@ -50,7 +50,7 @@ class MapProviderControllerTest extends TestCase
     public function testMapProviderSave(): void
     {
         $controller = new MapProviderController();
-        $request    = self::createRequest(RequestMethodInterface::METHOD_POST, [], ['provider' => '', 'geonames' => '']);
+        $request    = self::createRequest(RequestMethodInterface::METHOD_POST, [], ['provider' => '', 'use_gazetteer' => '', 'opencage' => '']);
         $response   = $controller->mapProviderSave($request);
 
         $this->assertSame(StatusCodeInterface::STATUS_FOUND, $response->getStatusCode());


### PR DESCRIPTION
I initially thought that as we're using Nominatim on the "Control panel-Geographic data-edit" pages it would be consistent to use the same thing for place autocomplete. Then I wondered which was better - Nominatim or Geonames - I searched but couldn't find a definitive answer but I did find OpenCage see https://opencagedata.com/ which aggregates searches over a number of geocoders including Nominatim and Geonames. It is also supported by the geocoder we use for the geographic data editing so I came up with this.
![dump](https://user-images.githubusercontent.com/104515/76902333-aec74e80-6893-11ea-970a-11f8432cb9e3.jpg)

