### PR TITLE
First Korean translate Complete.

### DIFF
--- a/resources/lang/ko/messages.po
+++ b/resources/lang/ko/messages.po
@@ -234,7 +234,7 @@ msgstr[0] "%s 손자"
 #, php-format
 msgid "%s individual"
 msgid_plural "%s individuals"
-msgstr[0] "%s 개인"
+msgstr[0] "%s 인물"
 
 #: app/Http/RequestHandlers/SearchReplaceAction.php:75
 #: app/Http/RequestHandlers/SearchReplaceAction.php:109
@@ -242,7 +242,7 @@ msgstr[0] "%s 개인"
 #, php-format
 msgid "%s individual has been updated."
 msgid_plural "%s individuals have been updated."
-msgstr[0] "%s 개인정보가 업데이트 되었습니다."
+msgstr[0] "%s 인물 정보가 업데이트 되었습니다."
 
 #: app/Http/Controllers/Admin/LocationController.php:890
 #, php-format
@@ -346,7 +346,7 @@ msgstr[0] "$%s 주"
 #, php-format
 msgid "%s year"
 msgid_plural "%s years"
-msgstr[0] "%s 년"
+msgstr[0] "%s "
 
 #: app/Http/Controllers/CalendarController.php:537
 #: resources/views/modules/yahrzeit/list.phtml:44
@@ -608,37 +608,37 @@ msgstr "A URL"
 #. I18N: Description of the “RelationshipsChart” module
 #: app/Module/RelationshipsChartModule.php:112
 msgid "A chart displaying relationships between two individuals."
-msgstr "두 개인의 관계를 보여주는 차트."
+msgstr "두 인물의 관계를 보여주는 차트."
 
 #. I18N: Description of the “FamilyBookChart” module
 #: app/Module/FamilyBookChartModule.php:102
 msgid "A chart of an individual’s ancestors and descendants, as a family book."
-msgstr "Family Book 모양으로 개인 조상과 후손을 보여주는 차트."
+msgstr "Family Book 모양으로 인물 조상과 후손을 보여주는 차트."
 
 #. I18N: Description of the “CompactTreeChart” module
 #: app/Module/CompactTreeChartModule.php:95
 msgid "A chart of an individual’s ancestors, as a compact tree."
-msgstr "compact tree 차트로 보여주는 개인의 조상"
+msgstr "compact tree 차트로 보여주는 인물의 조상"
 
 #. I18N: Description of the “PedigreeChart” module
 #: app/Module/PedigreeChartModule.php:129
 msgid "A chart of an individual’s ancestors, formatted as a tree."
-msgstr "가계도화 된 개인의 조상 차트"
+msgstr "가계도화 된 인물의 조상 차트"
 
 #. I18N: Description of the “AncestorsChart” module
 #: app/Module/AncestorsChartModule.php:118
 msgid "A chart of an individual’s ancestors."
-msgstr "개인의 조상 차트."
+msgstr "인물의 조상 차트."
 
 #. I18N: Description of the “DescendancyChart” module
 #: app/Module/DescendancyChartModule.php:118
 msgid "A chart of an individual’s descendants."
-msgstr "개인의 자손 차트."
+msgstr "인물의 자손 차트."
 
 #. I18N: Description of the “LifespansChart” module
 #: app/Module/LifespansChartModule.php:94
 msgid "A chart of individuals’ lifespans."
-msgstr "개인의 수명 차트."
+msgstr "인물의 수명 차트."
 
 #: resources/views/edit/link-child-to-family.phtml:29
 msgid "A child may have more than one set of parents. The relationship between the child and the parents can be biological, legal, or based on local culture and tradition. If no pedigree is specified, then a biological relationship will be assumed."
@@ -652,7 +652,7 @@ msgstr "일반적인 오류는 같은 레코드에 여러 개의 링크가있는
 #. I18N: Description of the “Fan Chart” module
 #: app/Module/FanChartModule.php:127
 msgid "A fan chart of an individual’s ancestors."
-msgstr "개인 조상의 Fan Chart"
+msgstr "인물 조상의 Fan Chart"
 
 #: resources/views/admin/map-import-form.phtml:19
 #: resources/views/admin/trees-export.phtml:18
@@ -713,7 +713,7 @@ msgstr "자주 묻는 질문 및 답변 목록."
 #. I18N: Description of the “Individuals” module
 #: app/Module/IndividualListModule.php:59
 msgid "A list of individuals."
-msgstr "개인 목록."
+msgstr "인물 목록."
 
 #. I18N: Description of the “Media objects” module
 #: app/Module/MediaListModule.php:62
@@ -823,29 +823,29 @@ msgstr "사용자가 %s 에서 Webtree에 등록했습니다."
 #: app/Module/PedigreeReportModule.php:52
 #: resources/xml/reports/pedigree_report.xml:4
 msgid "A report of an individual’s ancestors, formatted as a tree."
-msgstr "개인 조상 가계도"
+msgstr "인물 조상 가계도"
 
 #. I18N: Description of the “Ancestors” module
 #: app/Module/AhnentafelReportModule.php:52
 #: resources/xml/reports/ahnentafel_report.xml:5
 msgid "A report of an individual’s ancestors, in a narrative style."
-msgstr "개인의 조상에 관한 이야기."
+msgstr "인물의 조상에 관한 이야기."
 
 #. I18N: Description of the “Descendants” module
 #: app/Module/DescendancyReportModule.php:52
 #: resources/xml/reports/descendancy_report.xml:4
 msgid "A report of an individual’s descendants, in a narrative style."
-msgstr "개인의 자손에 대한 이야기"
+msgstr "인물의 자손에 대한 이야기"
 
 #. I18N: Description of the “Individual” module
 #: app/Module/IndividualReportModule.php:52
 #: resources/xml/reports/individual_report.xml:4
 msgid "A report of an individual’s details."
-msgstr "개인의 세부 사항에 대한 보고서."
+msgstr "인물의 세부 사항에 대한 보고서."
 
 #: resources/xml/reports/fact_sources.xml:4
 msgid "A report of facts which are supported by a given source."
-msgstr "특정 출처에서 지원하는 사실에 대한 보고서."
+msgstr "특정 출처에서 지원하는 정보에 대한 보고서."
 
 #. I18N: Description of the “Family” module
 #: app/Module/FamilyGroupReportModule.php:56
@@ -856,30 +856,30 @@ msgstr "가족 및 세부 보고서."
 #. I18N: Description of the “Deaths” module
 #: app/Module/DeathReportModule.php:52 resources/xml/reports/death_report.xml:4
 msgid "A report of individuals who died in a given time or place."
-msgstr "죽은 시간이나 장소에 관한 개인에 대한 보고서."
+msgstr "죽은 시간이나 장소에 관한 인물에 대한 보고서."
 
 #. I18N: Description of the “Occupations” module
 #: app/Module/OccupationReportModule.php:56
 #: resources/xml/reports/occupation_report.xml:4
 msgid "A report of individuals who had a given occupation."
-msgstr "개인의 직업에 관한 보고서"
+msgstr "인물의 직업에 관한 보고서"
 
 #. I18N: Description of the “Births” module
 #: app/Module/BirthReportModule.php:52 resources/xml/reports/birth_report.xml:4
 msgid "A report of individuals who were born in a given time or place."
-msgstr " 태어난 시간이나 장소에 관한 개인에 대한 보고서."
+msgstr " 태어난 시간이나 장소에 관한 인물에 대한 보고서."
 
 #. I18N: Description of the “Cemeteries” module
 #: app/Module/CemeteryReportModule.php:52
 #: resources/xml/reports/cemetery_report.xml:4
 msgid "A report of individuals who were buried in a given place."
-msgstr "특정 장소에 매장 된 개인에 대한 보고서."
+msgstr "특정 장소에 매장 된 인물에 대한 보고서."
 
 #. I18N: Description of the “Marriages” module
 #: app/Module/MarriageReportModule.php:52
 #: resources/xml/reports/marriage_report.xml:4
 msgid "A report of individuals who were married in a given time or place."
-msgstr "결혼한 시간이나 장소에 관한 개인에 대한 보고서"
+msgstr "결혼한 시간이나 장소에 관한 인물에 대한 보고서"
 
 #. I18N: Description of the “Changes” module
 #: app/Module/ChangeReportModule.php:56
@@ -923,47 +923,47 @@ msgstr "Role은 데이터를 보거나 환경 설정을 변경할 수있는 권�
 #. I18N: Description of the “Family navigator” module
 #: app/Module/FamilyNavigatorModule.php:51
 msgid "A sidebar showing an individual’s close families and relatives."
-msgstr "개인의 가까운 가족과 친척을 보여주는 SideBar."
+msgstr "인물의 가까운 가족과 친척을 보여주는 SideBar."
 
 #. I18N: Description of the “Extra information” module
 #: app/Module/IndividualMetadataModule.php:67
 msgid "A sidebar showing non-genealogy information about an individual."
-msgstr "개인에 대한 비 계보 정보를 보여주는 SideBar."
+msgstr "인물에 대한 비 계보 정보를 보여주는 SideBar."
 
 #. I18N: Description of the “Descendants” module
 #: app/Module/DescendancyModule.php:72
 msgid "A sidebar showing the descendants of an individual."
-msgstr "개인의 자손을 보여주는 SideBar."
+msgstr "인물의 자손을 보여주는 SideBar."
 
 #. I18N: Description of the “Families” module
 #: app/Module/RelativesTabModule.php:53
 msgid "A tab showing the close relatives of an individual."
-msgstr "개인의 친척을 보여주는 탭."
+msgstr "인물의 친척을 보여주는 탭."
 
 #. I18N: Description of the “Facts and events” module
 #: app/Module/IndividualFactsTabModule.php:77
 msgid "A tab showing the facts and events of an individual."
-msgstr "개인의 친척을 보여주는 탭."
+msgstr "인물의 친척을 보여주는 탭."
 
 #. I18N: Description of the “Media” module
 #: app/Module/MediaTabModule.php:71
 msgid "A tab showing the media objects linked to an individual."
-msgstr "개인의 사실과 사건을 보여주는 탭."
+msgstr "인물의 사실과 사건을 보여주는 탭."
 
 #. I18N: Description of the “Notes” module
 #: app/Module/NotesTabModule.php:70
 msgid "A tab showing the notes attached to an individual."
-msgstr "개인에게 첨부 된 메모를 보여주는 탭."
+msgstr "인물에게 첨부 된 노트를 보여주는 탭."
 
 #. I18N: Description of the “Sources” module
 #: app/Module/SourcesTabModule.php:70
 msgid "A tab showing the sources linked to an individual."
-msgstr "개인에 연결된 소스를 보여주는 탭."
+msgstr "인물에 연결된 출처를 보여주는 탭."
 
 #. I18N: Description of the “TimelineChart” module
 #: app/Module/TimelineChartModule.php:107
 msgid "A timeline displaying individual events."
-msgstr "개별 이벤트를 표시하는 타임 라인."
+msgstr "인물의 이벤트를 표시하는 타임 라인."
 
 #: resources/views/admin/users-edit.phtml:98
 msgid "A user will not be able to sign in until both “email verified” and “approved by administrator” are selected."
@@ -1196,7 +1196,7 @@ msgstr "딸 추가"
 
 #: resources/views/edit/raw-gedcom-record.phtml:47
 msgid "Add a fact"
-msgstr "사실 추가"
+msgstr "정보 추가"
 
 #: app/Http/Controllers/EditIndividualController.php:159
 #: resources/views/family-page-grandparents.phtml:24
@@ -1312,7 +1312,7 @@ msgstr "부인 추가"
 #: app/Http/Controllers/EditIndividualController.php:609
 #: resources/views/modules/relatives/tab.phtml:126
 msgid "Add a wife using an existing individual"
-msgstr "기존 개인 데이터베이스 자료를 사용하여 부인 추가"
+msgstr "기존 인물 데이터베이스 자료를 사용하여 부인 추가"
 
 #. I18N: FAQ = “Frequently Asked Question”
 #: app/Module/FrequentlyAskedQuestionsModule.php:301
@@ -1338,11 +1338,11 @@ msgstr "클립보드에 추가"
 
 #: app/Module/ModuleHistoricEventsTrait.php:40
 msgid "Add historic events to an individual’s page."
-msgstr "개인 페이지에 역사적인 이벤트를 추가"
+msgstr "인물 페이지에 역사적인 이벤트를 추가"
 
 #: resources/views/modules/lifespans-chart/page.phtml:20
 msgid "Add individuals"
-msgstr "개인 추가"
+msgstr "인물 추가"
 
 #: resources/views/modules/relatives/family.phtml:136
 msgid "Add marriage details"
@@ -1369,11 +1369,11 @@ msgstr "더 많은 필드 추가"
 #. I18N: Description of the “Stories” module
 #: app/Module/StoriesModule.php:77
 msgid "Add narrative stories to individuals in the family tree."
-msgstr ""
+msgstr "가계도의 인물에게 이야기체의 스토리를 추가하십시오."
 
 #: resources/views/admin/map-import-form.phtml:69
 msgid "Add new, and update existing records"
-msgstr "가계도의 개인에게 스토리를 추가"
+msgstr "가계도의 인물에게 스토리를 추가"
 
 #: resources/views/admin/trees-import.phtml:87
 msgid "Add spaces where long lines were wrapped"
@@ -1765,11 +1765,11 @@ msgstr "전체"
 #: app/Http/Controllers/AdminController.php:261
 #: resources/views/admin/trees-privacy.phtml:248
 msgid "All facts and events"
-msgstr "모든 사실과 사건"
+msgstr "모든 정보와 이벤트"
 
 #: resources/views/admin/trees-preferences.phtml:722
 msgid "All family facts"
-msgstr "가족의 모든 사실"
+msgstr "가족의 모든 정보"
 
 #: app/Http/RequestHandlers/RegisterAction.php:234
 msgid "All fields must be completed."
@@ -1777,12 +1777,12 @@ msgstr "모든 필드를 작성해야합니다."
 
 #: resources/views/admin/trees-preferences.phtml:668
 msgid "All individual facts"
-msgstr "개인의 모든 사실"
+msgstr "인물의 모든 정보"
 
 #: resources/views/calendar-page.phtml:97
 #: resources/views/calendar-page.phtml:109
 msgid "All individuals"
-msgstr "모든 개인"
+msgstr "모든 인물"
 
 #: app/Http/Controllers/Admin/ModuleController.php:85
 #: resources/views/admin/components.phtml:13
@@ -1797,11 +1797,11 @@ msgstr "All records"
 
 #: resources/views/admin/trees-preferences.phtml:817
 msgid "All repository facts"
-msgstr "모든 저장소 사실"
+msgstr "모든 저장소 정보"
 
 #: resources/views/admin/trees-preferences.phtml:776
 msgid "All source facts"
-msgstr "모든 소스 사실"
+msgstr "모든 출처 정보"
 
 #. I18N: Description of the “CKEditor” module. WYSIWYG = “what you see is what you get”
 #: app/Module/CkeditorModule.php:54
@@ -1862,7 +1862,7 @@ msgstr "차트를 표시하는 다른 방법"
 #. I18N: Description of the “Census assistant” module
 #: app/Module/CensusAssistantModule.php:57
 msgid "An alternative way to enter census transcripts and link them to individuals."
-msgstr "인구조사 사본을 입력하고 개인과 연결하는 다른 방법."
+msgstr "인구조사 사본을 입력하고 인물과 연결하는 다른 방법."
 
 #. I18N: Description of the “Theme change” module
 #: app/Module/ThemeSelectModule.php:56
@@ -1876,25 +1876,25 @@ msgstr "로그인 로그아웃에 대한 방법."
 
 #: app/Functions/FunctionsEdit.php:477
 msgid "An associate is another individual who was involved with this fact or event, such as a witness or a priest."
-msgstr "동료는 증인이나 성직자와 같은이 사실이나 사건에 연루된 다른 사람입니다."
+msgstr "동료는 증인이나 성직자와 같은 이 사실이나 사건에 연루된 다른 인물입니다."
 
 #: app/Functions/FunctionsEdit.php:475
 msgid "An associate is another individual who was involved with this individual, such as a friend or an employer."
-msgstr "동료는 친구 나 고용주와 같이 개인과 관련된 다른 개인입니다."
+msgstr "동료는 친구 나 고용주와 같은 인물과 관련된 다른 인물입니다."
 
 #. I18N: Description of the “HourglassChart” module
 #: app/Module/HourglassChartModule.php:100
 msgid "An hourglass chart of an individual’s ancestors and descendants."
-msgstr "개인의 조상과 자손의 모래 시계 차트."
+msgstr "인물의 조상과 자손의 모래 시계 차트."
 
 #: resources/views/edit/reorder-families.phtml:65
 msgid "An individual can have more than one set of parents.  For example, birth and adopted."
-msgstr "개인은 둘 이상의 부모 세트를 가질 수 있습니다. 예를 들어, 출생 및 입양."
+msgstr "인물은 둘 이상의 부모 세트를 가질 수 있습니다. 예를 들어, 출생 및 입양."
 
 #. I18N: Description of the “Interactive tree” module
 #: app/Module/InteractiveTreeModule.php:63
 msgid "An interactive tree, showing all the ancestors and descendants of an individual."
-msgstr "개인의 모든 조상과 후손을 보여주는 대화식 가계도"
+msgstr "인물의 모든 조상과 후손을 보여주는 대화식 가계도"
 
 #: resources/views/errors/database-error.phtml:8
 #: resources/views/setup/step-6-failed.phtml:8
@@ -2146,7 +2146,7 @@ msgstr "관련"
 
 #: app/Http/RequestHandlers/HelpText.php:249
 msgid "Associate events with this source"
-msgstr "이 소스와 이벤트 연관"
+msgstr "이 출처와 이벤트 연관"
 
 #. I18N: Location of an LDS church temple
 #: app/GedcomCode/GedcomCodeTemp.php:249
@@ -2179,7 +2179,7 @@ msgstr "기다리는 중"
 
 #: app/GedcomCode/GedcomCodeRela.php:107
 msgid "Attending"
-msgstr ""
+msgstr "기다리는 중"
 
 #: app/GedcomCode/GedcomCodeRela.php:104
 msgctxt "FEMALE"
@@ -2297,11 +2297,11 @@ msgstr "평균 연령"
 #: resources/views/modules/statistics-chart/custom.phtml:30
 #: resources/views/statistics/individuals/lifespan.phtml:20
 msgid "Average age at death"
-msgstr ""
+msgstr "사망 평균 연령"
 
 #: app/Statistics/Google/ChartMarriageAge.php:155
 msgid "Average age at marriage"
-msgstr "사망 평균 연령"
+msgstr "결혼 평균 연령"
 
 #: app/Statistics/Google/ChartMarriageAge.php:152
 msgid "Average age in century of marriage"
@@ -2321,7 +2321,7 @@ msgstr "평균 숫자"
 #: resources/views/modules/html/template-statistics.phtml:92
 #: resources/views/statistics/families/children.phtml:20
 msgid "Average number of children per family"
-msgstr "가족당 평균 어린이 수"
+msgstr "가족당 평균 자녀 수"
 
 #. I18N: help text for family tree / GEDCOM file names
 #: resources/views/admin/trees-create.phtml:43
@@ -2732,12 +2732,12 @@ msgstr "출생한 나라"
 #: resources/xml/reports/bdm_report.xml:8
 #: resources/xml/reports/birth_report.xml:8
 msgid "Birth date range end"
-msgstr "생년월일 종료"
+msgstr "생년월일 범위 종료"
 
 #: resources/xml/reports/bdm_report.xml:7
 #: resources/xml/reports/birth_report.xml:7
 msgid "Birth date range start"
-msgstr ""
+msgstr "생년월일 범위 시작"
 
 #: app/GedcomTag.php:1326
 msgid "Birth of a brother"
@@ -4043,12 +4043,12 @@ msgstr "가계도 작성"
 #: resources/views/modals/create-media-from-file.phtml:16
 #: resources/views/modals/create-media-object.phtml:11
 msgid "Create a media object"
-msgstr "미디어 오브젝트 작성"
+msgstr "미디어 개체 작성"
 
 #: app/Functions/FunctionsEdit.php:551
 #: resources/views/modals/create-repository.phtml:11
 msgid "Create a repository"
-msgstr "repository 작성"
+msgstr "저장소 작성"
 
 #: app/Functions/FunctionsEdit.php:504
 #: resources/views/modals/create-note-object.phtml:11
@@ -4062,7 +4062,7 @@ msgstr "인구조사 보조자료로 공유노트 작성"
 #: app/Functions/FunctionsEdit.php:568
 #: resources/views/modals/create-source.phtml:11
 msgid "Create a source"
-msgstr "소스 작성"
+msgstr "출처 작성"
 
 #: app/Functions/FunctionsEdit.php:576
 #: resources/views/modals/create-submitter.phtml:11
@@ -4079,7 +4079,7 @@ msgstr "고유 한 파일 이름 작성"
 
 #: app/Http/Controllers/EditIndividualController.php:362
 msgid "Create an individual"
-msgstr "개인 만들기"
+msgstr "인물 만들기"
 
 #: resources/views/modules/statistics-chart/custom.phtml:10
 msgid "Create your own chart"
@@ -4569,7 +4569,7 @@ msgstr "일:"
 #: app/Statistics/Google/ChartMortality.php:78
 #: resources/views/lists/individuals-table.phtml:205
 msgid "Dead"
-msgstr ""
+msgstr "사망"
 
 #. I18N: gedcom tag DEAT
 #: app/GedcomTag.php:654 resources/views/calendar-page.phtml:170
@@ -4872,12 +4872,12 @@ msgstr "Dec"
 #: resources/views/lists/individuals-table.phtml:476
 #: resources/views/lists/individuals-table.phtml:493
 msgid "Decade of birth"
-msgstr ""
+msgstr "출생의 10 년"
 
 #: resources/views/lists/individuals-table.phtml:502
 #: resources/views/lists/individuals-table.phtml:519
 msgid "Decade of death"
-msgstr "출생의 10 년"
+msgstr "사망의 10 년"
 
 #: resources/views/lists/families-table.phtml:492
 #: resources/views/lists/families-table.phtml:508
@@ -5010,7 +5010,7 @@ msgstr "계정 삭제"
 
 #: resources/views/family-page-menu.phtml:51
 msgid "Deleting the family will unlink all of the individuals from each other but will leave the individuals in place. Are you sure you want to delete this family?"
-msgstr "가족을 삭제하면 모든 개인이 서로 연결이 끊어 지지만 개인은 그대로 유지됩니다. 이 가족을 삭제 하시겠습니까?"
+msgstr "가족을 삭제하면 모든 인물이 서로 연결이 끊어지지만 인물은 그대로 유지됩니다. 이 가족을 삭제 하시겠습니까?"
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:132
@@ -5327,7 +5327,7 @@ msgstr "사용자 이름이 중복되었습니다. 해당 사용자 이름을 �
 
 #: resources/views/help/source-events.phtml:8
 msgid "Each source records specific events, generally for a given date range and for a place jurisdiction. For example a Census records census events and church records record birth, marriage, and death events.<br><br>Select the events that are recorded by this source from the list of events provided. The date should be specified in a range format such as <i>FROM 1900 TO 1910</i>. The place jurisdiction is the name of the lowest jurisdiction that encompasses all lower-level places named in this source. For example, “Oneida, Idaho, USA” would be used as a source jurisdiction place for events occurring in the various towns within Oneida County. “Idaho, USA” would be the source jurisdiction place if the events recorded took place not only in Oneida County but also in other counties in Idaho."
-msgstr "각 소스는 일반적으로 특정 날짜 범위 및 장소 관할 구역에 대한 특정 이벤트를 기록합니다. 예를 들어 인구 조사는 인구 조사 사건을 기록하고 교회 기록은 출생, 결혼 및 사망 사건을 기록합니다. <br><br> 기록 된 사건을 선택하십시오"
+msgstr "각 출처는 일반적으로 특정 날짜 범위 및 장소 관할 구역에 대한 특정 이벤트를 기록합니다. 예를 들어 인구 조사는 인구 조사 정보을 기록하고 교회 기록은 출생, 결혼 및 사망 정보를 기록합니다. <br><br> 기록 된 정보을 선택하십시오"
 
 #: resources/views/help/pending-changes.phtml:21
 msgid "Each user account has an option to “automatically accept changes”. When this is enabled, any changes made by that user are saved immediately. Many administrators enable this for their own user account."
@@ -5834,12 +5834,12 @@ msgstr "Fact 9"
 #. I18N: A configuration setting
 #: resources/views/admin/trees-preferences.phtml:523
 msgid "Fact icons"
-msgstr "Fact 아이콘"
+msgstr "정보 아이콘"
 
 #: resources/views/admin/trees-privacy.phtml:216
 #: resources/views/edit/add-fact-row.phtml:15
 msgid "Fact or event"
-msgstr "Fact 또는 이벤트"
+msgstr "정보 또는 이벤트"
 
 #. I18N: Name of a module/tab on the individual page.
 #: app/Module/IndividualFactsTabModule.php:66
@@ -5849,31 +5849,31 @@ msgstr "Fact 또는 이벤트"
 #: resources/xml/reports/individual_ext_report.xml:153
 #: resources/xml/reports/individual_report.xml:149
 msgid "Facts and events"
-msgstr "사실 및 이벤트"
+msgstr "정보 및 이벤트"
 
 #: resources/views/admin/trees-preferences.phtml:717
 msgid "Facts for family records"
-msgstr "가족 기록에 대한 사실"
+msgstr "가족 기록에 대한 정보"
 
 #: resources/views/admin/trees-preferences.phtml:663
 msgid "Facts for individual records"
-msgstr "인물 기록에 대한 사실"
+msgstr "인물 기록에 대한 정보"
 
 #: resources/views/admin/trees-preferences.phtml:748
 msgid "Facts for new families"
-msgstr "새로운 가족들에 대한 사실"
+msgstr "새로운 가족들에 대한 정보"
 
 #: resources/views/admin/trees-preferences.phtml:694
 msgid "Facts for new individuals"
-msgstr "새로운 인물에 대한 사실"
+msgstr "새로운 인물에 대한 정보"
 
 #: resources/views/admin/trees-preferences.phtml:812
 msgid "Facts for repository records"
-msgstr "레포지토리 기록에 대한 사실"
+msgstr "저장소 기록에 대한 정보"
 
 #: resources/views/admin/trees-preferences.phtml:771
 msgid "Facts for source records"
-msgstr "소스 기록에 대한 사실"
+msgstr "출처 기록에 대한 정보"
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:191
@@ -6250,7 +6250,7 @@ msgstr "필터"
 
 #: resources/xml/reports/fact_sources.xml:5
 msgid "Find a source"
-msgstr "소스 찾기"
+msgstr "출처 찾기"
 
 #: resources/views/edit/input-addon-keyboard.phtml:9
 #: resources/views/edit/input-addon-keyboard.phtml:12
@@ -7271,22 +7271,22 @@ msgstr "관리자가 사용자 계정을 생성하면 확인 이메일이 전송
 #: resources/views/help/name.phtml:22
 #, php-format
 msgid "If an individual does not have a surname, no slashes are needed: <%s>Jón Einarsson<%s>"
-msgstr "개인에게 성이 없으면 슬래시가 필요하지 않습니다. <%s> Jon Einarsson <%s>"
+msgstr "인물에게 성이 없으면 슬래시가 필요하지 않습니다. <%s> Jon Einarsson <%s>"
 
 #: resources/views/help/name.phtml:19
 #, php-format
 msgid "If an individual has two separate surnames, both should be enclosed by slashes: <%s>José Antonio /Gómez/ /Iglesias/<%s>"
-msgstr "개인이 두 개의 별명을 가진 경우 둘 다 슬래시로 묶어야합니다. <%s>José Antonio /Gómez/ /Iglesias/<%s>"
+msgstr "인물이 두 개의 별명을 가진 경우 둘 다 슬래시로 묶어야합니다. <%s>José Antonio /Gómez/ /Iglesias/<%s>"
 
 #: resources/views/help/name.phtml:28
 #, php-format
 msgid "If an individual was known by a nickname which is not part of their formal name, it should be enclosed by quotation marks. For example, <%s>John &quot;Nobby&quot; /Clark/<%s>."
-msgstr "개인이 정식 이름의 일부가 아닌 닉네임으로 알려진 경우 따옴표로 묶어야합니다. 예를 들어 <%s> John "Nobby"/Clark/ <%s>입니다."
+msgstr "인물이 정식 이름의 일부가 아닌 닉네임으로 알려진 경우 따옴표로 묶어야합니다. 예를 들어 <%s> John "Nobby"/Clark/ <%s>입니다."
 
 #: resources/views/help/name.phtml:25
 #, php-format
 msgid "If an individual was not known by their first given name, the preferred name should be indicated with an asterisk: <%s>John Paul* /Smith/<%s>"
-msgstr ""
+msgstr "인물이 첫 번째 이름으로 알려지지 않은 경우 선호하는 이름은 별표 (<%s>John Paul* /Smith/<%s>)로 표시해야합니다."
 
 #: resources/views/help/name.phtml:16
 #, php-format
@@ -7610,7 +7610,7 @@ msgstr "가장 오래 살았던 인물"
 #: resources/xml/reports/fact_sources.xml:54
 #: resources/xml/reports/fact_sources.xml:258
 msgid "Individuals"
-msgstr "개인"
+msgstr "인물"
 
 #: app/Statistics/Google/ChartIndividualWithSources.php:96
 #: resources/views/statistics/other/chart-sources.phtml:20
@@ -9165,18 +9165,18 @@ msgstr "Mercury"
 
 #: resources/views/admin/trees-duplicates.phtml:30
 msgid "Merge"
-msgstr "Merge"
+msgstr "병합"
 
 #: app/Http/Controllers/AdminTreesController.php:497
 #: resources/views/admin/control-panel.phtml:160
 msgid "Merge family trees"
-msgstr "Merge 가계도"
+msgstr "가계도 병합"
 
 #: app/Http/RequestHandlers/MergeFactsPage.php:57
 #: app/Http/RequestHandlers/MergeRecordsPage.php:67
 #: resources/views/admin/trees.phtml:156
 msgid "Merge records"
-msgstr "Merge records"
+msgstr "자료 병합"
 
 #. I18N: Location of an LDS church temple
 #: app/GedcomCode/GedcomCodeTemp.php:468
@@ -9264,7 +9264,7 @@ msgstr "군"
 #. I18N: gedcom tag _MILT
 #: app/GedcomTag.php:1978
 msgid "Military service"
-msgstr ""
+msgstr "병역"
 
 #. I18N: Name of a module/report
 #: app/Module/MissingFactsReportModule.php:44
@@ -9946,7 +9946,7 @@ msgstr "매핑 가능한 항목이 없습니다."
 #: resources/views/admin/merge-records-step-2.phtml:109
 #: resources/views/admin/merge-records-step-2.phtml:155
 msgid "No matching facts found"
-msgstr "일치하는 사실을 찾을 수 없습니다
+msgstr "일치하는 정보를 찾을 수 없습니다
 "
 
 #: resources/views/modules/gedcom_news/list.phtml:9
@@ -12671,54 +12671,54 @@ msgstr "통계 차트 표시"
 #: resources/views/admin/trees-preferences.phtml:583
 #, php-format
 msgid "Show the %1$s %2$s parts of a place name."
-msgstr ""
+msgstr "장소 이름의 %1$s %2$s 부분을 표시하십시오."
 
 #. I18N: Description of the “Pedigree map” module
 #: app/Module/PedigreeMapModule.php:129
 msgid "Show the birthplace of ancestors on a map."
-msgstr ""
+msgstr "조상의 출생지를 지도에 표시하십시오."
 
 #: resources/views/modules/html/config.phtml:45
 msgid "Show the date and time of update"
-msgstr ""
+msgstr "업데이트 날짜 및 시간 표시"
 
 #: resources/views/admin/trees-preferences.phtml:430
 msgid "Show the events of close relatives on the individual page"
-msgstr ""
+msgstr "인물 페이지에 가까운 친척의 사건을 보여주십시오"
 
 #. I18N: A configuration setting
 #: resources/views/admin/trees-privacy.phtml:22
 msgid "Show the family tree"
-msgstr ""
+msgstr "가계도 표시"
 
 #: app/Http/Controllers/ListController.php:285
 msgid "Show the list of individuals"
-msgstr ""
+msgstr "인물 목록 표시"
 
 #: app/Http/Controllers/ListController.php:291
 msgid "Show the list of surnames"
-msgstr ""
+msgstr "가문 목록 표시"
 
 #. I18N: Description of the “Places” module
 #: app/Module/PlacesModule.php:79
 msgid "Show the location of events on a map."
-msgstr ""
+msgstr "이벤트의 위치를 지도에 표시하십시오."
 
 #. I18N: label for a yes/no option
 #: resources/views/modules/recent_changes/config.phtml:37
 msgid "Show the user who made the change"
-msgstr ""
+msgstr "변경한 사용자 표시"
 
 #. I18N: Label for a configuration option
 #: resources/views/modules/faq/edit.phtml:41
 #: resources/views/modules/html/config.phtml:56
 #: resources/views/modules/stories/edit.phtml:49
 msgid "Show this block for which languages"
-msgstr ""
+msgstr "어떤 언어에 대해 이 블록을 표시"
 
 #: resources/views/admin/trees-preferences.phtml:292
 msgid "Show thumbnail images in charts and family groups."
-msgstr ""
+msgstr "썸네일 이미지를 차트와 가족 그룹으로 표시하십시오."
 
 #: app/Functions/FunctionsEdit.php:125 app/Functions/FunctionsEdit.php:248
 #: app/Functions/FunctionsEdit.php:269
@@ -12730,7 +12730,7 @@ msgstr ""
 #: app/Http/Controllers/AdminTreesController.php:760
 #: resources/views/modals/restriction-fields.phtml:21
 msgid "Show to managers"
-msgstr ""
+msgstr "관리자에게 표시"
 
 #: app/Functions/FunctionsEdit.php:124 app/Functions/FunctionsEdit.php:247
 #: app/Functions/FunctionsEdit.php:268
@@ -12744,7 +12744,7 @@ msgstr ""
 #: resources/views/admin/trees-privacy.phtml:92
 #: resources/views/modals/restriction-fields.phtml:18
 msgid "Show to members"
-msgstr ""
+msgstr "회원에게 표시"
 
 #: app/Functions/FunctionsEdit.php:123 app/Functions/FunctionsEdit.php:246
 #: app/Functions/FunctionsEdit.php:267
@@ -12758,49 +12758,49 @@ msgstr ""
 #: resources/views/admin/trees-privacy.phtml:153
 #: resources/views/modals/restriction-fields.phtml:15
 msgid "Show to visitors"
-msgstr ""
+msgstr "방문자에게 표시"
 
 #: resources/views/lists/families-table.phtml:197
 #: resources/views/lists/individuals-table.phtml:255
 msgid "Show “leaves” couples or individuals. These are individuals who are alive but have no children recorded in the database."
-msgstr ""
+msgstr "“떠난”커플 또는 개인을 보여줍니다. 이들은 살아 있지만 데이터베이스에 기록 된 자녀가없는 개인입니다."
 
 #: resources/views/lists/families-table.phtml:189
 #: resources/views/lists/individuals-table.phtml:247
 msgid "Show “roots” couples or individuals. These individuals may also be called “patriarchs”. They are individuals who have no parents recorded in the database."
-msgstr ""
+msgstr "뿌리” 커플 또는 개인을 보여줍니다. 이 사람들은 또한“가부장”이라고도합니다. 그들은 데이터베이스에 부모가 기록되어 있지 않은 개인입니다."
 
 #. I18N: %s are placeholders for numbers
 #: resources/views/lists/datatables-attributes.phtml:25
 #: resources/views/lists/datatables-attributes.phtml:26
 #, php-format
 msgid "Showing %1$s to %2$s of %3$s"
-msgstr ""
+msgstr "%3$s의 %1$s ~ %2$s 표시"
 
 #: resources/views/modules/pedigree-chart/previous.phtml:22
 msgid "Sibling"
-msgstr ""
+msgstr "형제"
 
 #: resources/views/modules/pedigree-chart/previous.phtml:20
 msgid "Siblings"
-msgstr ""
+msgstr "형제"
 
 #: resources/views/admin/modules.phtml:166
 #: resources/views/admin/modules.phtml:169
 msgid "Sidebar"
-msgstr ""
+msgstr "사이드바"
 
 #: app/Http/Controllers/Admin/ModuleController.php:240
 #: resources/views/admin/control-panel.phtml:535
 #: resources/views/admin/modules.phtml:75
 #: resources/views/admin/modules.phtml:77
 msgid "Sidebars"
-msgstr ""
+msgstr "사이드바"
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:447
 msgid "Sierra Leone"
-msgstr ""
+msgstr "Sierra Leone"
 
 #. I18N: Name of a module
 #: app/Http/RequestHandlers/LoginPage.php:77 app/Module/LoginBlockModule.php:43
@@ -12816,99 +12816,99 @@ msgstr "로그아웃"
 #: app/Http/Controllers/AdminSiteController.php:117
 #: resources/views/admin/control-panel.phtml:95
 msgid "Sign-in and registration"
-msgstr ""
+msgstr "로그인 및 등록"
 
 #: resources/views/help/date.phtml:122
 msgid "Simple dates are assumed to be in the gregorian calendar. To specify a date in another calendar, add a keyword before the date. This keyword is optional if the month or year format make the date unambiguous."
-msgstr ""
+msgstr "간단한 날짜는 그레고리력으로되어 있다고 가정합니다. 다른 캘린더에서 날짜를 지정하려면 날짜 앞에 키워드를 추가하십시오. 월 또는 연도 형식으로 날짜를 모호하지 않게하려면이 키워드는 선택 사항입니다."
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:437
 msgid "Singapore"
-msgstr ""
+msgstr "Singapore"
 
 #: resources/xml/reports/individual_ext_report.xml:355
 #: resources/xml/reports/individual_report.xml:352
 msgid "Sister"
-msgstr ""
+msgstr "여자형제"
 
 #. I18N: A configuration setting
 #: resources/views/modules/google-analytics/form.phtml:9
 #: resources/views/modules/matomo-analytics/form.phtml:9
 #: resources/views/modules/statcounter/form.phtml:9
 msgid "Site identification code"
-msgstr ""
+msgstr "사이트 식별 코드"
 
 #. I18N: Help text for the “Preferred contact method” configuration setting
 #: resources/views/admin/users-edit.phtml:172
 #: resources/views/edit-account-page.phtml:128
 msgid "Site members can send each other messages. You can choose to how these messages are sent to you, or choose not receive them at all."
-msgstr ""
+msgstr "사이트 회원은 서로 메시지를 보낼 수 있습니다. 이러한 메시지를 보내는 방법을 선택하거나 전혀받지 않도록 선택할 수 있습니다."
 
 #. I18N: A configuration setting
 #: resources/views/modules/bing-webmaster-tools/form.phtml:9
 #: resources/views/modules/google-webmaster-tools/form.phtml:9
 msgid "Site verification code"
-msgstr ""
+msgstr "사이트 인증 코드"
 
 #: resources/views/modules/bing-webmaster-tools/form.phtml:18
 #: resources/views/modules/google-webmaster-tools/form.phtml:18
 msgid "Site verification codes do not work when webtrees is installed in a subfolder."
-msgstr ""
+msgstr "웹 트리가 하위 폴더에 설치되어 있으면 사이트 확인 코드가 작동하지 않습니다."
 
 #. I18N: Name of a module - see http://en.wikipedia.org/wiki/Sitemaps
 #: app/Module/SiteMapModule.php:155
 msgid "Sitemaps"
-msgstr ""
+msgstr "사이트맵"
 
 #. I18N: The www.sitemaps.org site is translated into many languages (e.g. http://www.sitemaps.org/fr/) - choose an appropriate URL.
 #: resources/views/modules/sitemap/config.phtml:13
 msgid "Sitemaps are a way for webmasters to tell search engines about the pages on a website that are available for crawling. All major search engines support sitemaps. For more information, see <a href=\"http://www.sitemaps.org/\">www.sitemaps.org</a>."
-msgstr ""
+msgstr "사이트 맵은 웹 마스터가 크롤링 할 수있는 웹 사이트의 페이지에 대해 검색 엔진에 알리는 방법입니다. 모든 주요 검색 엔진은 사이트 맵을 지원합니다."
 
 #. I18N: a month in the Jewish calendar
 #: app/Date/JewishDate.php:199
 msgctxt "GENITIVE"
 msgid "Sivan"
-msgstr ""
+msgstr "Sivan"
 
 #. I18N: a month in the Jewish calendar
 #: app/Date/JewishDate.php:305
 msgctxt "INSTRUMENTAL"
 msgid "Sivan"
-msgstr ""
+msgstr "Sivan"
 
 #. I18N: a month in the Jewish calendar
 #: app/Date/JewishDate.php:252
 msgctxt "LOCATIVE"
 msgid "Sivan"
-msgstr ""
+msgstr "Sivan"
 
 #. I18N: a month in the Jewish calendar
 #: app/Date/JewishDate.php:146
 msgctxt "NOMINATIVE"
 msgid "Sivan"
-msgstr ""
+msgstr "Sivan"
 
 #. I18N: Skip over the headers and menus, to the main content of the page
 #: resources/views/layouts/administration.phtml:48
 #: resources/views/layouts/default.phtml:83
 msgid "Skip to content"
-msgstr ""
+msgstr "내용으로 건너 뛰기"
 
 #: app/GedcomCode/GedcomCodeRela.php:335
 msgid "Slave"
-msgstr ""
+msgstr "노예"
 
 #: app/GedcomCode/GedcomCodeRela.php:332
 msgctxt "FEMALE"
 msgid "Slave"
-msgstr ""
+msgstr "노예"
 
 #: app/GedcomCode/GedcomCodeRela.php:328
 msgctxt "MALE"
 msgid "Slave"
-msgstr ""
+msgstr "노예"
 
 #. I18N: gedcom tag _SSHOW
 #. I18N: Name of a module
@@ -12919,16 +12919,16 @@ msgstr "슬라이드 쇼"
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:463
 msgid "Slovakia"
-msgstr ""
+msgstr "Slovakia"
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:465
 msgid "Slovenia"
-msgstr ""
+msgstr "Slovenia"
 
 #: resources/views/setup/step-2-server-checks.phtml:48
 msgid "Small systems (500 individuals): 16–32 MB, 10–20 seconds"
-msgstr ""
+msgstr "소규모 시스템 (개인 500 명) : 16–32MB, 10–20 초"
 
 #. I18N: Location of an LDS church temple
 #: app/GedcomCode/GedcomCodeTemp.php:621
@@ -12938,7 +12938,7 @@ msgstr ""
 #. I18N: gedcom tag SSN
 #: app/GedcomTag.php:1026
 msgid "Social security number"
-msgstr ""
+msgstr "주민등록번호"
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:445
@@ -12953,30 +12953,30 @@ msgstr ""
 #. I18N: Help text for the “GEDCOM media path” configuration setting. A “path” is something like “C:\Documents\Genealogy\Photos\John_Smith.jpeg”
 #: resources/views/admin/trees-import.phtml:105
 msgid "Some genealogy software creates GEDCOM files that contain media filenames with full paths. These paths will not exist on the web-server. To allow webtrees to find the file, the first part of the path must be removed."
-msgstr ""
+msgstr "일부 계보 소프트웨어는 전체 경로가 포함 된 미디어 파일 이름이 포함 된 GEDCOM 파일을 생성합니다. 이 경로는 웹 서버에 존재하지 않습니다. 웹 트리가 파일을 찾도록하려면 경로의 첫 부분을 제거해야합니다."
 
 #. I18N: Help text for the “Hit counters” configuration setting
 #: resources/views/admin/trees-preferences.phtml:655
 msgid "Some pages can display the number of times that they have been visited."
-msgstr ""
+msgstr "일부 페이지는 방문한 횟수를 표시 할 수 있습니다."
 
 #. I18N: Help text for the “Fact icons” configuration setting
 #: resources/views/admin/trees-preferences.phtml:528
 msgid "Some themes can display icons on the “Facts and events” tab."
-msgstr ""
+msgstr "일부 테마는 "정보 및 이벤트" 탭에 아이콘을 표시 할 수 있습니다."
 
 #: resources/views/edit/change-family-members.phtml:49
 #: resources/xml/reports/family_group_report.xml:774
 #: resources/xml/reports/individual_ext_report.xml:526
 #: resources/xml/reports/individual_report.xml:530
 msgid "Son"
-msgstr ""
+msgstr "아들"
 
 #. I18N: e.g. “Son of [father name & mother name]”
 #: app/Module/InteractiveTree/TreeView.php:357
 #, php-format
 msgid "Son of %s"
-msgstr ""
+msgstr "%s의 아들"
 
 #. I18N: Label for a configuration option
 #: resources/views/modules/faq/config.phtml:41
@@ -12995,7 +12995,7 @@ msgstr ""
 #: resources/xml/reports/occupation_report.xml:6
 #: resources/xml/reports/relative_ext_report.xml:7
 msgid "Sort order"
-msgstr ""
+msgstr "정렬 순서"
 
 #. I18N: Abbreviation for “Sosa-Stradonitz number”. This is an individual’s surname, so may need transliterating into non-latin alphabets.
 #: resources/views/lists/individuals-table.phtml:267
@@ -13008,7 +13008,7 @@ msgstr ""
 
 #: app/Http/RequestHandlers/SearchAdvancedPage.php:228
 msgid "Sounds like"
-msgstr ""
+msgstr "처럼 들린다"
 
 #. I18N: gedcom tag SOUR
 #. I18N: Name of a module/report
@@ -13044,18 +13044,18 @@ msgstr ""
 #: resources/xml/reports/missing_facts_report.xml:529
 #: resources/xml/reports/missing_facts_report.xml:570
 msgid "Source"
-msgstr ""
+msgstr "출처"
 
 #. I18N: Help text for the “Use full source citations” configuration setting
 #: resources/views/admin/trees-preferences.phtml:907
 msgid "Source citations can include fields to record the quality of the data (primary, secondary, etc.) and the date the event was recorded in the source. If you don’t use these fields, you can disable them when creating new source citations."
-msgstr ""
+msgstr "출처 인용에는 데이터의 품질 (1 차, 2 차 등) 및 이벤트가 소스에 기록 된 날짜를 기록하는 필드가 포함될 수 있습니다. 이 입력란을 사용하지 않으면 새 출처 인용을 만들 때 사용 중지 할 수 있습니다."
 
 #. I18N: A configuration setting
 #: resources/views/admin/trees-preferences.phtml:917
 #: resources/xml/reports/fact_sources.xml:6
 msgid "Source type"
-msgstr ""
+msgstr "출처 유형"
 
 #. I18N: Name of a module/list
 #. I18N: Name of a module
@@ -13086,11 +13086,11 @@ msgstr ""
 #: resources/xml/reports/individual_ext_report.xml:644
 #: resources/xml/reports/individual_report.xml:646
 msgid "Sources"
-msgstr ""
+msgstr "출처"
 
 #: resources/xml/reports/missing_facts_report.xml:14
 msgid "Sources to the events"
-msgstr ""
+msgstr "이벤트 "
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:540
@@ -13133,32 +13133,32 @@ msgstr ""
 #: resources/xml/reports/individual_ext_report.xml:202
 #: resources/xml/reports/individual_ext_report.xml:219
 msgid "Spouse"
-msgstr ""
+msgstr "배우자"
 
 #: app/GedcomTag.php:741
 msgid "Spouse census date"
-msgstr ""
+msgstr "배우자 인구조사 날짜"
 
 #: app/GedcomTag.php:743
 msgid "Spouse census place"
-msgstr ""
+msgstr "배우자 인구조사 장소"
 
 #: app/GedcomTag.php:751
 msgid "Spouse note"
-msgstr ""
+msgstr "배우자 노트"
 
 #: resources/views/edit/reorder-families.phtml:21
 #: resources/views/lists/surnames-table.phtml:27
 #: resources/views/modules/family-book-chart/page.phtml:45
 #: resources/views/modules/pedigree-chart/previous.phtml:29
 msgid "Spouses"
-msgstr ""
+msgstr "배우자"
 
 #: resources/xml/reports/individual_ext_report.xml:6
 #: resources/xml/reports/missing_facts_report.xml:6
 #: resources/xml/reports/relative_ext_report.xml:6
 msgid "Spouses and children"
-msgstr ""
+msgstr "배우자와 자녀"
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:302
@@ -13182,20 +13182,20 @@ msgstr ""
 
 #: resources/views/modules/random_media/config.phtml:40
 msgid "Start slide show on page load"
-msgstr ""
+msgstr "페이지 로드 시 슬라이드 쇼 시작"
 
 #: resources/views/modules/lifespans-chart/page.phtml:45
 msgid "Start year"
-msgstr ""
+msgstr "시작년도"
 
 #: resources/xml/reports/change_report.xml:5
 msgid "Starting range of change dates"
-msgstr ""
+msgstr "변경 날짜의 시작 범위"
 
 #. I18N: gedcom tag STAE
 #: app/GedcomTag.php:1029
 msgid "State"
-msgstr ""
+msgstr "주"
 
 #. I18N: Name of a module
 #. I18N: Name of a module/chart
@@ -13205,27 +13205,27 @@ msgstr ""
 #: resources/views/modules/gedcom_stats/statistics.phtml:17
 #: resources/views/modules/gedcom_stats/statistics.phtml:137
 msgid "Statistics"
-msgstr ""
+msgstr "통계"
 
 #. I18N: gedcom tag STAT
 #: app/Functions/FunctionsPrint.php:382 app/GedcomTag.php:1032
 #: resources/views/admin/changes-log.phtml:36
 #: resources/views/admin/changes-log.phtml:116
 msgid "Status"
-msgstr ""
+msgstr "상태"
 
 #: app/GedcomTag.php:1034
 msgid "Status change date"
-msgstr ""
+msgstr "날짜 변경 상태"
 
 #: app/Functions/FunctionsDate.php:45
 msgid "Stillborn"
-msgstr ""
+msgstr "사산"
 
 #. I18N: LDS sealing status; see http://en.wikipedia.org/wiki/Sealing_(Latter_Day_Saints)
 #: app/GedcomCode/GedcomCodeStat.php:136
 msgid "Stillborn: exempt"
-msgstr ""
+msgstr "사산 : 면제"
 
 #. I18N: Location of an LDS church temple
 #: app/GedcomCode/GedcomCodeTemp.php:633
@@ -13242,17 +13242,17 @@ msgstr "정지"
 #: app/Module/StoriesModule.php:207
 #: resources/views/modules/stories/edit.phtml:13
 msgid "Stories"
-msgstr ""
+msgstr "스토리"
 
 #: resources/views/modules/stories/edit.phtml:40
 msgid "Story"
-msgstr ""
+msgstr "스토리"
 
 #: resources/views/modules/stories/config.phtml:36
 #: resources/views/modules/stories/edit.phtml:31
 #: resources/views/modules/stories/list.phtml:12
 msgid "Story title"
-msgstr ""
+msgstr "스토리 제목"
 
 #: app/Module/UserMessagesModule.php:180
 #: resources/views/admin/broadcast.phtml:38
@@ -13264,22 +13264,22 @@ msgstr "제목"
 #. I18N: gedcom tag SUBN
 #: app/GedcomTag.php:1040
 msgid "Submission"
-msgstr ""
+msgstr "제출"
 
 #. I18N: LDS sealing status; see http://en.wikipedia.org/wiki/Sealing_(Latter_Day_Saints)
 #: app/GedcomCode/GedcomCodeStat.php:139
 msgid "Submitted but not yet cleared"
-msgstr ""
+msgstr "제출했지만 아직 지워지지 않았습니다."
 
 #. I18N: gedcom tag SUBM
 #: app/GedcomTag.php:1037 resources/views/admin/trees.phtml:247
 #: resources/views/modules/recent_changes/changes-table.phtml:75
 msgid "Submitter"
-msgstr ""
+msgstr "제출자"
 
 #: resources/views/lists/submitters-table.phtml:60
 msgid "Submitter name"
-msgstr ""
+msgstr "제출자 이름"
 
 #. I18N: Name of a module/list
 #: app/Http/Controllers/ListController.php:548
@@ -13288,7 +13288,7 @@ msgstr ""
 #: resources/views/admin/merge-records-step-1.phtml:29
 #: resources/views/lists/submitters-table.phtml:55
 msgid "Submitters"
-msgstr ""
+msgstr "제출자"
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:429
@@ -13309,15 +13309,15 @@ msgstr ""
 #: resources/views/admin/control-panel.phtml:59
 #, php-format
 msgid "Support and documentation can be found at %s."
-msgstr ""
+msgstr "지원 및 설명서는 %s에서 찾을 수 있습니다."
 
 #: app/Services/ServerCheckService.php:328
 msgid "Support for PostgreSQL is experimental."
-msgstr ""
+msgstr "PostgreSQL 지원은 실험적입니다."
 
 #: app/Services/ServerCheckService.php:333
 msgid "Support for SQL Server is experimental."
-msgstr ""
+msgstr "SQL Server 지원은 실험적입니다."
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:461
@@ -13334,45 +13334,45 @@ msgstr ""
 #: resources/views/modules/statistics-chart/custom.phtml:160
 #: resources/views/search-phonetic-page.phtml:29
 msgid "Surname"
-msgstr ""
+msgstr "가문이름"
 
 #: app/Statistics/Google/ChartDistribution.php:333
 msgid "Surname distribution chart"
-msgstr ""
+msgstr "가문이름 분포도"
 
 #: resources/views/admin/trees-preferences.phtml:333
 msgid "Surname list style"
-msgstr ""
+msgstr "가문이름 목록 스타일"
 
 #: resources/views/modules/fix-add-marr-names/options.phtml:16
 msgid "Surname option"
-msgstr ""
+msgstr "가문이름 옵션"
 
 #. I18N: gedcom tag SPFX
 #: app/GedcomTag.php:1023
 msgid "Surname prefix"
-msgstr ""
+msgstr "가문이름 접두사"
 
 #: resources/views/admin/trees-preferences.phtml:887
 msgid "Surname tradition"
-msgstr ""
+msgstr "가문이름 전통"
 
 #: resources/views/lists/surnames-table.phtml:18
 #: resources/views/modules/gedcom_stats/config.phtml:48
 #: resources/views/modules/gedcom_stats/statistics.phtml:56
 #: resources/views/modules/statistics-chart/custom.phtml:155
 msgid "Surnames"
-msgstr ""
+msgstr "가문이름"
 
 #. I18N: In the Lithuanian surname tradition, ...
 #: app/SurnameTradition.php:113
 msgid "Surnames are inflected to indicate an individual’s gender and marital status."
-msgstr ""
+msgstr "가문이름은 개인의 성별과 결혼 상태를 나타내기 위해 활용됩니다."
 
 #. I18N: In the Polish surname tradition, ...
 #: app/SurnameTradition.php:106
 msgid "Surnames are inflected to indicate an individual’s gender."
-msgstr ""
+msgstr "가문이름은 개인의 성별을 나타 내기 위해 활용됩니다."
 
 #. I18N: Location of an LDS church temple
 #: app/GedcomCode/GedcomCodeTemp.php:636
@@ -13387,7 +13387,7 @@ msgstr ""
 #. I18N: Reverse the order of two individuals
 #: resources/views/modules/relationships-chart/page.phtml:72
 msgid "Swap individuals"
-msgstr ""
+msgstr "인물 교환"
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:469
@@ -13411,7 +13411,7 @@ msgstr ""
 
 #: resources/views/admin/trees.phtml:290
 msgid "Synchronize family trees with GEDCOM files"
-msgstr ""
+msgstr "GEDCOM 파일과 가계도 동기화"
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:474
@@ -13421,14 +13421,14 @@ msgstr ""
 #: resources/views/admin/modules.phtml:158
 #: resources/views/admin/modules.phtml:161
 msgid "Tab"
-msgstr ""
+msgstr "탭"
 
 #: resources/views/setup/step-4-database-mysql.phtml:99
 #: resources/views/setup/step-4-database-pgsql.phtml:86
 #: resources/views/setup/step-4-database-sqlite.phtml:58
 #: resources/views/setup/step-4-database-sqlsvr.phtml:86
 msgid "Table prefix"
-msgstr ""
+msgstr "테이블 접두사"
 
 #: resources/xml/reports/ahnentafel_report.xml:13
 #: resources/xml/reports/bdm_report.xml:12
@@ -13454,7 +13454,7 @@ msgstr ""
 #: resources/views/admin/modules.phtml:71
 #: resources/views/admin/modules.phtml:73
 msgid "Tabs"
-msgstr ""
+msgstr "탭"
 
 #. I18N: Location of an LDS church temple
 #: app/GedcomCode/GedcomCodeTemp.php:645
@@ -13513,7 +13513,7 @@ msgstr ""
 #. I18N: A configuration setting
 #: resources/views/admin/trees-preferences.phtml:168
 msgid "Technical help contact"
-msgstr ""
+msgstr "기술 지원 문의"
 
 #. I18N: Location of an LDS church temple
 #: app/GedcomCode/GedcomCodeTemp.php:651
@@ -13522,12 +13522,12 @@ msgstr ""
 
 #: resources/views/modules/html/config.phtml:20
 msgid "Templates"
-msgstr ""
+msgstr "템플릿"
 
 #. I18N: gedcom tag TEMP
 #: app/GedcomTag.php:1046 resources/xml/reports/individual_report.xml:208
 msgid "Temple"
-msgstr ""
+msgstr "사원"
 
 #. I18N: a month in the Jewish calendar
 #: app/Date/JewishDate.php:185
@@ -13557,7 +13557,7 @@ msgstr ""
 #: app/GedcomTag.php:1049 resources/views/admin/trees-preferences.phtml:594
 #: resources/views/modals/source-fields.phtml:53
 msgid "Text"
-msgstr ""
+msgstr "텍스트"
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:482
@@ -13566,20 +13566,20 @@ msgstr ""
 
 #: resources/views/help/name.phtml:8
 msgid "The <b>name</b> field contains the individual’s full name, as they would have spelled it or as it was recorded. This is how it will be displayed on screen. It uses standard genealogy annotations to identify different parts of the name."
-msgstr ""
+msgstr "<b>이름</b> 입력란에는 철자가 기록되거나 기록 된대로 개인의 성명이 포함됩니다. 이것이 화면에 표시되는 방식입니다. 표준 계보 주석을 사용하여 이름의 다른 부분을 식별합니다."
 
 #: resources/views/help/surname.phtml:8
 msgid "The <b>surname</b> field contains a name that is used for sorting and grouping. It can be different to the individual’s actual surname which is always taken from the <b>name</b> field. This field can be used to sort surnames with or without a prefix (Gogh / van Gogh) and to group spelling variations or inflections (Kowalski / Kowalska). If an individual needs to be listed under more than one surname, each name should be separated by a comma."
-msgstr ""
+msgstr "<b>가문이름</b> 필드에는 정렬 및 그룹화에 사용되는 이름이 있습니다. 항상 <b>이름</b> 입력란에서 가져온 개인의 실제 가문이름과 다를 수 있습니다. 이 필드는 접두사 (Gogh / van Gogh)가 있거나 없는 가문이름을 정렬하고 철자 변형 또는 변곡 (Kowalski / Kowalska)을 그룹화하는 데 사용할 수 있습니다. 개인을 둘 이상의 가문이름 아래에 나열해야하는 경우 각 이름은 쉼표로 구분해야합니다."
 
 #: app/Http/Controllers/AdminTreesController.php:1500
 #, php-format
 msgid "The GEDCOM file “%s” has been imported."
-msgstr ""
+msgstr "GEDCOM 파일 “%s”을(를) 가져 왔습니다."
 
 #: resources/views/modals/media-file-fields.phtml:98
 msgid "The GEDCOM standard does not allow URLs in media objects."
-msgstr ""
+msgstr "GEDCOM 표준은 미디어 객체의 URL을 허용하지 않습니다."
 
 #. I18N: Location of an LDS church temple
 #: app/GedcomCode/GedcomCodeTemp.php:378
@@ -13589,261 +13589,261 @@ msgstr ""
 #: app/Services/ServerCheckService.php:125
 #, php-format
 msgid "The PHP extension “%s” is not installed."
-msgstr ""
+msgstr "PHP 익스텐션 "%s"이(가) 설치되지 않았습니다."
 
 #: app/Services/ServerCheckService.php:183
 #, php-format
 msgid "The PHP function “%1$s” is disabled."
-msgstr ""
+msgstr "PHP 기능 “%1$s”이 비활성화 되었습니다."
 
 #. I18N: PHP internal error message - php.net/manual/en/features.file-upload.errors.php
 #: app/Functions/Functions.php:57
 msgid "The PHP temporary folder is missing."
-msgstr ""
+msgstr "PHP 임시 폴더가 없습니다."
 
 #: app/Services/ServerCheckService.php:144
 #, php-format
 msgid "The PHP.INI setting “%1$s” is disabled."
-msgstr ""
+msgstr "PHP.INI 설정 “%1$s”이 비활성화되었습니다."
 
 #: app/Services/ServerCheckService.php:148
 #, php-format
 msgid "The PHP.INI setting “%1$s” is enabled."
-msgstr ""
+msgstr "PHP.INI 설정 “%1$s”이 활성화되었습니다."
 
 #: resources/views/emails/approve-user-html.phtml:13
 #: resources/views/emails/approve-user-text.phtml:8
 #, php-format
 msgid "The administrator at the webtrees site %s has approved your application for an account. You may now sign in by accessing the following link: %s"
-msgstr ""
+msgstr "웹 트리 사이트 %s의 관리자가 귀하의 계정 신청을 승인했습니다. 다음 링크에 액세스하여 로그인 할 수 있습니다 : %s"
 
 #: resources/views/verify-success-page.phtml:16
 msgid "The administrator has been informed. As soon as they give you permission to sign in, you can sign in with your username and password."
-msgstr ""
+msgstr "관리자에게 정보가 제공되었습니다. 로그인 권한을 부여하면 사용자 이름과 비밀번호로 로그인 할 수 있습니다."
 
 #. I18N: Description of the “Calendar” module
 #: app/Module/CalendarMenuModule.php:52
 msgid "The calendar menu."
-msgstr ""
+msgstr "달력 메뉴"
 
 #. I18N: %s is the name of a genealogy record
 #: app/Http/RequestHandlers/PendingChangesAcceptRecord.php:69
 #: app/Http/RequestHandlers/PendingChangesAcceptTree.php:62
 #, php-format
 msgid "The changes to “%s” have been accepted."
-msgstr ""
+msgstr ""%s"에 대한 변경이 승인되었습니다."
 
 #. I18N: %s is the name of a genealogy record
 #: app/Http/RequestHandlers/PendingChangesRejectRecord.php:67
 #: app/Http/RequestHandlers/PendingChangesRejectTree.php:62
 #, php-format
 msgid "The changes to “%s” have been rejected."
-msgstr ""
+msgstr "%s"에 대한 변경이 거부되었습니다."
 
 #. I18N: Description of the “Charts” module
 #: app/Module/ChartsMenuModule.php:71
 msgid "The charts menu."
-msgstr ""
+msgstr "차트 메뉴"
 
 #: resources/views/modules/clippings/show.phtml:10
 msgid "The clippings cart allows you to take extracts from this family tree and download them as a GEDCOM file."
-msgstr ""
+msgstr "클리핑 카트를 사용하면 이 가계도에서 추출한 내용을 가져 와서 GEDCOM 파일로 다운로드 할 수 있습니다."
 
 #: resources/views/admin/trees-preferences.phtml:382
 msgid "The date and time of the last update"
-msgstr ""
+msgstr "마지막 업데이트 날짜 및 시간"
 
 #: app/Http/Controllers/Admin/LocationController.php:415
 #: app/Http/RequestHandlers/AccountUpdate.php:113
 #, php-format
 msgid "The details for “%s” have been updated."
-msgstr ""
+msgstr ""%s"의 세부 정보가 업데이트되었습니다."
 
 #. I18N: %s is a filename
 #: app/Http/Controllers/Admin/UpgradeController.php:308
 #: app/Http/RequestHandlers/ExportGedcomServer.php:79
 #, php-format
 msgid "The family tree has been exported to %s."
-msgstr ""
+msgstr "가계도를 %s로 내보냈습니다."
 
 #: app/Http/RequestHandlers/CreateTreeAction.php:64
 #, php-format
 msgid "The family tree “%s” already exists."
-msgstr ""
+msgstr "가계도 "%s"이(가) 이미 존재합니다."
 
 #: app/Http/RequestHandlers/CreateTreeAction.php:71
 #, php-format
 msgid "The family tree “%s” has been created."
-msgstr ""
+msgstr "가계도 "%s"이(가) 생성되었습니다."
 
 #. I18N: %s is the name of a family tree
 #: app/Http/Controllers/AdminTreesController.php:1507
 #: app/Http/RequestHandlers/DeleteTreeAction.php:65
 #, php-format
 msgid "The family tree “%s” has been deleted."
-msgstr ""
+msgstr "가계도 "%s"이(가) 삭제되었습니다."
 
 #. I18N: %s is the name of a family tree
 #: app/Http/RequestHandlers/SelectDefaultTree.php:54
 #, php-format
 msgid "The family tree “%s” will be shown to visitors when they first arrive at this website."
-msgstr ""
+msgstr "이 웹 사이트에 처음 방문하면 가계도 "%s"이(가) 방문자에게 표시됩니다."
 
 #: app/Http/Controllers/AdminTreesController.php:697
 msgid "The family trees have been merged successfully."
-msgstr ""
+msgstr "가계도가 성공적으로 병합되었습니다."
 
 #. I18N: Description of the “Family trees” module
 #: app/Module/TreesMenuModule.php:71
 msgid "The family trees menu."
-msgstr ""
+msgstr "가계도 메뉴"
 
 #. I18N: %s is the name of a family group, e.g. “Husband name + Wife name”
 #: app/Http/RequestHandlers/DeleteRecord.php:73
 #, php-format
 msgid "The family “%s” has been deleted because it only has one member."
-msgstr ""
+msgstr "%s" 가계는 하나의 구성원 만 있기 때문에 삭제되었습니다."
 
 #: app/Http/Controllers/Admin/MediaController.php:455
 #, php-format
 msgid "The file %s already exists. Use another filename."
-msgstr ""
+msgstr "파일 %s이(가) 이미 존재합니다. 다른 파일 이름을 사용하십시오."
 
 #: app/Http/RequestHandlers/ExportGedcomServer.php:82
 #, php-format
 msgid "The file %s could not be created."
-msgstr ""
+msgstr "파일 %s을(를) 만들 수 없습니다."
 
 #: app/Http/RequestHandlers/DeletePath.php:62
 #: app/Http/RequestHandlers/DeletePath.php:76
 #, php-format
 msgid "The file %s could not be deleted."
-msgstr ""
+msgstr "파일 %s을(를) 지울 수 없습니다."
 
 #: app/Http/RequestHandlers/DeletePath.php:60
 #, php-format
 msgid "The file %s has been deleted."
-msgstr ""
+msgstr "파일 %s이(가) 삭제되었습니다."
 
 #: app/Http/Controllers/Admin/MediaController.php:462
 #, php-format
 msgid "The file %s has been uploaded."
-msgstr ""
+msgstr "%s 파일이 업로드되었습니다."
 
 #. I18N: PHP internal error message - php.net/manual/en/features.file-upload.errors.php
 #: app/Functions/Functions.php:51
 msgid "The file was only partially uploaded. Please try again."
-msgstr ""
+msgstr "파일이 부분적으로 만 업로드되었습니다. 다시 시도하십시오."
 
 #. I18N: %s is a filename
 #: resources/views/media-page.phtml:121
 #: resources/views/modules/media-list/page.phtml:145
 #, php-format
 msgid "The file “%s” does not exist."
-msgstr ""
+msgstr ""%s”파일이 없습니다."
 
 #: resources/views/edit/reorder-families.phtml:67
 msgid "The first family in the list will be used in charts, lists, reports, etc."
-msgstr ""
+msgstr "목록의 첫 번째 가족은 차트, 목록, 보고서 등에 사용됩니다."
 
 #: app/Http/RequestHandlers/DeletePath.php:71
 #, php-format
 msgid "The folder %s could not be deleted."
-msgstr ""
+msgstr "폴더 %s을(를) 삭제할 수 없습니다."
 
 #: app/Http/Controllers/Admin/UpgradeController.php:261
 #, php-format
 msgid "The folder %s has been created."
-msgstr ""
+msgstr "폴더 %s이(가) 생성되었습니다."
 
 #: app/Http/RequestHandlers/DeletePath.php:69
 #, php-format
 msgid "The folder %s has been deleted."
-msgstr ""
+msgstr "폴더 %s이(가) 삭제되었습니다."
 
 #: resources/views/admin/site-preferences.phtml:36
 msgid "The folder can be specified in full (e.g. /home/user_name/webtrees_data/) or relative to the installation folder (e.g. ../../webtrees_data/)."
-msgstr ""
+msgstr "폴더는 전체 (예 : /home/user_name/webtrees_data/) 또는 설치 폴더 (예 : ../../webtrees_data/)와 관련하여 지정할 수 있습니다."
 
 #: app/Http/Controllers/AdminSiteController.php:97
 #, php-format
 msgid "The folder “%s” does not exist."
-msgstr ""
+msgstr ""%s"폴더가 없습니다."
 
 #: resources/views/admin/merge-records-step-2.phtml:26
 msgid "The following facts and events were found in both records."
-msgstr ""
+msgstr "다음 정보와 이벤트는 2개의 레코드에서 발견되었습니다."
 
 #. I18N: the name of an individual, source, etc.
 #: resources/views/admin/merge-records-step-2.phtml:73
 #: resources/views/admin/merge-records-step-2.phtml:119
 #, php-format
 msgid "The following facts and events were only found in the record of %s."
-msgstr ""
+msgstr "다음 정보와 이벤트는 %s의 레코드에서만 발견되었습니다."
 
 #: resources/views/setup/step-2-server-checks.phtml:45
 msgid "The following list shows typical requirements."
-msgstr ""
+msgstr "다음 목록은 일반적인 요구 사항을 보여줍니다."
 
 #: app/Http/RequestHandlers/HelpText.php:277
 msgid "The help text has not been written for this item."
-msgstr ""
+msgstr "이 항목에 대한 도움말 텍스트가 작성되지 않았습니다."
 
 #. I18N: Help text for the “Technical help contact” configuration setting
 #: resources/views/admin/trees-preferences.phtml:180
 msgid "The individual to be contacted about technical questions or errors encountered on your website."
-msgstr ""
+msgstr "웹 사이트에서 발생한 기술적 질문 또는 오류에 대해 연락을 받을 인물입니다."
 
 #. I18N: Help text for the “Genealogy contact” configuration setting
 #: resources/views/admin/trees-preferences.phtml:160
 msgid "The individual to contact about the genealogy data on this website."
-msgstr ""
+msgstr "이 웹 사이트에서 계보 데이터에 대해 문의 할 인물입니다."
 
 #. I18N: %s are names of records, such as sources, repositories or individuals
 #: app/Http/RequestHandlers/DeleteRecord.php:82
 #: app/Http/RequestHandlers/DeleteRecord.php:87
 #, php-format
 msgid "The link from “%1$s” to “%2$s” has been deleted."
-msgstr ""
+msgstr "%1$s”에서“%2$s”로의 링크가 삭제되었습니다."
 
 #: app/Http/RequestHandlers/MergeFactsAction.php:98
 #, php-format
 msgid "The link from “%1$s” to “%2$s” has been updated."
-msgstr ""
+msgstr "“%1$s”에서“%2$s”로의 링크가 업데이트되었습니다."
 
 #. I18N: Description of the “Lists” module
 #: app/Module/ListsMenuModule.php:69
 msgid "The lists menu."
-msgstr ""
+msgstr "목록 메뉴"
 
 #: resources/views/modules/place-hierarchy/sidebar.phtml:37
 msgid "The location of this place is not known."
-msgstr ""
+msgstr "이 장소의 위치를 알 수 없습니다."
 
 #: app/Http/Controllers/EditMediaController.php:284
 #, php-format
 msgid "The media file %1$s could not be renamed to %2$s."
-msgstr ""
+msgstr "미디어 파일 %1$s의 이름을 %2$s(으)로 바꿀 수 없습니다."
 
 #: app/Http/Controllers/EditMediaController.php:278
 #, php-format
 msgid "The media file %1$s has been renamed to %2$s."
-msgstr ""
+msgstr "미디어 파일 %1$s의 이름이 %2$s(으)로 바뀌었습니다."
 
 #: app/Http/RequestHandlers/CreateMediaObjectAction.php:116
 msgid "The media object has been created"
-msgstr ""
+msgstr "미디어 객체가 생성되었습니다"
 
 #: resources/views/setup/step-2-server-checks.phtml:42
 msgid "The memory and CPU time requirements depend on the number of individuals in your family tree."
-msgstr ""
+msgstr "메모리 및 CPU 사양 요구 사항은 가계도의 인물 수에 따라 다릅니다."
 
 #: app/Http/RequestHandlers/BroadcastAction.php:89
 #: app/Http/RequestHandlers/ContactAction.php:148
 #: app/Http/RequestHandlers/EmailPreferencesAction.php:92
 #: app/Http/RequestHandlers/MessageAction.php:105
 msgid "The message was not sent."
-msgstr ""
+msgstr "메시지가 전송되지 않았습니다."
 
 #: app/Http/RequestHandlers/BroadcastAction.php:82
 #: app/Http/RequestHandlers/ContactAction.php:141
@@ -13851,205 +13851,205 @@ msgstr ""
 #: app/Http/RequestHandlers/MessageAction.php:98
 #, php-format
 msgid "The message was successfully sent to %s."
-msgstr ""
+msgstr "메시지가 %s에 성공적으로 전송되었습니다."
 
 #: app/Http/Controllers/Admin/ModuleController.php:343
 #: app/Http/Controllers/Admin/ModuleController.php:620
 #, php-format
 msgid "The module “%s” has been disabled."
-msgstr ""
+msgstr ""%s"모듈이 비활성화되었습니다."
 
 #: app/Http/Controllers/Admin/ModuleController.php:341
 #: app/Http/Controllers/Admin/ModuleController.php:618
 #, php-format
 msgid "The module “%s” has been enabled."
-msgstr ""
+msgstr ""%s"모듈이 활성화되었습니다."
 
 #. I18N: Help text for the “Quick family facts” configuration setting
 #: resources/views/admin/trees-preferences.phtml:766
 msgid "The most common family facts and events are listed separately, so that they can be added more easily."
-msgstr ""
+msgstr "가장 일반적인 가족 정보와 이벤트는 별도로 나열되므로 더 쉽게 추가 할 수 있습니다."
 
 #. I18N: Help text for the “Quick individual facts” configuration setting
 #: resources/views/admin/trees-preferences.phtml:712
 msgid "The most common individual facts and events are listed separately, so that they can be added more easily."
-msgstr ""
+msgstr "가장 일반적인 개별 정보와 이벤트는 별도로 나열되므로 더 쉽게 추가 할 수 있습니다."
 
 #. I18N: Help text for the “Quick repository facts” configuration setting
 #: resources/views/admin/trees-preferences.phtml:848
 msgid "The most common repository facts are listed separately, so that they can be added more easily."
-msgstr ""
+msgstr "가장 일반적인 저장소 정보는 별도로 나열되므로 더 쉽게 추가 할 수 있습니다."
 
 #. I18N: Help text for the “Quick source facts” configuration setting
 #: resources/views/admin/trees-preferences.phtml:807
 msgid "The most common source facts are listed separately, so that they can be added more easily."
-msgstr ""
+msgstr "가장 일반적인 출처 정보는 별도로 나열되므로 더 쉽게 추가 할 수 있습니다."
 
 #: resources/views/admin/site-registration.phtml:50
 msgid "The new user will be asked to confirm their email address before the account is created."
-msgstr ""
+msgstr "계정을 만들기 전에 새 사용자에게 전자 메일 주소를 확인하라는 메시지가 표시됩니다."
 
 #: app/Http/RequestHandlers/CreateNoteAction.php:73
 msgid "The note has been created"
-msgstr ""
+msgstr "노트가 생성되었습니다"
 
 #: app/Http/Controllers/SetupController.php:370
 msgid "The password needs to be at least six characters long."
-msgstr ""
+msgstr "비밀번호는 6자 이상이어야합니다."
 
 #. I18N: Help text for the "Password" site configuration setting
 #: resources/views/admin/site-mail.phtml:161
 msgid "The password required for authentication with the SMTP server."
-msgstr ""
+msgstr "SMTP 서버 인증에 필요한 비밀번호입니다."
 
 #: app/Http/RequestHandlers/PasswordResetAction.php:84
 #: app/Http/RequestHandlers/PasswordResetPage.php:76
 msgid "The password reset link has expired."
-msgstr ""
+msgstr "비밀번호 재설정 링크가 만료되었습니다."
 
 #. I18N: Description of the “Place hierarchy” module
 #: app/Module/PlaceHierarchyListModule.php:57
 msgid "The place hierarchy."
-msgstr ""
+msgstr "장소 계층."
 
 #: app/Http/Controllers/AdminController.php:159
 #: app/Http/Controllers/AdminTreesController.php:964
 msgid "The preferences for all family trees have been updated."
-msgstr ""
+msgstr "모든 가계도에 대한 환경 설정이 업데이트되었습니다."
 
 #: app/Http/Controllers/AdminController.php:162
 #: app/Http/Controllers/AdminTreesController.php:968
 msgid "The preferences for new family trees have been updated."
-msgstr ""
+msgstr "새로운 가계도에 대한 환경 설정이 업데이트되었습니다."
 
 #: app/Http/Controllers/AdminController.php:152
 #: app/Http/Controllers/AdminTreesController.php:957
 #, php-format
 msgid "The preferences for the family tree “%s” have been updated."
-msgstr ""
+msgstr "가계도 "%s"의 환경 설정이 업데이트되었습니다."
 
 #: app/Http/Controllers/Admin/ModuleController.php:697
 #, php-format
 msgid "The preferences for the module “%s” have been deleted."
-msgstr ""
+msgstr "모듈 "%s"의 기본 설정이 삭제되었습니다."
 
 #: app/Module/CustomCssJsModule.php:99
 #: app/Module/RelationshipsChartModule.php:430 app/Module/SiteMapModule.php:172
 #, php-format
 msgid "The preferences for the module “%s” have been updated."
-msgstr ""
+msgstr ""%s"모듈의 환경 설정이 업데이트되었습니다."
 
 #: resources/views/setup/step-4-database-mysql.phtml:104
 #: resources/views/setup/step-4-database-pgsql.phtml:91
 #: resources/views/setup/step-4-database-sqlite.phtml:65
 #: resources/views/setup/step-4-database-sqlsvr.phtml:91
 msgid "The prefix is optional, but recommended. By giving the table names a unique prefix you can let several different applications share the same database."
-msgstr ""
+msgstr "접두사는 선택 사항이지만 권장됩니다. 테이블 이름에 고유 한 접두사를 부여하면 여러 다른 응용 프로그램이 동일한 데이터베이스를 공유 할 수 있습니다."
 
 #: app/Http/RequestHandlers/CopyFact.php:77
 msgid "The record has been copied to the clipboard."
-msgstr ""
+msgstr "레코드가 클립 보드에 복사되었습니다."
 
 #: app/Http/RequestHandlers/MergeFactsAction.php:162
 #, php-format
 msgid "The records “%1$s” and “%2$s” have been merged."
-msgstr ""
+msgstr "“%1$s” 및 “%2$s” 레코드가 병합되었습니다."
 
 #. I18N: Description of the “Reports” module
 #: app/Module/ReportsMenuModule.php:74
 msgid "The reports menu."
-msgstr ""
+msgstr "보고서 메뉴"
 
 #: app/Http/RequestHandlers/CreateRepositoryAction.php:78
 msgid "The repository has been created"
-msgstr ""
+msgstr "저장소가 작성되었습니다"
 
 #. I18N: Description of the “Search” module
 #: app/Module/SearchMenuModule.php:59
 msgid "The search menu."
-msgstr ""
+msgstr "검색 메뉴"
 
 #: app/Services/SearchService.php:1001
 msgid "The search returned too many results."
-msgstr ""
+msgstr "검색 결과가 너무 많습니다."
 
 #: resources/views/setup/step-2-server-checks.phtml:35
 msgid "The server configuration is OK."
-msgstr ""
+msgstr "서버 설정이 정상입니다."
 
 #: app/Services/ServerCheckService.php:248
 msgid "The server’s temporary folder cannot be accessed."
-msgstr ""
+msgstr "서버의 임시 폴더에 액세스 할 수 없습니다."
 
 #: app/Http/Controllers/AdminTreesController.php:1465
 #: app/Services/UpgradeService.php:150 app/Services/UpgradeService.php:183
 msgid "The server’s time limit has been reached."
-msgstr ""
+msgstr "서버의 시간 제한에 도달했습니다."
 
 #. I18N: Description of “Statistics” module
 #: app/Module/FamilyTreeStatisticsModule.php:62
 msgid "The size of the family tree, earliest and latest events, common names, etc."
-msgstr ""
+msgstr "가계도의 크기, 가장 빠른 최신 이벤트, 일반적인 이름 등"
 
 #: app/Http/RequestHandlers/CreateSourceAction.php:111
 msgid "The source has been created"
-msgstr ""
+msgstr "출처가 생성되었습니다"
 
 #: app/Http/RequestHandlers/CreateSubmitterAction.php:76
 msgid "The submitter has been created"
-msgstr ""
+msgstr "제출자가 작성되었습니다"
 
 #: resources/views/help/name.phtml:13
 #, php-format
 msgid "The surname is enclosed by slashes: <%s>John Paul /Smith/<%s>"
-msgstr ""
+msgstr "가문이름은 슬래시로 묶습니다. <%s>John Paul /Smith/<%s>"
 
 #: resources/views/admin/site-preferences.phtml:49
 #: resources/views/admin/users-edit.phtml:122
 #: resources/views/edit-account-page.phtml:104
 msgid "The time zone is required for date calculations, such as knowing today’s date."
-msgstr ""
+msgstr "시간대는 오늘 날짜 알기 등의 날짜 계산에 필요합니다."
 
 #. I18N: An XREF is the identification number used in GEDCOM files.
 #: resources/views/admin/trees-merge.phtml:17
 #, php-format
 msgid "The two family trees have %1$s record which uses the same “XREF”."
 msgid_plural "The two family trees have %1$s records which use the same “XREF”."
-msgstr[0] ""
+msgstr[0] "두 가계도에는 동일한 "XREF"를 사용하는 %1$s 레코드가 있습니다."
 
 #: app/Http/Controllers/Admin/UpgradeController.php:386
 msgid "The upgrade is complete."
-msgstr ""
+msgstr "업그레이드가 완료되었습니다."
 
 #. I18N: PHP internal error message - php.net/manual/en/features.file-upload.errors.php
 #: app/Functions/Functions.php:48
 msgid "The uploaded file exceeds the allowed size."
-msgstr ""
+msgstr "업로드 된 파일이 허용 된 크기를 초과합니다."
 
 #: app/Http/RequestHandlers/UsersCleanupAction.php:69
 #, php-format
 msgid "The user %s has been deleted."
-msgstr ""
+msgstr "사용자 %s이(가) 삭제되었습니다."
 
 #: resources/views/emails/register-notify-html.phtml:30
 #: resources/views/emails/register-notify-text.phtml:17
 msgid "The user has been sent an email with the information necessary to confirm the access request."
-msgstr ""
+msgstr "사용자에게 액세스 요청을 확인하는 데 필요한 정보가 포함 된 이메일이 발송되었습니다."
 
 #: app/Http/RequestHandlers/LoginAction.php:122
 #: app/Http/RequestHandlers/LoginAction.php:127
 msgid "The username or password is incorrect."
-msgstr ""
+msgstr "사용자 이름 또는 비밀번호가 올바르지 않습니다."
 
 #. I18N: Help text for the "Username" site configuration setting
 #: resources/views/admin/site-mail.phtml:147
 msgid "The username required for authentication with the SMTP server."
-msgstr ""
+msgstr "SMTP 서버 인증에 필요한 사용자 이름입니다."
 
 #. I18N: Help text for the “Description META tag” configuration setting
 #: resources/views/admin/trees-preferences.phtml:222
 msgid "The value to place in the “meta description” tag in the HTML page header. Leave this field empty to use the name of the family tree."
-msgstr ""
+msgstr "HTML 페이지 헤더의 "meta description"태그에 배치 할 값입니다. 가계도의 이름을 사용하려면이 필드를 비워 두십시오."
 
 #: app/Http/Controllers/Admin/ModuleController.php:348
 #: app/Http/Controllers/Admin/ModuleController.php:364
@@ -14069,95 +14069,95 @@ msgstr ""
 #: app/Http/Controllers/AdminSiteController.php:158
 #: app/Http/RequestHandlers/EmailPreferencesAction.php:82
 msgid "The website preferences have been updated."
-msgstr ""
+msgstr "웹 사이트 환경 설정이 업데이트되었습니다."
 
 #. I18N: Help text for the “Use GeoNames database for autocomplete on places” configuration setting
 #: resources/views/admin/map-provider.phtml:44
 msgid "The website www.geonames.org provides a large database of place names. This can be searched when entering new places. To use this feature, you must register for a free account at www.geonames.org and provide the username."
-msgstr ""
+msgstr "웹 사이트 www.geonames.org는 큰 장소 이름 데이터베이스를 제공합니다. 새로운 장소를 입력 할 때 검색 할 수 있습니다. 이 기능을 사용하려면 www.geonames.org에서 무료 계정을 등록하고 사용자 이름을 제공해야합니다."
 
 #: resources/views/errors/database-error.phtml:16
 #: resources/views/setup/step-6-failed.phtml:16
 msgid "The webtrees developers would be very interested to learn about this error. If you contact them, they will help you resolve the problem."
-msgstr ""
+msgstr "webtrees 개발자는  오류에 대해 매우 관심이 있습니다. 연락하면 문제 해결에 도움이됩니다."
 
 #: app/Module/ModuleThemeTrait.php:72 app/Module/ModuleThemeTrait.php:457
 #: resources/views/admin/modules.phtml:245
 #: resources/views/admin/modules.phtml:248
 #: resources/views/admin/users-edit.phtml:180
 msgid "Theme"
-msgstr ""
+msgstr "테마"
 
 #. I18N: Name of a module
 #: app/Module/ThemeSelectModule.php:45
 msgid "Theme change"
-msgstr ""
+msgstr "테마 변경"
 
 #: app/Http/Controllers/Admin/ModuleController.php:268
 #: resources/views/admin/control-panel.phtml:489
 #: resources/views/admin/modules.phtml:107
 #: resources/views/admin/modules.phtml:109
 msgid "Themes"
-msgstr ""
+msgstr "테마"
 
 #: resources/views/modules/personal_facts/tab.phtml:35
 msgid "There are no facts for this individual."
-msgstr ""
+msgstr "이 인물에 대한 정보는 없습니다."
 
 #: app/Http/Controllers/Admin/MediaController.php:329
 msgid "There are no links to this media object."
-msgstr ""
+msgstr "이 미디어 객체에 대한 링크가 없습니다."
 
 #: resources/views/modules/media/tab.phtml:20
 msgid "There are no media objects for this individual."
-msgstr "선택한 사람에 대한 미디어 개체가 없습니다."
+msgstr "선택한 인물에 대한 미디어 개체가 없습니다."
 
 #: resources/views/modules/notes/tab.phtml:31
 msgid "There are no notes for this individual."
-msgstr ""
+msgstr "이 인물에 대한 노트가 없습니다."
 
 #: app/Http/Controllers/Admin/UpgradeController.php:277
 #: resources/views/pending-changes-page.phtml:18
 msgid "There are no pending changes."
-msgstr ""
+msgstr "보류중인 변경 사항이 없습니다."
 
 #: app/Module/ResearchTaskModule.php:116
 msgid "There are no research tasks in this family tree."
-msgstr ""
+msgstr "이 가계도에는 연구 과제가 없습니다."
 
 #: resources/views/modules/sources_tab/tab.phtml:29
 msgid "There are no source citations for this individual."
-msgstr ""
+msgstr "이 인물에 대한 출처 인용이 없습니다."
 
 #: app/Module/ReviewChangesModule.php:155
 #: resources/views/emails/pending-changes-html.phtml:13
 #: resources/views/emails/pending-changes-text.phtml:10
 msgid "There are pending changes for you to moderate."
-msgstr ""
+msgstr "평가할 보류중인 변경 사항이 있습니다."
 
 #: app/Module/RecentChangesModule.php:123
 #, php-format
 msgid "There have been no changes within the last %s day."
 msgid_plural "There have been no changes within the last %s days."
-msgstr[0] ""
+msgstr[0] "지난 %s일동안 변경 사항이 없습니다."
 
 #: app/Http/RequestHandlers/PasswordRequestAction.php:107
 #, php-format
 msgid "There is no user account with the email “%s”."
-msgstr ""
+msgstr "이메일 "%s"의 사용자 계정이 없습니다"
 
 #: app/Http/Controllers/Admin/MediaController.php:465
 #: app/Http/Controllers/EditMediaController.php:134
 #: app/Http/RequestHandlers/CreateMediaObjectAction.php:86
 #: app/Services/MediaFileService.php:246
 msgid "There was an error uploading your file."
-msgstr ""
+msgstr "파일을 업로드하는 중에 오류가 발생했습니다."
 
 #. I18N: a month in the French republican calendar
 #: app/Date/FrenchDate.php:155
 msgctxt "GENITIVE"
 msgid "Thermidor"
-msgstr ""
+msgstr "Thermidor"
 
 #. I18N: a month in the French republican calendar
 #: app/Date/FrenchDate.php:249
@@ -14179,28 +14179,28 @@ msgstr ""
 
 #: resources/views/modules/privacy-policy/page.phtml:27
 msgid "These cookies are “essential”, and do not require consent."
-msgstr ""
+msgstr "이 쿠키는 “필수”이며 동의 할 필요가 없습니다."
 
 #: resources/views/admin/trees-unconnected.phtml:32
 #, php-format
 msgid "These groups of individuals are not related to %s."
-msgstr ""
+msgstr "이 인물 그룹은 %s와 관련이 없습니다."
 
 #: resources/views/modules/privacy-policy/page.phtml:48
 msgid "These services may use cookies or other tracking technology."
-msgstr ""
+msgstr "이러한 서비스는 쿠키 또는 기타 추적 기술을 사용할 수 있습니다."
 
 #: app/Http/RequestHandlers/LoginAction.php:137
 msgid "This account has not been approved. Please wait for an administrator to approve it."
-msgstr ""
+msgstr "이 계정은 승인되지 않았습니다. 관리자가 승인 할 때까지 기다리십시오."
 
 #: app/Http/RequestHandlers/LoginAction.php:132
 msgid "This account has not been verified. Please check your email for a verification message."
-msgstr ""
+msgstr "이 계정은 확인되지 않았습니다. 이메일에서 확인 메시지를 확인하십시오."
 
 #: resources/views/modules/review_changes/config.phtml:8
 msgid "This block will show editors a list of records with pending changes that need to be reviewed by a moderator. It also generates daily emails to moderators whenever pending changes exist."
-msgstr ""
+msgstr "이 블록은 편집자에게 중재자가 검토해야하는 보류중인 변경 사항이있는 레코드 목록을 표시합니다. 또한 보류중인 변경 사항이있을 때마다 중재자에게 매일 전자 메일을 생성합니다."
 
 #: resources/views/admin/users-create.phtml:63
 #: resources/views/admin/users-edit.phtml:67
@@ -14208,98 +14208,98 @@ msgstr ""
 #: resources/views/register-page.phtml:51
 #: resources/views/setup/step-5-administrator.phtml:77
 msgid "This email address will be used to send password reminders, website notifications, and messages from other family members who are registered on the website."
-msgstr ""
+msgstr "이 이메일 주소는 비밀번호 알림, 웹 사이트 알림 및 웹 사이트에 등록 된 다른 가족 구성원의 메시지를 보내는 데 사용됩니다."
 
 #: app/Exceptions/FamilyAccessDeniedException.php:35
 #: app/Exceptions/FamilyNotFoundException.php:35
 msgid "This family does not exist or you do not have permission to view it."
-msgstr ""
+msgstr "이 가족이 존재하지 않거나 볼 수있는 권한이 없습니다."
 
 #: resources/views/family-page.phtml:18
 msgid "This family has been deleted. The deletion will need to be reviewed by a moderator."
-msgstr ""
+msgstr "이 가족은 삭제되었습니다. 중재자가 삭제를 검토해야합니다."
 
 #. I18N: %1$s is “accept”, %2$s is “reject”. These are links.
 #: resources/views/family-page.phtml:16
 #, php-format
 msgid "This family has been deleted. You should review the deletion and then %1$s or %2$s it."
-msgstr ""
+msgstr "이 가족은 삭제되었습니다. 삭제를 검토 한 다음 %1$s 또는 %2$s 해야합니다."
 
 #: resources/views/family-page.phtml:24
 msgid "This family has been edited. The changes need to be reviewed by a moderator."
-msgstr ""
+msgstr "이 가족은 편집되었습니다. 중재자가 변경 사항을 검토해야합니다."
 
 #. I18N: %1$s is “accept”, %2$s is “reject”. These are links.
 #: resources/views/family-page.phtml:22
 #, php-format
 msgid "This family has been edited. You should review the changes and then %1$s or %2$s them."
-msgstr ""
+msgstr "이 가족은 편집되었습니다. 변경 사항을 검토 한 다음 %1$s 또는 %2$s 변경해야 합니다."
 
 #: resources/views/admin/trees-renumber.phtml:21
 #, php-format
 msgid "This family tree has %s record which uses the same “XREF” as another family tree."
 msgid_plural "This family tree has %s records which use the same “XREF” as another family tree."
-msgstr[0] ""
+msgstr[0] "이 가계도에는 다른 가계도와 동일한 "XREF"를 사용하는 %s 레코드가 있습니다."
 
 #: app/Module/SlideShowModule.php:163
 msgid "This family tree has no images to display."
-msgstr ""
+msgstr "이 가계도에는 표시 할 이미지가 없습니다."
 
 #. I18N: do not translate the #keywords#
 #: resources/views/modules/html/template-narrative.phtml:7
 msgid "This family tree was last updated on #gedcomUpdated#. There are #totalSurnames# surnames in this family tree. The earliest recorded event is the #firstEventType# of #firstEventName# in #firstEventYear#. The most recent event is the #lastEventType# of #lastEventName# in #lastEventYear#.<br><br>If you have any comments or feedback please contact #contactWebmaster#."
-msgstr ""
+msgstr "이 가계도는 #gedcomUpdated#에서 마지막으로 업데이트되었습니다. 이 가계도에는 #totalSurnames# 가문이 있습니다. 가장 먼저 기록 된 이벤트는 #firstEventYear#에서 #firstEventName#의 #firstEventType#입니다. 가장 최근의 이벤트는 #lastEventYear#의 #lastEventName#의 #lastEventType#입니다. <br><br> 답변이나 의견이 있으면 #contactWebmaster#로 문의하십시오."
 
 #: resources/views/modules/gedcom_stats/statistics.phtml:9
 #: resources/views/modules/html/template-statistics.phtml:13
 #, php-format
 msgid "This family tree was last updated on %s."
-msgstr ""
+msgstr "이 가계도는 %s에서 마지막으로 업데이트되었습니다."
 
 #. I18N: Help text for the "Data folder" site configuration setting
 #: resources/views/admin/site-preferences.phtml:26
 msgid "This folder will be used by webtrees to store media files, GEDCOM files, temporary files, etc. These files may contain private data, and should not be made available over the internet."
-msgstr ""
+msgstr "이 폴더는 웹 트리에서 미디어 파일, GEDCOM 파일, 임시 파일 등을 저장하는 데 사용됩니다.이 파일은 개인 데이터를 포함 할 수 있으며 인터넷을 통해 사용할 수 없습니다."
 
 #. I18N: Help text for the “Media folder” configuration setting
 #: resources/views/admin/trees-preferences.phtml:244
 msgid "This folder will be used to store the media files for this family tree."
-msgstr ""
+msgstr "이 폴더는이 가계도의 미디어 파일을 저장하는 데 사용됩니다."
 
 #: app/Http/Middleware/CheckCsrf.php:68
 msgid "This form has expired. Try again."
-msgstr ""
+msgstr "이 양식은 만료되었습니다. 다시 시도하십시오."
 
 #: app/Exceptions/IndividualAccessDeniedException.php:35
 #: app/Exceptions/IndividualNotFoundException.php:35
 msgid "This individual does not exist or you do not have permission to view it."
-msgstr ""
+msgstr "이 인물이 존재하지 않거나 볼 수있는 권한이 없습니다."
 
 #: resources/views/individual-page.phtml:30
 msgid "This individual has been deleted. The deletion will need to be reviewed by a moderator."
-msgstr ""
+msgstr "이 인물이 삭제되었습니다. 중재자가 삭제를 검토해야합니다."
 
 #. I18N: %1$s is “accept”, %2$s is “reject”. These are links.
 #: resources/views/individual-page.phtml:27
 #, php-format
 msgid "This individual has been deleted. You should review the deletion and then %1$s or %2$s it."
-msgstr ""
+msgstr "이 인물이 삭제되었습니다. 삭제를 검토 한 다음 %1$s 또는 %2$s 해야 합니다."
 
 #: resources/views/individual-page.phtml:39
 msgid "This individual has been edited. The changes need to be reviewed by a moderator."
-msgstr ""
+msgstr "이 인물은 편집되었습니다. 중재자가 변경 사항을 검토해야합니다."
 
 #. I18N: %1$s is “accept”, %2$s is “reject”. These are links.
 #: resources/views/individual-page.phtml:36
 #, php-format
 msgid "This individual has been edited. You should review the changes and then %1$s or %2$s them."
-msgstr ""
+msgstr "이 인물은 편집되었습니다. 변경 사항을 검토 한 다음 %1$s 또는 %2$s 변경해야합니다."
 
 #. I18N: Help text for the “Default individual” configuration setting
 #: resources/views/admin/trees-preferences.phtml:89
 #: resources/views/edit-account-page.phtml:68
 msgid "This individual will be selected by default when viewing charts and reports."
-msgstr ""
+msgstr "이 인물은 차트와 보고서를 볼 때 기본적으로 선택됩니다."
 
 #: app/Module/StatisticsChartModule.php:963
 #: app/Statistics/Repository/EventRepository.php:244
@@ -14330,7 +14330,7 @@ msgstr ""
 #: resources/views/statistics/other/places.phtml:55
 #: resources/views/statistics/other/top10-list.phtml:24
 msgid "This information is not available."
-msgstr ""
+msgstr "이 정보는 사용할 수 없습니다."
 
 #: app/Statistics/Repository/EventRepository.php:252
 #: app/Statistics/Repository/FamilyDatesRepository.php:110
@@ -14347,31 +14347,31 @@ msgstr ""
 #: app/Statistics/Repository/IndividualRepository.php:1227
 #: app/Statistics/Repository/IndividualRepository.php:1247
 msgid "This information is private and cannot be shown."
-msgstr ""
+msgstr "이 정보는 개인 정보이므로 표시 할 수 없습니다."
 
 #. I18N: Help text for the “Advanced name facts” configuration setting
 #: resources/views/admin/trees-preferences.phtml:863
 msgid "This is a comma separated list of GEDCOM fact tags that will be shown on the add/edit name form. If you use non-Latin alphabets such as Hebrew, Greek, Cyrillic, or Arabic, you may want to add tags such as _HEB, ROMN, FONE, etc. to allow you to store names in several different alphabets."
-msgstr ""
+msgstr "이름 추가/편집 양식에 표시되는 GEDCOM 팩트 태그의 쉼표로 구분 된 목록입니다. 히브리어, 그리스어, 키릴 어 또는 아랍어와 같은 비 라틴어 알파벳을 사용하는 경우 이름을 여러 알파벳으로 저장할 수 있도록 _HEB, ROMN, FONE 등과 같은 태그를 추가 할 수 있습니다."
 
 #. I18N: Help text for the “Facts for new families” configuration setting
 #: resources/views/admin/trees-preferences.phtml:753
 msgid "This is a comma separated list of GEDCOM fact tags that will be shown when adding a new family. For example, if MARR is in the list, then fields for marriage date and marriage place will be shown on the form."
-msgstr ""
+msgstr "새 패밀리를 추가 할 때 표시되는 쉼표로 구분 된 GEDCOM fact 태그 목록입니다. 예를 들어 MARR이 목록에 있으면 결혼 날짜 및 결혼 장소 필드가 양식에 표시됩니다."
 
 #. I18N: Help text for the “Facts for new individuals” configuration setting
 #: resources/views/admin/trees-preferences.phtml:699
 msgid "This is a comma separated list of GEDCOM fact tags that will be shown when adding a new individual. For example, if BIRT is in the list, fields for birth date and birth place will be shown on the form."
-msgstr ""
+msgstr "새 인물을 추가 할 때 표시되는 쉼표로 구분 된 GEDCOM fact 태그 목록입니다. 예를 들어, BIRT가 목록에 있으면 생년월일 및 출생지 필드가 양식에 표시됩니다."
 
 #. I18N: Help text for the “Advanced place name facts” configuration setting
 #: resources/views/admin/trees-preferences.phtml:876
 msgid "This is a comma separated list of GEDCOM fact tags that will be shown when you add or edit place names. If you use non-Latin alphabets such as Hebrew, Greek, Cyrillic, or Arabic, you may want to add tags such as _HEB, ROMN, FONE, etc. to allow you to store place names in several different alphabets."
-msgstr ""
+msgstr "장소 이름을 추가하거나 편집 할 때 표시되는 쉼표로 구분 된 GEDCOM 팩트 태그 목록입니다. 히브리어, 그리스어, 키릴 어 또는 아랍어와 같은 비 라틴어 알파벳을 사용하는 경우 _HEB, ROMN, FONE 등과 같은 태그를 추가하여 여러 다른 알파벳으로 장소 이름을 저장할 수 있습니다."
 
 #: resources/views/edit-account-page.phtml:56
 msgid "This is a link to your own record in the family tree. If this is the wrong individual, contact an administrator."
-msgstr ""
+msgstr "이것은 가계도에서 자신의 기록에 대한 링크입니다. 인물이 잘못된 경우 관리자에게 문의하십시오."
 
 #: resources/views/setup/step-4-database-mysql.phtml:68
 #: resources/views/setup/step-4-database-mysql.phtml:82
@@ -14380,58 +14380,58 @@ msgstr ""
 #: resources/views/setup/step-4-database-sqlsvr.phtml:58
 #: resources/views/setup/step-4-database-sqlsvr.phtml:70
 msgid "This is case sensitive."
-msgstr ""
+msgstr "대소문자를 구분합니다."
 
 #: app/Http/Controllers/Admin/UpgradeController.php:236
 #: resources/views/admin/control-panel.phtml:73
 #: resources/views/admin/upgrade/wizard.phtml:18
 msgid "This is the latest version of webtrees. No upgrade is available."
-msgstr ""
+msgstr "이것은 최신 버전의 webtrees입니다. 사용 가능한 업그레이드가 없습니다."
 
 #. I18N: Help text for the “All family facts” configuration setting
 #: resources/views/admin/trees-preferences.phtml:727
 msgid "This is the list of GEDCOM facts that your users can add to families. You can modify this list by removing or adding fact names, even custom ones, as necessary. Fact names that appear in this list must not also appear in the “Unique family facts” list."
-msgstr ""
+msgstr "이것은 사용자가 가족에게 추가 할 수있는 GEDCOM 정보의 목록입니다. 필요에 따라 정보 이름, 심지어 사용자 정의 이름을 제거하거나 추가하여 이 목록을 수정할 수 있습니다. 이 목록에 나오는 정보 이름은 "고유 한 가족 정보"목록에도 나타나지 않아야합니다."
 
 #. I18N: Help text for the “All individual facts” configuration setting
 #: resources/views/admin/trees-preferences.phtml:673
 msgid "This is the list of GEDCOM facts that your users can add to individuals. You can modify this list by removing or adding fact names, even custom ones, as necessary. Fact names that appear in this list must not also appear in the “Unique individual facts” list."
-msgstr ""
+msgstr "이것은 사용자가 인물에게 추가 할 수있는 GEDCOM 정보의 목록입니다. 필요에 따라 정보 이름, 심지어 사용자 정의 이름을 제거하거나 추가하여이 목록을 수정할 수 있습니다. 이 목록에 나타나는 정보 이름은 "고유 한 개별 정보"목록에도 나타나지 않아야합니다."
 
 #. I18N: Help text for the “All repository facts” configuration setting
 #: resources/views/admin/trees-preferences.phtml:822
 msgid "This is the list of GEDCOM facts that your users can add to repositories. You can modify this list by removing or adding fact names, even custom ones, as necessary. Fact names that appear in this list must not also appear in the “Unique repository facts” list."
-msgstr ""
+msgstr "사용자가 저장소에 추가 할 수있는 GEDCOM 정보 목록입니다. 필요에 따라 정보 이름, 심지어 사용자 정의 이름을 제거하거나 추가하여이 목록을 수정할 수 있습니다. 이 목록에 나타나는 정보 이름은 "고유 저장소 사실"정보에도 나타나지 않아야합니다."
 
 #. I18N: Help text for the “All source facts” configuration setting
 #: resources/views/admin/trees-preferences.phtml:781
 msgid "This is the list of GEDCOM facts that your users can add to sources. You can modify this list by removing or adding fact names, even custom ones, as necessary. Fact names that appear in this list must not also appear in the “Unique source facts” list."
-msgstr ""
+msgstr "사용자가 출처에 추가 할 수있는 GEDCOM 정보 목록입니다. 필요에 따라 정보 이름, 심지어 사용자 정의 이름을 제거하거나 추가하여이 목록을 수정할 수 있습니다. 이 목록에 나타나는 정보 이름은 "고유 출처 정보"목록에도 나타나지 않아야합니다."
 
 #. I18N: Help text for the “Unique family facts” configuration setting
 #: resources/views/admin/trees-preferences.phtml:740
 msgid "This is the list of GEDCOM facts that your users can only add once to families. For example, if MARR is in this list, users will not be able to add more than one MARR record to a family. Fact names that appear in this list must not also appear in the “All family facts” list."
-msgstr ""
+msgstr "이것은 사용자가 가족에게 한 번만 추가 할 수있는 GEDCOM 정보의 목록입니다. 예를 들어 MARR이 이 목록에 있으면 사용자는 하나 이상의 MARR 레코드를 가족에 추가 할 수 없습니다. 이 목록에 나오는 정보 이름은 “모든 가족 정보” 목록에도 나타나지 않아야합니다."
 
 #. I18N: Help text for the “Unique individual facts” configuration setting
 #: resources/views/admin/trees-preferences.phtml:686
 msgid "This is the list of GEDCOM facts that your users can only add once to individuals. For example, if BIRT is in this list, users will not be able to add more than one BIRT record to an individual. Fact names that appear in this list must not also appear in the “All individual facts” list."
-msgstr ""
+msgstr "사용자가 인물에게 한 번만 추가 할 수있는 GEDCOM 정보 목록입니다. 예를 들어, BIRT가 이 목록에 있으면 사용자는 둘 이상의 BIRT 레코드를 인물에게 추가 할 수 없습니다. 이 목록에 나타나는 정보 이름은 "모든 개별 정보" 목록에도 나타나지 않아야합니다."
 
 #. I18N: Help text for the “Unique repository facts” configuration setting
 #: resources/views/admin/trees-preferences.phtml:835
 msgid "This is the list of GEDCOM facts that your users can only add once to repositories. For example, if NAME is in this list, users will not be able to add more than one NAME record to a repository. Fact names that appear in this list must not also appear in the “All repository facts” list."
-msgstr ""
+msgstr "사용자가 저장소에 한 번만 추가 할 수있는 GEDCOM 정보 목록입니다. 예를 들어, NAME이 이 목록에 있으면 사용자는 저장소에 둘 이상의 NAME 레코드를 추가 할 수 없습니다. 이 목록에 나타나는 정보 이름은“모든 저장소 정보” 목록에도 나타나지 않아야합니다."
 
 #. I18N: Help text for the “Unique source facts” configuration setting
 #: resources/views/admin/trees-preferences.phtml:794
 msgid "This is the list of GEDCOM facts that your users can only add once to sources. For example, if TITL is in this list, users will not be able to add more than one TITL record to a source. Fact names that appear in this list must not also appear in the “All source facts” list."
-msgstr ""
+msgstr "사용자가 출처에 한 번만 추가 할 수있는 GEDCOM 정보 목록입니다. 예를 들어 TITL이이 목록에 있으면 사용자는 둘 이상의 TITL 레코드를 정보에 추가 할 수 없습니다. 이 목록에 나타나는 정보 이름은 "모든 출처 정보" 목록에도 나타나지 않아야합니다."
 
 #. I18N: Help text for the “Server name” site configuration setting
 #: resources/views/admin/site-mail.phtml:103
 msgid "This is the name of the SMTP server. “localhost” means that the mail service is running on the same computer as your web server."
-msgstr ""
+msgstr "이것은 SMTP 서버의 이름입니다. “localhost”는 메일 서비스가 웹 서버와 동일한 컴퓨터에서 실행되고 있음을 의미합니다."
 
 #: resources/views/admin/users-create.phtml:24
 #: resources/views/admin/users-edit.phtml:28
@@ -14439,306 +14439,306 @@ msgstr ""
 #: resources/views/register-page.phtml:39
 #: resources/views/setup/step-5-administrator.phtml:41
 msgid "This is your real name, as you would like it displayed on screen."
-msgstr ""
+msgstr "화면에 표시하려는 실제 이름입니다."
 
 #: app/Http/RequestHandlers/PasswordRequestAction.php:104
 msgid "This link is valid for one hour."
-msgstr ""
+msgstr "이 링크는 1 시간 동안 유효합니다."
 
 #: resources/views/help/data-fixes.phtml:16
 msgid "This list is created using a simple (but fast) search, and therefore includes records that will not be updated."
-msgstr ""
+msgstr "이 목록은 단순하지만 빠른 검색을 사용하여 작성되므로 업데이트되지 않는 레코드를 포함합니다."
 
 #: app/Exceptions/MediaAccessDeniedException.php:35
 #: app/Exceptions/MediaNotFoundException.php:35
 msgid "This media object does not exist or you do not have permission to view it."
-msgstr ""
+msgstr "이 미디어 개체가 없거나 볼 수있는 권한이 없습니다."
 
 #: resources/views/media-page.phtml:30
 msgid "This media object has been deleted. The deletion will need to be reviewed by a moderator."
-msgstr ""
+msgstr "이 미디어 개체가 삭제되었습니다. 중재자가 삭제를 검토해야합니다."
 
 #. I18N: %1$s is “accept”, %2$s is “reject”. These are links.
 #: resources/views/media-page.phtml:28
 #, php-format
 msgid "This media object has been deleted. You should review the deletion and then %1$s or %2$s it."
-msgstr ""
+msgstr "이 미디어 개체가 삭제되었습니다. 삭제를 검토 한 다음 %1$s 또는 %2$s 해야합니다."
 
 #: resources/views/media-page.phtml:36
 msgid "This media object has been edited. The changes need to be reviewed by a moderator."
-msgstr ""
+msgstr "이 미디어 개체가 편집되었습니다. 중재자가 변경 사항을 검토해야합니다."
 
 #. I18N: %1$s is “accept”, %2$s is “reject”. These are links.
 #: resources/views/media-page.phtml:34
 #, php-format
 msgid "This media object has been edited. You should review the changes and then %1$s or %2$s them."
-msgstr ""
+msgstr "이 미디어 개체가 편집되었습니다. 변경 사항을 검토 한 다음 %1$s 또는 %2$s 변경해야합니다."
 
 #: resources/views/emails/message-copy-html.phtml:25
 #: resources/views/emails/message-copy-text.phtml:15
 #: resources/views/emails/message-user-html.phtml:26
 #: resources/views/emails/message-user-text.phtml:16
 msgid "This message was sent while viewing the following URL: "
-msgstr ""
+msgstr "이 메시지는 다음 URL을 보면서 전송되었습니다."
 
 #: resources/views/setup/step-5-administrator.phtml:65
 msgid "This must be at least six characters long. It is case-sensitive."
-msgstr ""
+msgstr "6자 이상이어야합니다. 대소문자를 구분합니다."
 
 #. I18N: Help text for the “Sender name” site configuration setting
 #: resources/views/admin/site-mail.phtml:81
 msgid "This name is used in the “From” field, when sending automatic emails from this server."
-msgstr ""
+msgstr "이 이름은 이 서버에서 자동 이메일을 보낼 때 "보낸 사람" 필드에 사용됩니다."
 
 #: app/Exceptions/NoteAccessDeniedException.php:35
 #: app/Exceptions/NoteNotFoundException.php:35
 msgid "This note does not exist or you do not have permission to view it."
-msgstr ""
+msgstr "이 노트는 존재하지 않거나 볼 수있는 권한이 없습니다."
 
 #: resources/views/note-page.phtml:16
 msgid "This note has been deleted. The deletion will need to be reviewed by a moderator."
-msgstr ""
+msgstr "이 노트가 삭제되었습니다. 중재자가 삭제를 검토해야합니다."
 
 #. I18N: %1$s is “accept”, %2$s is “reject”. These are links.
 #: resources/views/note-page.phtml:14
 #, php-format
 msgid "This note has been deleted. You should review the deletion and then %1$s or %2$s it."
-msgstr ""
+msgstr "이 노트가 삭제되었습니다. 삭제를 검토 한 다음 %1$s 또는 %2$s 해야합니다."
 
 #: resources/views/note-page.phtml:22
 msgid "This note has been edited. The changes need to be reviewed by a moderator."
-msgstr ""
+msgstr "이 노트가 편집되었습니다. 중재자가 변경 사항을 검토해야합니다."
 
 #. I18N: %1$s is “accept”, %2$s is “reject”. These are links.
 #: resources/views/note-page.phtml:20
 #, php-format
 msgid "This note has been edited. You should review the changes and then %1$s or %2$s them."
-msgstr ""
+msgstr "이 노트가 편집되었습니다. 변경 사항을 검토 한 다음 %1$s 또는 %2$s 변경해야합니다."
 
 #. I18N: Help text for the “Automatically expand notes” configuration setting
 #: resources/views/admin/trees-preferences.phtml:544
 msgid "This option controls whether or not to automatically display content of a <i>Note</i> record on the Individual page."
-msgstr ""
+msgstr "이 옵션은 인물 페이지에 <i>Note</i> 레코드의 컨텐츠를 자동으로 표시할지 여부를 제어합니다."
 
 #. I18N: Help text for the “Automatically expand sources” configuration setting
 #: resources/views/admin/trees-preferences.phtml:560
 msgid "This option controls whether or not to automatically display content of a <i>Source</i> record on the Individual page."
-msgstr ""
+msgstr "이 옵션은 인물 페이지에 <i>출처</i> 레코드의 컨텐츠를 자동으로 표시할지 여부를 제어합니다."
 
 #. I18N: Help text for the “Age of parents next to child’s birthdate” configuration setting
 #: resources/views/admin/trees-preferences.phtml:403
 msgid "This option controls whether or not to show age of father and mother next to child’s birthdate on charts."
-msgstr ""
+msgstr "이 옵션은 자녀의 생년월일 옆에 아버지와 어머니의 연령을 차트에 표시할지 여부를 제어합니다."
 
 #. I18N: Help text for the “Estimated dates for birth and death” configuration setting
 #: resources/views/admin/trees-preferences.phtml:372
 msgid "This option controls whether or not to show estimated dates for birth and death instead of leaving blanks on individual lists and charts for individuals whose dates are not known."
-msgstr ""
+msgstr "이 옵션은 날짜를 모르는 개인의 인물 목록 및 차트에 공백을 남기지 않고 출생 및 사망 예상 날짜를 표시할지 여부를 제어합니다."
 
 #. I18N: Help text for the “Show a download link in the media viewer” configuration setting
 #: resources/views/admin/trees-preferences.phtml:275
 msgid "This option will make it easier for users to download images."
-msgstr ""
+msgstr "이 옵션을 사용하면 사용자가 이미지를보다 쉽게 ​​다운로드 할 수 있습니다."
 
 #. I18N: Help text for the “Show private relationships” configuration setting
 #: resources/views/admin/trees-privacy.phtml:155
 msgid "This option will retain family links in private records. This means that you will see empty “private” boxes on the pedigree chart and on other charts with private individuals."
-msgstr ""
+msgstr "이 옵션은 가족 기록을 개인 기록으로 유지합니다. 이는 가계도 및 인물이 있는 다른 차트에 빈 "비공개"상자가 표시됨을 의미합니다."
 
 #. I18N: Help text for the “Show names of private individuals” configuration setting
 #: resources/views/admin/trees-privacy.phtml:136
 msgid "This option will show the names (but no other details) of private individuals. Individuals are private if they are still alive or if a privacy restriction has been added to their individual record. To hide a specific name, add a privacy restriction to that name record."
-msgstr ""
+msgstr "이 옵션은 인물의 이름 (다른 세부 사항은 아님)을 표시합니다. 인물이 아직 살아 있거나 개인 기록에 개인 정보 제한이 추가 된 경우의 인물입니다. 특정 이름을 숨기려면 해당 이름 레코드에 개인 정보 제한을 추가하십시오."
 
 #: resources/views/edit/raw-gedcom-fact.phtml:15
 #: resources/views/edit/raw-gedcom-record.phtml:16
 msgid "This page allows you to bypass the usual forms, and edit the underlying data directly. It is an advanced option, and you should not use it unless you understand the GEDCOM format. If you make a mistake here, it can be difficult to fix."
-msgstr ""
+msgstr "이 페이지에서는 일반적인 양식을 무시하고 기본 데이터를 직접 편집 할 수 있습니다. 고급 옵션이며 GEDCOM 형식을 이해하지 않으면 사용하지 마십시오. 여기에서 실수하면 수정하기가 어려울 수 있습니다."
 
 #: app/Module/HitCountFooterModule.php:113
 #, php-format
 msgid "This page has been viewed %s time."
 msgid_plural "This page has been viewed %s times."
-msgstr[0] ""
+msgstr[0] "이 페이지는 %s번 조회되었습니다."
 
 #: resources/views/help/pending-changes.phtml:12
 msgid "This process allows the site’s owner to ensure that the new information follows the site’s standards and conventions, has proper source attributions, etc."
-msgstr ""
+msgstr "이 과정을 통해 사이트 소유자는 새로운 정보가 사이트의 표준 및 규칙을 따르고 적절한 소스 속성 등을 갖도록 할 수 있습니다."
 
 #: app/Exceptions/RecordAccessDeniedException.php:35
 #: app/Exceptions/RecordNotFoundException.php:35
 msgid "This record does not exist or you do not have permission to view it."
-msgstr ""
+msgstr "이 레코드가 존재하지 않거나 볼 수있는 권한이 없습니다."
 
 #: resources/views/admin/trees-privacy.phtml:237
 msgid "This record does not exist."
-msgstr ""
+msgstr "존재하지 않는 레코드입니다."
 
 #: resources/views/gedcom-record-page.phtml:16
 #: resources/views/submitter-page.phtml:16
 msgid "This record has been deleted. The deletion will need to be reviewed by a moderator."
-msgstr ""
+msgstr "이 레코드가 삭제되었습니다. 중재자가 삭제를 검토해야합니다."
 
 #. I18N: %1$s is “accept”, %2$s is “reject”. These are links.
 #: resources/views/gedcom-record-page.phtml:14
 #: resources/views/submitter-page.phtml:14
 #, php-format
 msgid "This record has been deleted. You should review the deletion and then %1$s or %2$s it."
-msgstr ""
+msgstr "이 레코드가 삭제되었습니다. 삭제를 검토 한 다음 %1$s 또는 %2$s 해야합니다."
 
 #: resources/views/gedcom-record-page.phtml:22
 #: resources/views/submitter-page.phtml:22
 msgid "This record has been edited. The changes need to be reviewed by a moderator."
-msgstr ""
+msgstr "이 레코드는 편집되었습니다. 중재자가 변경 사항을 검토해야합니다."
 
 #. I18N: %1$s is “accept”, %2$s is “reject”. These are links.
 #: resources/views/gedcom-record-page.phtml:20
 #: resources/views/submitter-page.phtml:20
 #, php-format
 msgid "This record has been edited. You should review the changes and then %1$s or %2$s them."
-msgstr ""
+msgstr "이 레코드는 편집되었습니다. 변경 사항을 검토 한 다음 %1$s 또는 %2$s 변경해야합니다."
 
 #: app/Exceptions/RepositoryAccessDeniedException.php:35
 #: app/Exceptions/RepositoryNotFoundException.php:35
 msgid "This repository does not exist or you do not have permission to view it."
-msgstr ""
+msgstr "이 저장소가 존재하지 않거나 볼 수있는 권한이 없습니다."
 
 #: resources/views/repository-page.phtml:16
 msgid "This repository has been deleted. The deletion will need to be reviewed by a moderator."
-msgstr ""
+msgstr "이 저장소가 삭제되었습니다. 중재자가 삭제를 검토해야합니다."
 
 #. I18N: %1$s is “accept”, %2$s is “reject”. These are links.
 #: resources/views/repository-page.phtml:14
 #, php-format
 msgid "This repository has been deleted. You should review the deletion and then %1$s or %2$s it."
-msgstr ""
+msgstr "이 저장소가 삭제되었습니다. 삭제를 검토 한 다음 %1$s 또는 %2$s 해야합니다."
 
 #: resources/views/repository-page.phtml:22
 msgid "This repository has been edited. The changes need to be reviewed by a moderator."
-msgstr ""
+msgstr "이 저장소가 편집되었습니다. 중재자가 변경 사항을 검토해야합니다."
 
 #. I18N: %1$s is “accept”, %2$s is “reject”. These are links.
 #: resources/views/repository-page.phtml:20
 #, php-format
 msgid "This repository has been edited. You should review the changes and then %1$s or %2$s them."
-msgstr ""
+msgstr "이 저장소가 편집되었습니다. 변경 사항을 검토 한 다음 %1$s 또는 %2$s 변경해야합니다."
 
 #: resources/views/modules/privacy-policy/page.phtml:16
 msgid "This research is a “legitimate interest” under article 6(f) of the EU General Data Protection Regulations."
-msgstr ""
+msgstr "이 연구는 EU 일반 데이터 보호 규정 6 (f) 조에 따른“합법적 인 관심사”입니다."
 
 #: resources/views/admin/users-edit.phtml:243
 msgid "This role has all the permissions of the editor role, plus permission to accept/reject changes made by other users."
-msgstr ""
+msgstr "이 역할에는 편집자 역할의 모든 권한과 다른 사용자의 변경 사항을 수락 / 거부 할 수있는 권한이 있습니다."
 
 #: resources/views/admin/users-edit.phtml:257
 msgid "This role has all the permissions of the manager role in all family trees, plus permission to change the settings/configuration of the website, users, and modules."
-msgstr ""
+msgstr "이 역할에는 모든 가계도에서 관리자 역할의 모든 권한과 웹 사이트, 사용자 및 모듈의 설정 / 구성을 변경할 수있는 권한이 있습니다."
 
 #: resources/views/admin/users-edit.phtml:237
 msgid "This role has all the permissions of the member role, plus permission to add/change/delete data. Any changes will need to be reviewed by a moderator, unless the user has the “automatically accept changes” option enabled."
-msgstr ""
+msgstr "이 역할에는 멤버 역할의 모든 권한과 데이터 추가/변경/삭제 권한이 있습니다. 사용자가 “변경 사항을 자동으로 수락하지 않는 한” 변경자는 중재자가 검토해야합니다."
 
 #: resources/views/admin/users-edit.phtml:251
 msgid "This role has all the permissions of the moderator role, plus any additional access granted by the family tree configuration, plus permission to change the settings/configuration of a family tree."
-msgstr ""
+msgstr "이 역할에는 중재자 역할의 모든 권한과 가계도 구성에서 부여한 추가 액세스 권한과 가계도의 설정/구성을 변경할 수있는 권한이 있습니다."
 
 #: resources/views/admin/users-edit.phtml:229
 msgid "This role has all the permissions of the visitor role, plus any additional access granted by the family tree configuration."
-msgstr ""
+msgstr "이 역할에는 방문자 역할의 모든 권한과 가계도 구성에서 부여한 추가 액세스 권한이 있습니다."
 
 #: resources/views/setup/step-2-server-checks.phtml:56
 #, php-format
 msgid "This server’s memory limit is %s MB and its CPU time limit is %s seconds."
-msgstr ""
+msgstr "이 서버의 메모리 제한은 %s MB이고 CPU 시간 제한은 %s 초입니다."
 
 #. I18N: Help text for the “Other facts to show in charts” configuration setting
 #: resources/views/admin/trees-preferences.phtml:419
 msgid "This should be a comma or space separated list of facts, in addition to birth and death, that you want to appear in chart boxes such as the pedigree chart. This list requires you to use fact tags as defined in the GEDCOM 5.5.1 standard. For example, if you wanted the occupation to show up in the box, you would add “OCCU” to this field."
-msgstr ""
+msgstr "가계도와 같은 차트 상자에 표시하려는 출생 및 사망 외에 쉼표 또는 공백으로 구분 된 사실 목록이어야합니다. 이 목록에는 GEDCOM 5.5.1 표준에 정의 된 팩트 태그를 사용해야합니다. 예를 들어, 직업을 상자에 표시하려면이 필드에 "OCCU"를 추가하십시오."
 
 #: app/Exceptions/SourceAccessDeniedException.php:35
 #: app/Exceptions/SourceNotFoundException.php:35
 msgid "This source does not exist or you do not have permission to view it."
-msgstr ""
+msgstr "이 출처가 존재하지 않거나 볼 수있는 권한이 없습니다."
 
 #: resources/views/source-page.phtml:17
 msgid "This source has been deleted. The deletion will need to be reviewed by a moderator."
-msgstr ""
+msgstr "이 출처가 삭제되었습니다. 중재자가 삭제를 검토해야합니다."
 
 #. I18N: %1$s is “accept”, %2$s is “reject”. These are links.
 #: resources/views/source-page.phtml:15
 #, php-format
 msgid "This source has been deleted. You should review the deletion and then %1$s or %2$s it."
-msgstr ""
+msgstr "이 출처가 삭제되었습니다. 삭제를 검토 한 다음 %1$s 또는 %2$s 해야합니다."
 
 #: resources/views/source-page.phtml:23
 msgid "This source has been edited. The changes need to be reviewed by a moderator."
-msgstr ""
+msgstr "이 출처는 편집되었습니다. 중재자가 변경 사항을 검토해야합니다."
 
 #. I18N: %1$s is “accept”, %2$s is “reject”. These are links.
 #: resources/views/source-page.phtml:21
 #, php-format
 msgid "This source has been edited. You should review the changes and then %1$s or %2$s them."
-msgstr ""
+msgstr "이 출처는 편집되었습니다. 변경 사항을 검토 한 다음 %1$s 또는 %2$s 변경해야 합니다."
 
 #. I18N: Help text for the “Add to TITLE header tag” configuration setting
 #: resources/views/admin/trees-preferences.phtml:202
 msgid "This text will be appended to each page title. It will be shown in the browser’s title bar, bookmarks, etc."
-msgstr ""
+msgstr "이 텍스트는 각 페이지 제목에 추가됩니다. 브라우저의 제목 표시 줄, 책갈피 등에 표시됩니다."
 
 #: app/Http/Controllers/AdminTreesController.php:288
 #: app/Http/Controllers/AdminTreesController.php:293
 msgid "This type of link is not allowed here."
-msgstr ""
+msgstr "이 유형의 링크는 여기에서 허용되지 않습니다."
 
 #: resources/views/errors/no-tree-access.phtml:8
 msgid "This user account does not have access to any tree."
-msgstr ""
+msgstr "이 사용자 계정은 어떤 가계도에도 액세스 할 수 없습니다."
 
 #: app/Http/Controllers/SetupController.php:159
 msgid "This usually means that you need to change the folder permissions to 777."
-msgstr ""
+msgstr "이것은 일반적으로 퍼미션을 777로 변경해야 함을 의미합니다."
 
 #: app/Services/UpgradeService.php:254
 msgid "This website is being upgraded. Try again in a few minutes."
-msgstr ""
+msgstr "이 웹 사이트는 업그레이드 중입니다. 몇 분 후에 다시 시도하십시오."
 
 #: resources/views/layouts/offline.phtml:65
 msgid "This website is down for maintenance. You should <a href=\"index.php\">try again</a> in a few minutes."
-msgstr ""
+msgstr "이 웹 사이트는 유지 관리를 위해 다운되었습니다. 몇 분 안에 <a href=\"index.php\">다시 시도</a> 해야합니다."
 
 #: resources/views/modules/privacy-policy/page.phtml:61
 msgid "This website is operated by the following individuals."
-msgstr ""
+msgstr "이 웹 사이트는 다음 개인이 운영합니다."
 
 #: resources/views/layouts/error.phtml:13
 #: resources/views/layouts/error.phtml:30
 #: resources/views/layouts/offline.phtml:62
 msgid "This website is temporarily unavailable"
-msgstr ""
+msgstr "이 웹 사이트는 일시적으로 이용할 수 없습니다"
 
 #: resources/views/modules/privacy-policy/page.phtml:13
 msgid "This website processes personal data for the purpose of historical and genealogical research."
-msgstr ""
+msgstr "이 웹 사이트는 역사 및 계보 연구 목적으로 개인 데이터를 처리합니다."
 
 #: resources/views/modules/privacy-policy/page.phtml:24
 msgid "This website uses cookies to enable login sessions, and to remember preferences such as your chosen language."
-msgstr ""
+msgstr "이 웹 사이트는 쿠키를 사용하여 로그인 세션을 활성화하고 선택한 언어와 같은 기본 설정을 기억합니다."
 
 #: resources/views/modules/privacy-policy/footer.phtml:15
 msgid "This website uses cookies to learn about visitor behavior."
-msgstr ""
+msgstr "이 웹 사이트는 쿠키를 사용하여 방문자 행동에 대해 학습합니다."
 
 #: resources/views/modules/privacy-policy/page.phtml:36
 msgid "This website uses third-party services to learn about visitor behavior."
-msgstr ""
+msgstr "이 웹 사이트는 타사 서비스를 사용하여 방문자 행동에 대해 학습합니다."
 
 #. I18N: %s is the name of a family tree
 #: resources/views/admin/trees-import.phtml:14
 #, php-format
 msgid "This will delete all the genealogy data from “%s” and replace it with data from a GEDCOM file."
-msgstr ""
+msgstr "그러면 "%s"에서 모든 계보 데이터가 삭제되고 GEDCOM 파일의 데이터로 대체됩니다."
 
 #. I18N: abbreviation for Thursday
 #: app/Date/AbstractCalendarDate.php:288
@@ -14748,12 +14748,12 @@ msgstr ""
 
 #: resources/views/admin/webtrees1-thumbnails.phtml:34
 msgid "Thumbnail image"
-msgstr ""
+msgstr "썸네일 이미지"
 
 #: resources/views/admin/trees-preferences.phtml:281
 #: resources/views/admin/trees-preferences.phtml:287
 msgid "Thumbnail images"
-msgstr ""
+msgstr "썸네일 이미지"
 
 #: app/Date/AbstractCalendarDate.php:258
 msgid "Thursday"
@@ -14767,19 +14767,19 @@ msgstr ""
 #. I18N: gedcom tag TIME
 #: app/GedcomTag.php:1052
 msgid "Time"
-msgstr ""
+msgstr "시간"
 
 #. I18N: A configuration setting
 #: resources/views/admin/site-preferences.phtml:44
 #: resources/views/admin/users-edit.phtml:117
 #: resources/views/edit-account-page.phtml:99
 msgid "Time zone"
-msgstr ""
+msgstr "타임존"
 
 #. I18N: Name of a module/chart
 #: app/Module/TimelineChartModule.php:96
 msgid "Timeline"
-msgstr ""
+msgstr "타임라인"
 
 #: resources/views/admin/changes-log.phtml:115
 #: resources/views/admin/site-logs.phtml:106
@@ -14859,7 +14859,7 @@ msgstr ""
 #: resources/views/modules/html/config.phtml:11
 #: resources/views/modules/user_blog/edit.phtml:17
 msgid "Title"
-msgstr ""
+msgstr "제목"
 
 #: app/GedcomTag.php:1061
 msgid "Title in Hebrew"
@@ -14880,43 +14880,43 @@ msgstr ""
 
 #: resources/views/modules/html/config.phtml:25
 msgid "To assist you in getting started with this block, we have created several standard templates. When you select one of these templates, the text area will contain a copy that you can then alter to suit your site’s requirements."
-msgstr ""
+msgstr "이 블록을 시작하는 데 도움을주기 위해 몇 가지 표준 템플릿을 만들었습니다. 이러한 템플릿 중 하나를 선택하면 텍스트 영역에 사이트의 요구 사항에 맞게 변경할 수있는 사본이 포함됩니다."
 
 #: resources/views/modules/todo/config.phtml:9
 msgid "To create new research tasks, you must first add “research task” to the list of facts and events in the family tree’s preferences."
-msgstr ""
+msgstr "새로운 연구 과제를 만들려면 먼저 가계도 환경 설정의 사실 및 사건 목록에 "연구 과제"를 추가해야합니다."
 
 #. I18N: Help text for the “Format text and notes” configuration setting
 #: resources/views/admin/trees-preferences.phtml:605
 msgid "To ensure compatibility with other genealogy applications, notes, text, and transcripts should be recorded in simple, unformatted text. However, formatting is often desirable to aid presentation, comprehension, etc."
-msgstr ""
+msgstr "다른 계보 응용 프로그램과의 호환성을 보장하려면 노트, 텍스트 및 대화내용을 형식이 지정되지 않은 간단한 텍스트로 기록해야합니다. 그러나 프리젠테이션, 이해력 등을 돕기 위해 형식을 지정하는 것이 바람직합니다."
 
 #. I18N: “Apache” is a software program.
 #: resources/views/admin/site-preferences.phtml:30
 msgid "To protect this private data, webtrees uses an Apache configuration file (.htaccess) which blocks all access to this folder. If your web-server does not support .htaccess files, and you cannot restrict access to this folder, then you can select another folder, away from your web documents."
-msgstr ""
+msgstr "이 개인 데이터를 보호하기 위해 웹 트리는이 폴더에 대한 모든 액세스를 차단하는 Apache 구성 파일 (.htaccess)을 사용합니다. 웹 서버가 .htaccess 파일을 지원하지 않고이 폴더에 대한 액세스를 제한 할 수없는 경우 웹 문서에서 다른 폴더를 선택할 수 있습니다."
 
 #: resources/views/help/zip-gedcom.phtml:8
 msgid "To reduce the size of the download, you can compress the data into a .ZIP file. You will need to uncompress the .ZIP file before you can use it."
-msgstr ""
+msgstr "다운로드 크기를 줄이려면 데이터를 .ZIP 파일로 압축 할 수 있습니다. .ZIP 파일의 압축을 풀어야 사용할 수 있습니다."
 
 #: resources/views/emails/password-request-html.phtml:12
 #: resources/views/emails/password-request-text.phtml:8
 msgid "To set a new password, follow this link."
-msgstr ""
+msgstr "새 비밀번호를 설정하려면이 링크를 따르십시오."
 
 #. I18N: Help text for the "Custom welcome text" site configuration setting
 #: resources/views/admin/site-registration.phtml:36
 msgid "To set this text for other languages, you must switch to that language, and visit this page again."
-msgstr ""
+msgstr "이 언어를 다른 언어로 설정하려면 해당 언어로 전환 한 후이 페이지를 다시 방문해야합니다."
 
 #: resources/views/modules/sitemap/config.phtml:44
 msgid "To tell search engines that sitemaps are available, you can use the following links."
-msgstr ""
+msgstr "검색 엔진에 사이트 맵을 사용할 수 있도록하려면 다음 링크를 사용하십시오."
 
 #: resources/views/modules/sitemap/config.phtml:36
 msgid "To tell search engines that sitemaps are available, you should add the following line to your robots.txt file."
-msgstr ""
+msgstr "검색 엔진에 사이트 맵을 사용할 수있게하려면 robots.txt 파일에 다음 줄을 추가해야합니다."
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:480
@@ -14948,36 +14948,36 @@ msgstr ""
 #, php-format
 msgid "Top %s given name"
 msgid_plural "Top %s given names"
-msgstr[0] ""
+msgstr[0] "상위 %s 이름"
 
 #. I18N: Title for a list of the most common surnames, %s is a number. Note that a separate translation exists when %s is 1
 #: app/Module/TopSurnamesModule.php:161
 #, php-format
 msgid "Top %s surname"
 msgid_plural "Top %s surnames"
-msgstr[0] ""
+msgstr[0] "상위 %s 가문이름"
 
 #. I18N: i.e. most popular given name.
 #: app/Module/TopGivenNamesModule.php:101
 msgid "Top given name"
-msgstr ""
+msgstr "제일 많은 이름"
 
 #. I18N: Name of a module. Top=Most common
 #: app/Module/TopGivenNamesModule.php:47
 #: resources/views/statistics/individuals/names.phtml:55
 msgid "Top given names"
-msgstr ""
+msgstr "제일 많은 이름"
 
 #. I18N: i.e. most popular surname.
 #: app/Module/TopSurnamesModule.php:158
 msgid "Top surname"
-msgstr ""
+msgstr "제일 많은 가문이름"
 
 #. I18N: Name of a module. Top=Most common
 #: app/Module/TopSurnamesModule.php:64
 #: resources/views/statistics/individuals/names.phtml:31
 msgid "Top surnames"
-msgstr ""
+msgstr "제일 많은 가문이름"
 
 #. I18N: Location of an LDS church temple
 #: app/GedcomCode/GedcomCodeTemp.php:663
@@ -15003,33 +15003,33 @@ msgstr ""
 #: resources/views/lists/chart-by-age.phtml:24
 #: resources/views/lists/chart-by-decade.phtml:16
 msgid "Total"
-msgstr ""
+msgstr "Total"
 
 #: resources/xml/reports/change_report.xml:127
 msgid "Total accepted changes: "
-msgstr ""
+msgstr "허용되는 Total 변경 사항: "
 
 #: resources/views/statistics/individuals/total-events.phtml:22
 msgid "Total births"
-msgstr ""
+msgstr "Total 출생"
 
 #: resources/views/statistics/individuals/total-records.phtml:61
 msgid "Total dead"
-msgstr ""
+msgstr "Total 사망"
 
 #: resources/views/statistics/individuals/total-events.phtml:70
 msgid "Total deaths"
-msgstr ""
+msgstr "Total 사망"
 
 #: resources/views/statistics/families/total-records.phtml:71
 msgid "Total divorces"
-msgstr ""
+msgstr "Total 이혼"
 
 #: resources/views/modules/gedcom_stats/config.phtml:30
 #: resources/views/statistics/other/total-events.phtml:12
 #: resources/xml/reports/missing_facts_report.xml:602
 msgid "Total events"
-msgstr ""
+msgstr "Total 이벤트"
 
 #: app/Statistics/Google/ChartNoChildrenFamilies.php:133
 #: resources/views/statistics/families/total-records.phtml:12
@@ -15039,15 +15039,15 @@ msgstr ""
 #: resources/xml/reports/fact_sources.xml:354
 #: resources/xml/reports/marriage_report.xml:111
 msgid "Total families"
-msgstr ""
+msgstr "Total 가족"
 
 #: resources/views/statistics/individuals/total-records.phtml:32
 msgid "Total females"
-msgstr ""
+msgstr "Total 가족"
 
 #: resources/views/statistics/individuals/names.phtml:46
 msgid "Total given names"
-msgstr ""
+msgstr "Total 이름"
 
 #: resources/views/statistics/individuals/total-records.phtml:12
 #: resources/xml/reports/bdm_report.xml:210
@@ -15062,33 +15062,33 @@ msgstr ""
 #: resources/xml/reports/occupation_report.xml:94
 #: resources/xml/reports/relative_ext_report.xml:140
 msgid "Total individuals"
-msgstr ""
+msgstr "Total 인물"
 
 #: resources/views/statistics/individuals/total-records.phtml:53
 msgid "Total living"
-msgstr ""
+msgstr "Total 생존"
 
 #: resources/views/statistics/individuals/total-records.phtml:23
 msgid "Total males"
-msgstr ""
+msgstr "Total 남성"
 
 #: resources/views/statistics/families/total-records.phtml:23
 msgid "Total marriages"
-msgstr ""
+msgstr "Total 결혼"
 
 #: resources/xml/reports/change_report.xml:87
 msgid "Total pending changes: "
-msgstr ""
+msgstr "모든 보류중인 변경 사항: "
 
 #: resources/views/modules/gedcom_stats/config.phtml:25
 #: resources/views/modules/html/template-statistics.phtml:31
 #: resources/views/statistics/individuals/names.phtml:22
 msgid "Total surnames"
-msgstr ""
+msgstr "Total 가문이름"
 
 #: resources/views/modules/gedcom_stats/config.phtml:31
 msgid "Total users"
-msgstr ""
+msgstr "Total 사용자"
 
 #: app/Http/Controllers/Admin/ModuleController.php:100
 #: app/Module/ModuleAnalyticsTrait.php:83
@@ -15100,19 +15100,19 @@ msgstr ""
 #: resources/views/admin/modules.phtml:232
 #: resources/views/modules/privacy-policy/page.phtml:32
 msgid "Tracking and analytics"
-msgstr ""
+msgstr "추적 및 분석"
 
 #. I18N: gedcom tag TRLR
 #: app/GedcomTag.php:1064
 msgid "Trailer"
-msgstr ""
+msgstr "트레일러"
 
 #: app/Module/AncestorsChartModule.php:275
 #: app/Module/DescendancyChartModule.php:264
 #: resources/views/emails/register-notify-html.phtml:25
 #: resources/views/emails/register-notify-text.phtml:15
 msgid "Tree"
-msgstr ""
+msgstr "트리"
 
 #. I18N: The third day in the French republican calendar
 #: app/Date/FrenchDate.php:291
@@ -15187,15 +15187,15 @@ msgstr ""
 #: resources/views/modules/random_media/config.phtml:19
 #: resources/views/modules/recent_changes/changes-table.phtml:38
 msgid "Type"
-msgstr ""
+msgstr "유형"
 
 #: app/GedcomTag.php:722
 msgid "Type of event"
-msgstr ""
+msgstr "이벤트 유형"
 
 #: app/GedcomTag.php:727
 msgid "Type of fact"
-msgstr ""
+msgstr "정보 유형"
 
 #. I18N: gedcom tag URL (A web address / URL)
 #. I18N: gedcom tag WWW (A web address / URL)
@@ -15235,33 +15235,33 @@ msgstr ""
 #. I18N: LDS sealing status; see http://en.wikipedia.org/wiki/Sealing_(Latter_Day_Saints)
 #: app/GedcomCode/GedcomCodeStat.php:142
 msgid "Uncleared: insufficient data"
-msgstr ""
+msgstr "불분명 : 데이터 부족"
 
 #: resources/views/admin/trees-preferences.phtml:735
 msgid "Unique family facts"
-msgstr ""
+msgstr "독특한 가족 정보"
 
 #. I18N: gedcom tag _UID
 #: app/GedcomTag.php:2065
 msgid "Unique identifier"
-msgstr ""
+msgstr "고유 식별자"
 
 #. I18N: Help text for the “Add unique identifiers” configuration setting
 #: resources/views/admin/trees-preferences.phtml:137
 msgid "Unique identifiers allow the same record to be found in different family trees and in different systems. They will be added whenever records are created or updated. If you do not want unique identifiers to be displayed, you can hide them using the privacy rules."
-msgstr ""
+msgstr "고유 식별자를 사용하면 다른 가계도 및 다른 시스템에서 동일한 레코드를 찾을 수 있습니다. 레코드가 작성되거나 업데이트 될 때마다 추가됩니다. 고유 식별자를 표시하지 않으려면 개인 정보 보호 규칙을 사용하여 숨길 수 있습니다."
 
 #: resources/views/admin/trees-preferences.phtml:681
 msgid "Unique individual facts"
-msgstr ""
+msgstr "독특한 인물 정보"
 
 #: resources/views/admin/trees-preferences.phtml:830
 msgid "Unique repository facts"
-msgstr ""
+msgstr "독특한 저장소 정보"
 
 #: resources/views/admin/trees-preferences.phtml:789
 msgid "Unique source facts"
-msgstr ""
+msgstr "독특한 출처 정보"
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:54
@@ -15283,12 +15283,12 @@ msgstr ""
 #: app/Statistics/Google/ChartSex.php:72
 #: app/Statistics/Service/CountryService.php:38
 msgid "Unknown"
-msgstr ""
+msgstr "알 수 없는"
 
 #: app/Statistics/Google/ChartNoChildrenFamilies.php:120
 msgctxt "unknown century"
 msgid "Unknown"
-msgstr ""
+msgstr "알 수 없는"
 
 #: app/Functions/FunctionsEdit.php:564
 #: app/Http/RequestHandlers/IndividualPage.php:293
@@ -15299,34 +15299,34 @@ msgstr ""
 #: resources/xml/reports/individual_report.xml:602
 msgctxt "unknown gender"
 msgid "Unknown"
-msgstr ""
+msgstr "알 수 없는"
 
 #: resources/views/edit-account-page.phtml:52
 msgctxt "unknown people"
 msgid "Unknown"
-msgstr ""
+msgstr "알 수 없는"
 
 #: app/GedcomTag.php:2113
 msgid "Unrecognized GEDCOM code"
-msgstr ""
+msgstr "인식 할 수없는 GEDCOM 코드"
 
 #: resources/views/admin/media.phtml:45
 msgid "Unused files"
-msgstr ""
+msgstr "사용하지 않는 파일"
 
 #: app/Http/Controllers/Admin/UpgradeController.php:219
 #, php-format
 msgid "Unzip %s to a temporary folder…"
-msgstr ""
+msgstr "임시 폴더에 %s의 압축을 풉니다…"
 
 #: app/Module/PedigreeChartModule.php:392
 msgid "Up"
-msgstr ""
+msgstr "위"
 
 #. I18N: Name of a module
 #: app/Module/UpcomingAnniversariesModule.php:100
 msgid "Upcoming events"
-msgstr ""
+msgstr "다가오는 이벤트"
 
 #: app/Http/RequestHandlers/DataFixData.php:108
 #: resources/views/modules/batch_update/admin.phtml:77
@@ -15337,17 +15337,17 @@ msgstr "업데이트"
 #: resources/views/modules/batch_update/admin.phtml:82
 #: resources/views/modules/batch_update/admin.phtml:86
 msgid "Update all"
-msgstr ""
+msgstr "전부 업데이트"
 
 #. I18N: Name of a module
 #: app/Module/FixPlaceNames.php:63
 msgid "Update place names"
-msgstr ""
+msgstr "장소이름 업데이트"
 
 #. I18N: Description of a “Data fix” module
 #: app/Module/FixPlaceNames.php:74
 msgid "Update the higher-level parts of place names, while keeping the lower-level parts."
-msgstr ""
+msgstr "하위 레벨 부분을 유지하면서 상위 레벨의 장소 이름 부분을 업데이트하십시오."
 
 #. I18N: %s is a version number, such as 1.2.3
 #. I18N: %s is a version number
@@ -15361,16 +15361,16 @@ msgstr ""
 #: app/Http/Controllers/Admin/UpgradeController.php:114
 #: app/Http/Controllers/Admin/UpgradeController.php:214
 msgid "Upgrade wizard"
-msgstr ""
+msgstr "Upgrade wizard"
 
 #: app/Http/Controllers/Admin/MediaController.php:388
 #: resources/views/admin/control-panel.phtml:610
 msgid "Upload media files"
-msgstr ""
+msgstr "미디어 파일 업로드"
 
 #: resources/views/admin/media-upload.phtml:13
 msgid "Upload one or more media files from your local computer. Media files can be pictures, video, audio, or other formats."
-msgstr ""
+msgstr "로컬 컴퓨터에서 하나 이상의 미디어 파일을 업로드하십시오. 미디어 파일은 사진, 비디오, 오디오 또는 기타 형식 일 수 있습니다."
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:512
@@ -15379,11 +15379,11 @@ msgstr ""
 
 #: app/Services/EmailService.php:239
 msgid "Use SMTP to send messages"
-msgstr ""
+msgstr "SMTP를 사용하여 메시지 보내기"
 
 #: app/Module/FixSearchAndReplace.php:103
 msgid "Use a “?” to match a single character, use “*” to match zero or more characters."
-msgstr ""
+msgstr "“?”를 사용하십시오 단일 문자를 일치 시키려면 “*”를 사용하여 0 개 이상의 문자를 일치시킵니다."
 
 #. I18N: placeholder text for new-password field
 #: resources/views/admin/users-create.phtml:48
@@ -15392,22 +15392,22 @@ msgstr ""
 #, php-format
 msgid "Use at least %s character."
 msgid_plural "Use at least %s characters."
-msgstr[0] ""
+msgstr[0] "%s자 이상을 사용하십시오."
 
 #: resources/xml/reports/family_group_report.xml:12
 #: resources/xml/reports/individual_ext_report.xml:13
 #: resources/xml/reports/individual_report.xml:10
 msgid "Use colors"
-msgstr ""
+msgstr "색상 사용"
 
 #: resources/views/modules/interactive-tree/chart.phtml:10
 msgid "Use compact layout"
-msgstr ""
+msgstr "컴팩트 레이아웃 사용"
 
 #. I18N: A configuration setting
 #: resources/views/admin/trees-preferences.phtml:902
 msgid "Use full source citations"
-msgstr ""
+msgstr "전체 출처 인용 사용"
 
 #: resources/views/setup/step-4-database-mysql.phtml:105
 #: resources/views/setup/step-4-database-pgsql.phtml:92
@@ -15415,39 +15415,39 @@ msgstr ""
 #: resources/views/setup/step-4-database-sqlite.phtml:66
 #: resources/views/setup/step-4-database-sqlsvr.phtml:92
 msgid "Use letters A-Z, a-z, digits 0-9, or underscores"
-msgstr ""
+msgstr "문자 A-Z, a-z, 숫자 0-9 또는 밑줄을 사용하십시오."
 
 #. I18N: A configuration setting
 #: resources/views/admin/site-mail.phtml:126
 msgid "Use password"
-msgstr ""
+msgstr "비밀번호 사용"
 
 #. I18N: "sendmail" is the name of some mail software
 #: app/Services/EmailService.php:238
 msgid "Use sendmail to send messages"
-msgstr ""
+msgstr "sendmail을 사용하여 메시지 보내기"
 
 #. I18N: Help text for the “Use silhouettes” configuration setting
 #: resources/views/admin/trees-preferences.phtml:307
 msgid "Use silhouette images when no highlighted image for that individual has been specified. The images used are specific to the gender of the individual in question."
-msgstr ""
+msgstr "해당 인물에 대해 강조 표시된 이미지가 지정되지 않은 경우 실루엣 이미지를 사용하십시오. 사용 된 이미지는 해당 인물의 성별에 따라 다릅니다."
 
 #. I18N: A configuration setting
 #: resources/views/admin/trees-preferences.phtml:302
 msgid "Use silhouettes"
-msgstr ""
+msgstr "실루엣 사용"
 
 #: resources/views/admin/map-provider.phtml:31
 msgid "Use the GeoNames database for autocomplete on places"
-msgstr ""
+msgstr "장소에서 자동 완성을 위해 GeoNames 데이터베이스 사용"
 
 #: resources/views/register-page.phtml:89
 msgid "Use this field to tell the site administrator why you are requesting an account and how you are related to the genealogy displayed on this site. You can also use this to enter any other comments you may have for the site administrator."
-msgstr ""
+msgstr "이 필드를 사용하여 사이트 관리자에게 계정을 요청하는 이유와이 사이트에 표시된 계보와 관련이있는 방법을 알려줍니다. 이를 사용하여 사이트 관리자에 대해 다른 의견을 입력 할 수도 있습니다."
 
 #: app/Functions/FunctionsEdit.php:588
 msgid "Use this image for charts and on the individual’s page."
-msgstr ""
+msgstr "이 이미지를 차트와 인물 페이지에 사용하십시오."
 
 #: resources/views/admin/changes-log.phtml:66
 #: resources/views/admin/changes-log.phtml:119
@@ -15456,7 +15456,7 @@ msgstr ""
 #: resources/views/modules/recent_changes/changes-table.phtml:49
 #: resources/views/pending-changes-page.phtml:53
 msgid "User"
-msgstr ""
+msgstr "사용자"
 
 #: app/Http/Controllers/Admin/UsersController.php:107
 #: resources/views/admin/control-panel.phtml:354
@@ -15465,19 +15465,19 @@ msgstr ""
 #: resources/views/admin/users-create.phtml:9
 #: resources/views/admin/users-edit.phtml:12
 msgid "User administration"
-msgstr ""
+msgstr "사용자 관리"
 
 #: resources/views/admin/users-cleanup.phtml:48
 msgid "User didn’t verify within 7 days."
-msgstr ""
+msgstr "사용자가 7 일 이내에 확인하지 않았습니다."
 
 #: resources/views/admin/users-cleanup.phtml:50
 msgid "User not verified by administrator."
-msgstr ""
+msgstr "관리자가 사용자를 확인하지 않았습니다."
 
 #: app/Http/RequestHandlers/VerifyEmail.php:73
 msgid "User verification"
-msgstr ""
+msgstr "사용자 확인"
 
 #. I18N: A configuration setting
 #: resources/views/admin/site-mail.phtml:44
@@ -15507,17 +15507,17 @@ msgstr "사용자 이름이나 이메일 주소"
 #: resources/views/edit-account-page.phtml:25
 #: resources/views/register-page.phtml:63
 msgid "Usernames are case-insensitive and ignore accented letters, so that “chloe”, “chloë”, and “Chloe” are considered to be the same."
-msgstr ""
+msgstr "사용자 이름은 대소 문자를 구분하지 않으며 악센트 부호 문자를 무시하므로 "chloe", "chloë"및 "Chloe"는 동일하게 간주됩니다."
 
 #: resources/views/admin/control-panel.phtml:320
 #: resources/views/modules/gedcom_stats/statistics.phtml:123
 #: resources/views/modules/html/template-statistics.phtml:55
 msgid "Users"
-msgstr ""
+msgstr "사용자"
 
 #: resources/views/admin/users-cleanup.phtml:29
 msgid "User’s account has been inactive too long: "
-msgstr ""
+msgstr "사용자 계정이 너무 오래 비활성 상태입니다: "
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:516
@@ -15537,7 +15537,7 @@ msgstr ""
 #. I18N: Description of the “StatisticsChart” module
 #: app/Module/StatisticsChartModule.php:106
 msgid "Various statistics charts."
-msgstr ""
+msgstr "다양한 통계 차트."
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:518
@@ -15614,12 +15614,12 @@ msgstr ""
 #. I18N: gedcom tag VERS
 #: app/GedcomTag.php:1073
 msgid "Version"
-msgstr ""
+msgstr "버젼"
 
 #. I18N: Type of media object
 #: app/GedcomTag.php:2405
 msgid "Video"
-msgstr ""
+msgstr "영상"
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:528
@@ -15628,16 +15628,16 @@ msgstr ""
 
 #: app/Functions/FunctionsPrintFacts.php:1038
 msgid "View"
-msgstr ""
+msgstr "보기"
 
 #: resources/views/modules/place-hierarchy/page.phtml:50
 #, php-format
 msgid "View table of events occurring in %s"
-msgstr ""
+msgstr "%s에서 발생하는 이벤트 테이블 보기"
 
 #: resources/views/calendar-page.phtml:191
 msgid "View this day"
-msgstr ""
+msgstr "오늘 보기"
 
 #: app/Functions/FunctionsPrintFacts.php:228
 #: app/Functions/FunctionsPrintFacts.php:712
@@ -15645,15 +15645,15 @@ msgstr ""
 #: resources/views/statistics/families/top10-list-age.phtml:25
 #: resources/views/statistics/families/top10-nolist-age.phtml:25
 msgid "View this family"
-msgstr ""
+msgstr "가족 보기"
 
 #: resources/views/calendar-page.phtml:195
 msgid "View this month"
-msgstr ""
+msgstr "월 보기"
 
 #: resources/views/calendar-page.phtml:199
 msgid "View this year"
-msgstr ""
+msgstr "년 보기"
 
 #. I18N: Location of an LDS church temple
 #: app/GedcomCode/GedcomCodeTemp.php:681
@@ -15664,13 +15664,14 @@ msgstr ""
 #: resources/views/admin/users-edit.phtml:148
 #: resources/views/edit-account-page.phtml:136
 msgid "Visible online"
-msgstr ""
+msgstr "온라인으로 표시"
 
 #. I18N: A configuration setting
 #: resources/views/admin/users-edit.phtml:154
 #: resources/views/edit-account-page.phtml:139
 msgid "Visible to other users when online"
-msgstr ""
+msgstr "온라인 일 때 다른 사용자에게 공개
+"
 
 #. I18N: Listbox entry; name of a role
 #: app/Http/Controllers/Admin/UsersController.php:420
@@ -15679,7 +15680,7 @@ msgstr ""
 #: resources/views/modules/clippings/download.phtml:28
 #: resources/views/modules/clippings/download.phtml:41
 msgid "Visitor"
-msgstr ""
+msgstr "방문자"
 
 #. I18N: Name of a module/report. “Vital records” are life events - birth/marriage/death
 #: app/Module/BirthDeathMarriageReportModule.php:40
@@ -15687,7 +15688,7 @@ msgstr ""
 #: resources/xml/reports/bdm_report.xml:3
 #: resources/xml/reports/bdm_report.xml:34
 msgid "Vital records"
-msgstr ""
+msgstr "중요한 기록"
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:534
@@ -15701,17 +15702,17 @@ msgstr ""
 
 #: app/GedcomCode/GedcomCodeRela.php:346
 msgid "Ward"
-msgstr ""
+msgstr "후견인"
 
 #: app/GedcomCode/GedcomCodeRela.php:343
 msgctxt "FEMALE"
 msgid "Ward"
-msgstr ""
+msgstr "후견인"
 
 #: app/GedcomCode/GedcomCodeRela.php:339
 msgctxt "MALE"
 msgid "Ward"
-msgstr ""
+msgstr "후견인"
 
 #. I18N: Location of an LDS church temple
 #: app/GedcomCode/GedcomCodeTemp.php:684
@@ -15720,33 +15721,33 @@ msgstr ""
 
 #: resources/views/admin/trees-preferences.phtml:313
 msgid "Watermarks"
-msgstr ""
+msgstr "워터마크"
 
 #. I18N: Help text for the “Images without watermarks” configuration setting
 #: resources/views/admin/trees-preferences.phtml:323
 msgid "Watermarks are optional and normally shown just to visitors."
-msgstr ""
+msgstr "워터 마크는 선택사항이며 일반적으로 방문자에게만 표시됩니다."
 
 #: resources/views/register-success-page.phtml:17
 #, php-format
 msgid "We will now send a confirmation email to the address <b>%s</b>. You must verify your account request by following instructions in the confirmation email. If you do not confirm your account request within seven days, your application will be rejected automatically. You will have to apply again.<br><br>After you have followed the instructions in the confirmation email, the administrator still has to approve your request before your account can be used.<br><br>To sign in to this website, you will need to know your username and password."
-msgstr ""
+msgstr "이제 <b>%s</b> 주소로 확인 이메일을 보내드립니다. 확인 이메일의 지침에 따라 계정 요청을 확인해야합니다. 7일 이내에 계정 요청을 확인하지 않으면 신청서가 자동으로 거부됩니다. 다시 신청해야합니다. <br><br> 확인 이메일의 지침을 따른 후에도 관리자는 계정을 사용하기 전에 요청을 승인해야합니다. <br><br> 로그인하려면 웹 사이트에서 사용자 이름과 비밀번호를 알아야합니다."
 
 #: resources/views/admin/control-panel.phtml:42
 #: resources/views/admin/control-panel.phtml:468
 #: resources/views/admin/trees-preferences.phtml:185
 msgid "Website"
-msgstr ""
+msgstr "웹사이트"
 
 #: app/Http/RequestHandlers/SiteLogsPage.php:102
 #: resources/views/admin/control-panel.phtml:105
 msgid "Website logs"
-msgstr ""
+msgstr "웹사이트 로그"
 
 #: app/Http/Controllers/AdminSiteController.php:62
 #: resources/views/admin/control-panel.phtml:83
 msgid "Website preferences"
-msgstr ""
+msgstr "웹사이트 환경설정"
 
 #. I18N: abbreviation for Wednesday
 #: app/Date/AbstractCalendarDate.php:286
@@ -15761,22 +15762,22 @@ msgstr ""
 #. I18N: gedcom tag _WEIG
 #: app/GedcomTag.php:2071
 msgid "Weight"
-msgstr ""
+msgstr "무게"
 
 #. I18N: A %s is the user’s name
 #: app/Module/UserWelcomeModule.php:122
 #, php-format
 msgid "Welcome %s"
-msgstr ""
+msgstr "환영합니다 %s"
 
 #. I18N: A configuration setting
 #: resources/views/admin/site-registration.phtml:19
 msgid "Welcome text on sign-in page"
-msgstr ""
+msgstr "로그인 페이지의 환영 텍스트"
 
 #: resources/views/login-page.phtml:21
 msgid "Welcome to this genealogy website"
-msgstr ""
+msgstr "이 계보 웹 사이트에 오신 것을 환영합니다"
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:177
@@ -15786,60 +15787,60 @@ msgstr ""
 #. I18N: Help text for the “Keep the existing ‘last change’ information” configuration setting
 #: resources/views/admin/trees-preferences.phtml:937
 msgid "When a record is edited, the user and timestamp are recorded. Sometimes it is desirable to keep the existing “last change” information, for example when making minor corrections to someone else’s data. This option controls whether this feature is selected by default."
-msgstr ""
+msgstr "레코드가 편집되면 사용자 및 타임 스탬프가 기록됩니다. 예를 들어 다른 사람의 데이터를 약간 수정하는 경우와 같이 기존의 "마지막 변경"정보를 유지하는 것이 바람직 할 수 있습니다. 이 옵션은이 기능이 기본적으로 선택되는지 여부를 제어합니다."
 
 #: resources/views/admin/users-edit.phtml:89
 msgid "When a user registers for an account, an email is sent to their email address with a verification link. When they follow this link, we know the email address is correct, and the “email verified” option is selected automatically."
-msgstr ""
+msgstr "사용자가 계정을 등록하면 확인 링크가 포함 된 이메일이 이메일 주소로 전송됩니다. 그들이이 링크를 따라갈 때, 우리는 이메일 주소가 정확하다는 것을 알고 있으며“이메일 확인”옵션이 자동으로 선택됩니다."
 
 #. I18N: Help text for the “Source type” configuration setting
 #: resources/views/admin/trees-preferences.phtml:922
 msgid "When adding new close relatives, you can add source citations to the records (individual and family) or to the facts and events (birth, marriage, and death). This option controls whether records or facts will be selected by default."
-msgstr ""
+msgstr "가까운 친척을 추가 할 때 기록 (인물 및 가족) 또는 정보 및 이벤트 (출생, 결혼 및 사망)에 출처 인용을 추가 할 수 있습니다. 이 옵션은 기본적으로 레코드 또는 정보 선택할지 여부를 제어합니다."
 
 #: resources/views/edit/reorder-families.phtml:24
 msgid "When an individual has more than one spouse, you should sort the families in date order."
-msgstr ""
+msgstr "인물에 배우자가 둘 이상 있으면 가족을 날짜 순서대로 정렬해야합니다."
 
 #. I18N: Help text for the “Surname tradition” configuration setting
 #: resources/views/admin/trees-preferences.phtml:892
 msgid "When you add a new family member, a default surname can be provided. This surname will depend on the local tradition."
-msgstr ""
+msgstr "새 가족 구성원을 추가 할 때 기본 가문이름을 제공 할 수 있습니다. 이 가문이름은 지역 전통에 따라 다릅니다."
 
 #: resources/views/help/pending-changes.phtml:8
 msgid "When you add, edit, or delete information, the changes are not saved immediately. Instead, they are kept in a “pending” area. These pending changes need to be reviewed by a moderator before they are accepted."
-msgstr ""
+msgstr "정보를 추가, 편집 또는 삭제할 때 변경 사항이 즉시 저장되지 않습니다. 대신 "보류중인"영역에 유지됩니다. 이러한 보류중인 변경 사항은 중재자가 승인하기 전에 검토해야합니다."
 
 #: resources/views/help/relationship-privacy.phtml:8
 msgid "Where a user is associated to an individual record in a family tree and has a role of member, editor, or moderator, you can prevent them from accessing the details of distant, living relations. You specify the number of relationship steps that the user is allowed to see."
-msgstr ""
+msgstr "사용자가 가계도의 개별 레코드에 연결되어 있고 구성원, 편집자 또는 중재자 역할을하는 경우, 먼 관계에있는 세부 정보에 액세스하지 못하게 할 수 있습니다. 사용자가 볼 수있는 관계 단계 수를 지정합니다."
 
 #. I18N: Label for a configuration option
 #: resources/views/modules/sitemap/config.phtml:17
 msgid "Which family trees should be included in the sitemaps"
-msgstr ""
+msgstr "사이트 맵에 포함되어야하는 가계도"
 
 #. I18N: A configuration setting
 #: resources/views/admin/trees-preferences.phtml:256
 msgid "Who can upload new media files"
-msgstr ""
+msgstr "새 미디어 파일을 업로드 할 수있는 사람"
 
 #. I18N: Name of a module. (A list of users who are online now)
 #: app/Module/LoggedInUsersModule.php:42
 msgid "Who is online"
-msgstr ""
+msgstr "온라인 상태 인 사람"
 
 #: resources/views/admin/data-fix-page.phtml:80
 msgid "Why does this list include records that do not need to be updated?"
-msgstr ""
+msgstr "이 목록에 업데이트 할 필요가없는 레코드가 포함 된 이유는 무엇입니까?"
 
 #: resources/views/lists/families-table.phtml:173
 msgid "Widow"
-msgstr ""
+msgstr "배우자와 사별한 부인"
 
 #: resources/views/lists/families-table.phtml:165
 msgid "Widower"
-msgstr ""
+msgstr "배우자와 사별한 남편"
 
 #. I18N: gedcom tag WIFE
 #: app/Functions/FunctionsPrint.php:298 app/GedcomTag.php:1076
@@ -15856,24 +15857,24 @@ msgstr ""
 #: resources/xml/reports/individual_report.xml:489
 #: resources/xml/reports/relative_ext_report.xml:104
 msgid "Wife"
-msgstr ""
+msgstr "부인"
 
 #: resources/views/modules/timeline-chart/chart.phtml:345
 msgid "Wife’s age"
-msgstr ""
+msgstr "부인의 나이"
 
 #: app/Module/FixMissingMarriedNames.php:95
 msgid "Wife’s maiden surname becomes new given name"
-msgstr ""
+msgstr "아내의 가문이름은 이름이 새로워집니다"
 
 #: app/Module/FixMissingMarriedNames.php:94
 msgid "Wife’s surname replaced by husband’s surname"
-msgstr ""
+msgstr "아내의 가문이름은 남편의 가문이름으로 대체"
 
 #. I18N: gedcom tag WILL
 #: app/GedcomTag.php:1079
 msgid "Will"
-msgstr ""
+msgstr "유언"
 
 #. I18N: Location of an LDS church temple
 #: app/GedcomCode/GedcomCodeTemp.php:687
@@ -15883,17 +15884,17 @@ msgstr ""
 #: app/Statistics/Google/ChartFamilyWithSources.php:88
 #: app/Statistics/Google/ChartIndividualWithSources.php:88
 msgid "With sources"
-msgstr ""
+msgstr "출처와 함께"
 
 #: app/Statistics/Google/ChartFamilyWithSources.php:83
 #: app/Statistics/Google/ChartIndividualWithSources.php:83
 msgid "Without sources"
-msgstr ""
+msgstr "출처 없이"
 
 #. I18N: gedcom tag _WITN
 #: app/GedcomCode/GedcomCodeRela.php:350 app/GedcomTag.php:2074
 msgid "Witness"
-msgstr ""
+msgstr "증거"
 
 #. I18N: In the paternal surname tradition, ...
 #. I18N: In the Polish surname tradition, ...
@@ -15901,14 +15902,14 @@ msgstr ""
 #: app/SurnameTradition.php:81 app/SurnameTradition.php:104
 #: app/SurnameTradition.php:111
 msgid "Wives take their husband’s surname."
-msgstr ""
+msgstr "아내는 남편의 가문이름을 가져옵니다."
 
 #: app/Http/Controllers/Admin/LocationController.php:297
 #: resources/views/modules/place-hierarchy/page.phtml:29
 #: resources/views/modules/place-hierarchy/page.phtml:32
 #: resources/views/modules/statistics-chart/custom.phtml:171
 msgid "World"
-msgstr ""
+msgstr "세계"
 
 #. I18N: gedcom tag _YART - A yahrzeit is a special anniversary of death in the Hebrew faith/calendar.
 #: app/GedcomTag.php:2080 resources/views/modules/yahrzeit/table.phtml:35
@@ -15922,12 +15923,12 @@ msgstr ""
 
 #: app/Module/CalendarMenuModule.php:116 resources/views/calendar-page.phtml:51
 msgid "Year"
-msgstr ""
+msgstr "년"
 
 #: resources/views/modules/timeline-chart/chart.phtml:134
 #: resources/views/modules/timeline-chart/chart.phtml:402
 msgid "Year:"
-msgstr ""
+msgstr "년도:"
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:538
@@ -15939,43 +15940,43 @@ msgstr ""
 #: resources/views/emails/register-user-text.phtml:9
 #, php-format
 msgid "You (or someone claiming to be you) has requested an account at %1$s using the email address %2$s."
-msgstr ""
+msgstr "귀하 (또는 귀하를 주장하는 사람)가 이메일 주소 %2$s을(를) 사용하여 %1$s에 계정을 요청했습니다."
 
 #: app/Http/RequestHandlers/ContactAction.php:121
 #: app/Http/RequestHandlers/RegisterAction.php:251
 msgid "You are not allowed to send messages that contain external links."
-msgstr ""
+msgstr "외부 링크가 포함 된 메시지를 보낼 수 없습니다."
 
 #: resources/views/modules/login_block/sign-out.phtml:9
 #, php-format
 msgid "You are signed in as %s."
-msgstr ""
+msgstr "%s(으)로 로그인했습니다."
 
 #: app/Http/RequestHandlers/LoginPage.php:96
 msgid "You can apply for an account using the link below."
-msgstr ""
+msgstr "아래 링크를 사용하여 계정을 신청할 수 있습니다."
 
 #. I18N: Help text for the "Default theme" site configuration setting
 #: resources/views/admin/site-preferences.phtml:64
 msgid "You can change the appearance of webtrees using “themes”. Each theme has a different style, layout, color scheme, etc."
-msgstr ""
+msgstr ""테마"를 사용하여 웹 트리의 모양을 변경할 수 있습니다. 각 테마마다 스타일, 레이아웃, 색 구성표 등이 다릅니다."
 
 #: resources/views/admin/users-edit.phtml:157
 #: resources/views/edit-account-page.phtml:141
 msgid "You can choose whether to appear in the list of users who are currently signed-in."
-msgstr ""
+msgstr "현재 로그인 한 사용자 목록에 표시할지 여부를 선택할 수 있습니다."
 
 #. I18N: %s is a URL
 #: resources/views/edit/raw-gedcom-fact.phtml:18
 #: resources/views/edit/raw-gedcom-record.phtml:19
 #, php-format
 msgid "You can download a copy of the GEDCOM specification from %s."
-msgstr ""
+msgstr "%s에서 GEDCOM 사양 사본을 다운로드 할 수 있습니다."
 
 #. I18N: Description of a “Data fix” module
 #: app/Module/FixMissingMarriedNames.php:81
 msgid "You can make it easier to search for married women by recording their married name. However not all women take their husband’s surname, so beware of introducing incorrect information into your database."
-msgstr ""
+msgstr "결혼 한 이름을 기록하여 기혼 여성을보다 쉽게 검색 할 수 있습니다. 그러나 모든 여성이 남편의 성을 사용하는 것은 아니므로 데이터베이스에 잘못된 정보를 도입하지 않도록주의하십시오."
 
 #: resources/views/modules/privacy-policy/page.phtml:52
 msgid "You can opt out of tracking by setting the “Do Not Track” header in your browser preferences."
@@ -15983,156 +15984,156 @@ msgstr ""
 
 #: resources/views/admin/trees-renumber.phtml:17
 msgid "You can renumber the records in a family tree, so that these internal reference numbers are not duplicated in any other family tree."
-msgstr ""
+msgstr "가계도에서 레코드의 번호를 다시 매길 수 있으므로 이러한 내부 참조 번호가 다른 가계도에서 중복되지 않습니다."
 
 #: resources/views/admin/trees-renumber.phtml:26
 msgid "You can renumber this family tree."
-msgstr ""
+msgstr "이 가계도의 번호를 다시 지정할 수 있습니다."
 
 #. I18N: Privacy restrictions are RESN tags in GEDCOM.
 #: resources/views/admin/trees-privacy.phtml:161
 msgid "You can set the access for a specific record, fact, or event by adding a restriction to it. If a record, fact, or event does not have a restriction, the following default restrictions will be used."
-msgstr ""
+msgstr "제한을 추가하여 특정 레코드, 정보 또는 이벤트에 대한 액세스를 설정할 수 있습니다. 레코드, 정보 또는 이벤트에 제한이없는 경우 다음 기본 제한이 사용됩니다."
 
 #. I18N: Description of a “Data fix” module
 #: app/Module/FixMissingDeaths.php:70
 msgid "You can speed up the privacy calculations by adding a death record to individuals whose death can be inferred from other dates, but who do not have a record of death, burial, cremation, etc."
-msgstr ""
+msgstr "다른 날짜로부터 사망을 유추 할 수 있지만 사망, 매장, 화장 등을 기록하지 않은 인물에게 사망 기록을 추가하여 인물 정보 계산 속도를 높일 수 있습니다."
 
 #: app/Http/RequestHandlers/LoginAction.php:115
 msgid "You cannot sign in because your browser does not accept cookies."
-msgstr ""
+msgstr "브라우저가 쿠키를 허용하지 않기 때문에 로그인 할 수 없습니다."
 
 #: app/Exceptions/HttpAccessDeniedException.php:34
 #: app/Exceptions/HttpNotFoundException.php:34
 msgid "You do not have permission to view this page."
-msgstr ""
+msgstr "이 페이지를 볼 수있는 권한이 없습니다."
 
 #: resources/views/verify-success-page.phtml:13
 msgid "You have confirmed your request to become a registered user."
-msgstr ""
+msgstr "등록 된 사용자가 되기위한 요청을 확인했습니다."
 
 #: resources/views/admin/trees-import.phtml:17
 msgid "You have selected a GEDCOM file with a different name. Is this correct?"
-msgstr ""
+msgstr "다른 이름의 GEDCOM 파일을 선택했습니다. 맞습니까?"
 
 #: app/Http/RequestHandlers/Logout.php:51
 msgid "You have signed out."
-msgstr ""
+msgstr "로그아웃 했습니다."
 
 #: resources/views/modules/faq/config.phtml:15
 msgid "You may use HTML to format the answer and to add links to other websites."
-msgstr ""
+msgstr "HTML을 사용하여 답변의 형식을 지정하고 다른 웹 사이트에 대한 링크를 추가 할 수 있습니다."
 
 #: app/Http/Controllers/SetupController.php:366
 msgid "You must enter all the administrator account fields."
-msgstr ""
+msgstr "모든 관리자 계정 필드를 입력해야합니다."
 
 #: resources/views/admin/trees-merge.phtml:20
 msgid "You must renumber the records in one of the trees before you can merge them."
-msgstr ""
+msgstr "병합하기 전에 트리 중 하나의 레코드 번호를 다시 매겨 야합니다."
 
 #: app/Module/ChartsBlockModule.php:161
 msgid "You must select an individual and a chart type in the block preferences"
-msgstr ""
+msgstr "블록 환경 설정에서 인물 및 차트 유형을 선택해야합니다"
 
 #: resources/views/admin/users-edit.phtml:344
 msgid "You must specify an individual record before you can restrict the user to their immediate family."
-msgstr ""
+msgstr "사용자를 직계 가족으로 제한하기 전에 인물 레코드를 지정해야합니다."
 
 #: app/Http/RequestHandlers/LoginPage.php:88
 msgid "You need to be a family member to access this website."
-msgstr ""
+msgstr "이 웹 사이트에 접속하려면 가족 구성원이어야합니다."
 
 #: app/Http/RequestHandlers/LoginPage.php:85
 msgid "You need to be an authorized user to access this website."
-msgstr ""
+msgstr "이 웹 사이트에 액세스하려면 인증 된 사용자 여야합니다."
 
 #: resources/views/admin/control-panel.phtml:139
 #: resources/views/admin/trees.phtml:33
 msgid "You need to create a family tree."
-msgstr ""
+msgstr "가계도를 만들어야합니다."
 
 #: resources/views/emails/verify-notify-html.phtml:22
 #: resources/views/emails/verify-notify-text.phtml:15
 msgid "You need to review the account details."
-msgstr ""
+msgstr "계정 정보를 검토해야합니다."
 
 #: resources/views/setup/step-5-administrator.phtml:31
 msgid "You need to set up an administrator account. This account can control all aspects of this webtrees installation. Please choose a strong password."
-msgstr ""
+msgstr "관리자 계정을 설정해야합니다. 이 계정은이 웹 트리 설치의 모든면을 제어 할 수 있습니다."
 
 #: resources/views/emails/message-copy-html.phtml:12
 #: resources/views/emails/message-copy-text.phtml:8
 msgid "You sent the following message to a webtrees user:"
-msgstr ""
+msgstr "웹 트리 사용자에게 다음 메시지를 보냈습니다."
 
 #: app/Http/Controllers/Admin/UpgradeController.php:273
 msgid "You should accept or reject all pending changes before upgrading."
-msgstr ""
+msgstr "업그레이드하기 전에 보류중인 모든 변경 사항을 수락하거나 거부해야합니다."
 
 #. I18N: e.g. ‘You should delete the “http://” from “http://www.example.com” and try again.’
 #: app/Http/RequestHandlers/ContactAction.php:122
 #: app/Http/RequestHandlers/RegisterAction.php:251
 #, php-format
 msgid "You should delete the “%1$s” from “%2$s” and try again."
-msgstr ""
+msgstr "%2$s"에서 "%1$s"을(를) 삭제하고 다시 시도해야합니다."
 
 #: resources/views/admin/users-edit.phtml:95
 msgid "You should not approve an account unless you know that the email address is correct."
-msgstr ""
+msgstr "이메일 주소가 정확하다는 것을 모르면 계정을 승인해서는 안됩니다."
 
 #: resources/views/emails/register-notify-html.phtml:34
 #: resources/views/emails/register-notify-text.phtml:19
 msgid "You will be informed by email when this prospective user has confirmed the request. You can then complete the process by activating the username. The new user will not be able to sign in until you activate the account."
-msgstr ""
+msgstr "이 예상 사용자가 요청을 확인하면 이메일로 알려드립니다. 그런 다음 사용자 이름을 활성화하여 프로세스를 완료 할 수 있습니다. 새 사용자는 계정을 활성화 할 때까지 로그인 할 수 없습니다."
 
 #: resources/views/setup/step-5-administrator.phtml:53
 msgid "You will use this to sign in to webtrees."
-msgstr ""
+msgstr "이를 사용하여 웹 트리에 로그인합니다."
 
 #: resources/views/statistics/families/birth-age.phtml:22
 msgid "Youngest father"
-msgstr ""
+msgstr "가장 어린 아버지"
 
 #: resources/views/statistics/families/marriage-age.phtml:42
 msgid "Youngest female"
-msgstr ""
+msgstr "가장 어린 여성"
 
 #: resources/views/statistics/families/marriage-age.phtml:22
 msgid "Youngest male"
-msgstr ""
+msgstr "가장 어린 남성"
 
 #: resources/views/statistics/families/birth-age.phtml:42
 msgid "Youngest mother"
-msgstr ""
+msgstr "가장 어린 어머니"
 
 #: resources/views/modules/clippings/show.phtml:15
 msgid "Your clippings cart is empty."
-msgstr ""
+msgstr "클리핑 카트가 비어 있습니다."
 
 #: resources/views/contact-page.phtml:28
 #: resources/views/setup/step-5-administrator.phtml:36
 msgid "Your name"
-msgstr ""
+msgstr "당신의 이름"
 
 #: app/Http/RequestHandlers/PasswordResetAction.php:77
 msgid "Your password has been updated."
-msgstr ""
+msgstr "비밀번호가 업데이트되었습니다."
 
 #: app/Http/RequestHandlers/RegisterAction.php:146
 #, php-format
 msgid "Your registration at %s"
-msgstr ""
+msgstr "%s에 등록"
 
 #: resources/views/modules/batch_update/admin.phtml:85
 msgid "Your user account does not have “automatically accept changes” enabled. You will only be able to change one record at a time."
-msgstr ""
+msgstr "사용자 계정에 "자동으로 변경 내용 수락"이 활성화되어 있지 않습니다. 한 번에 하나의 레코드 만 변경할 수 있습니다."
 
 #: app/Services/ServerCheckService.php:198
 #, php-format
 msgid "Your web server is using PHP version %s, which is no longer receiving security updates. You should upgrade to a later version as soon as possible."
-msgstr ""
+msgstr "웹 서버가 더 이상 보안 업데이트를받지 않는 PHP 버전 %s을(를) 사용하고 있습니다. 가능한 빨리 최신 버전으로 업그레이드해야합니다."
 
 #. I18N: Name of a country or state
 #: app/Statistics/Service/CountryService.php:542
@@ -16147,7 +16148,7 @@ msgstr ""
 #: resources/views/admin/location-edit.phtml:65
 #: resources/views/modules/fanchart/page.phtml:44
 msgid "Zoom"
-msgstr ""
+msgstr "Zoom"
 
 #: resources/views/admin/location-edit.phtml:134
 #: resources/views/modules/pedigree-map/chart.phtml:95
@@ -16155,11 +16156,11 @@ msgstr ""
 #: resources/views/modules/places/tab.phtml:85
 #: resources/views/modules/timeline-chart/page.phtml:38
 msgid "Zoom in"
-msgstr ""
+msgstr "확대"
 
 #: resources/views/admin/locations.phtml:18
 msgid "Zoom level"
-msgstr ""
+msgstr "Zoom level"
 
 #: resources/views/admin/location-edit.phtml:135
 #: resources/views/modules/pedigree-map/chart.phtml:96
@@ -16167,13 +16168,13 @@ msgstr ""
 #: resources/views/modules/places/tab.phtml:86
 #: resources/views/modules/timeline-chart/page.phtml:41
 msgid "Zoom out"
-msgstr ""
+msgstr "축소"
 
 #. I18N: Gedcom ABT dates
 #: app/Date.php:341
 #, php-format
 msgid "about %s"
-msgstr ""
+msgstr "약 %s"
 
 #. I18N: %1$s is “accept”, %2$s is “reject”. These are links.
 #: resources/views/family-page.phtml:22
@@ -16183,7 +16184,7 @@ msgstr ""
 #: resources/views/source-page.phtml:21 resources/views/submitter-page.phtml:20
 msgctxt "You should review the changes and then accept or reject them."
 msgid "accept"
-msgstr ""
+msgstr "동의"
 
 #. I18N: %1$s is “accept”, %2$s is “reject”. These are links.
 #: resources/views/family-page.phtml:16
@@ -16193,12 +16194,12 @@ msgstr ""
 #: resources/views/source-page.phtml:15 resources/views/submitter-page.phtml:14
 msgctxt "You should review the deletion and then accept or reject it."
 msgid "accept"
-msgstr ""
+msgstr "동의"
 
 #. I18N: the status of an edit accepted/rejected/pending
 #: app/Http/RequestHandlers/PendingChangesLogPage.php:122
 msgid "accepted"
-msgstr ""
+msgstr "인정됨"
 
 #. I18N: A button label.
 #: resources/views/admin/trees-privacy.phtml:224
@@ -16209,43 +16210,43 @@ msgstr ""
 #: resources/views/modules/lifespans-chart/page.phtml:66
 #: resources/views/modules/timeline-chart/page.phtml:27
 msgid "add"
-msgstr ""
+msgstr "추가"
 
 #. I18N: A button label.
 #: resources/views/admin/locations.phtml:101
 msgid "add place"
-msgstr ""
+msgstr "장소 추가"
 
 #. I18N: The name given to a child by its adoptive parents
 #: app/GedcomCode/GedcomCodeName.php:73
 msgid "adopted name"
-msgstr ""
+msgstr "입양 된 이름"
 
 #. I18N: The name given to a child by its adoptive parents
 #: app/GedcomCode/GedcomCodeName.php:69
 msgctxt "FEMALE"
 msgid "adopted name"
-msgstr ""
+msgstr "입양 된 이름"
 
 #. I18N: The name given to a child by its adoptive parents
 #: app/GedcomCode/GedcomCodeName.php:64
 msgctxt "MALE"
 msgid "adopted name"
-msgstr ""
+msgstr "입양 된 이름"
 
 #: app/Statistics/Repository/EventRepository.php:326
 msgid "adoption"
-msgstr ""
+msgstr "양자"
 
 #. I18N: Gedcom AFT dates
 #: app/Date.php:361
 #, php-format
 msgid "after %s"
-msgstr ""
+msgstr "%s 이후"
 
 #: app/Functions/FunctionsPrint.php:280
 msgid "after death"
-msgstr ""
+msgstr "사망 후"
 
 #: app/Http/RequestHandlers/IndividualPage.php:117
 #: app/Http/RequestHandlers/IndividualPage.php:120
@@ -16253,28 +16254,28 @@ msgstr ""
 #: app/Module/StatisticsChartModule.php:593
 #: app/Module/StatisticsChartModule.php:654
 msgid "age"
-msgstr ""
+msgstr "나이"
 
 #. I18N: The name by which an individual is also known. e.g. a professional name or a stage name
 #: app/GedcomCode/GedcomCodeName.php:87
 msgid "also known as"
-msgstr ""
+msgstr "~으로 알려진"
 
 #. I18N: The name by which an individual is also known. e.g. a professional name or a stage name
 #: app/GedcomCode/GedcomCodeName.php:83
 msgctxt "FEMALE"
 msgid "also known as"
-msgstr ""
+msgstr "~으로 알려진"
 
 #. I18N: The name by which an individual is also known. e.g. a professional name or a stage name
 #: app/GedcomCode/GedcomCodeName.php:78
 msgctxt "MALE"
 msgid "also known as"
-msgstr ""
+msgstr "~으로 알려진"
 
 #: app/Functions/FunctionsEdit.php:587
 msgid "always"
-msgstr ""
+msgstr "항상"
 
 #: app/Statistics/Repository/FamilyRepository.php:465
 #: app/Statistics/Repository/UserRepository.php:96
@@ -16288,124 +16289,124 @@ msgstr ""
 #: resources/xml/reports/descendancy_report.xml:433
 #: resources/xml/reports/descendancy_report.xml:486
 msgid "and"
-msgstr ""
+msgstr "그리고"
 
 #: app/Functions/Functions.php:1036
 msgctxt "father’s brother’s wife"
 msgid "aunt"
-msgstr ""
+msgstr "숙모"
 
 #: app/Functions/Functions.php:794
 msgctxt "father’s sister"
 msgid "aunt"
-msgstr ""
+msgstr "고모"
 
 #: app/Functions/Functions.php:1116
 msgctxt "mother’s brother’s wife"
 msgid "aunt"
-msgstr ""
+msgstr "외숙모"
 
 #: app/Functions/Functions.php:832
 msgctxt "mother’s sister"
 msgid "aunt"
-msgstr ""
+msgstr "이모"
 
 #: app/Functions/Functions.php:1168
 msgctxt "parent’s brother’s wife"
 msgid "aunt"
-msgstr ""
+msgstr "숙모(외숙모)"
 
 #: app/Functions/Functions.php:850
 msgctxt "parent’s sister"
 msgid "aunt"
-msgstr ""
+msgstr "고모(이모)"
 
 #: app/Functions/Functions.php:792
 msgctxt "father’s sibling"
 msgid "aunt/uncle"
-msgstr ""
+msgstr "고모/삼촌"
 
 #: app/Functions/Functions.php:830
 msgctxt "mother’s sibling"
 msgid "aunt/uncle"
-msgstr ""
+msgstr "이모/외삼촌"
 
 #: app/Functions/Functions.php:848
 msgctxt "parent’s sibling"
 msgid "aunt/uncle"
-msgstr ""
+msgstr "고모/삼촌(이모/외삼촌)"
 
 #: resources/views/modules/faq/show.phtml:24
 msgid "back to top"
-msgstr ""
+msgstr "맨 위로"
 
 #. I18N: Gedcom BEF dates
 #: app/Date.php:357
 #, php-format
 msgid "before %s"
-msgstr ""
+msgstr "%s 이전"
 
 #. I18N: Gedcom BET-AND dates
 #: app/Date.php:373
 #, php-format
 msgid "between %s and %s"
-msgstr ""
+msgstr "%s와 %s 사이"
 
 #: app/Statistics/Repository/EventRepository.php:323
 msgid "birth"
-msgstr ""
+msgstr "출생"
 
 #. I18N: The name given to an individual at their birth
 #: app/GedcomCode/GedcomCodeName.php:101
 msgid "birth name"
-msgstr ""
+msgstr "출생 이름"
 
 #. I18N: The name given to an individual at their birth
 #: app/GedcomCode/GedcomCodeName.php:97
 msgctxt "FEMALE"
 msgid "birth name"
-msgstr ""
+msgstr "출생 이름"
 
 #. I18N: The name given to an individual at their birth
 #: app/GedcomCode/GedcomCodeName.php:92
 msgctxt "MALE"
 msgid "birth name"
-msgstr ""
+msgstr "출생 이름"
 
 #. I18N: Extend privacy to dead individuals who were…
 #: resources/views/admin/trees-privacy.phtml:110
 #, php-format
 msgid "born in the last %1$s years or died in the last %2$s years"
-msgstr ""
+msgstr "지난 %1$s년에 출생 또는 지난 %2$s년에 사망"
 
 #: app/Functions/Functions.php:706
 msgid "brother"
-msgstr ""
+msgstr "남자형제"
 
 #: app/Functions/Functions.php:974
 msgctxt "brother’s wife’s brother"
 msgid "brother-in-law"
-msgstr ""
+msgstr "사돈총각"
 
 #: app/Functions/Functions.php:800
 msgctxt "husband’s brother"
 msgid "brother-in-law"
-msgstr ""
+msgstr "시숙"
 
 #: app/Functions/Functions.php:1090
 msgctxt "husband’s sister’s husband"
 msgid "brother-in-law"
-msgstr ""
+msgstr "시매부"
 
 #: app/Functions/Functions.php:868
 msgctxt "sister’s husband"
 msgid "brother-in-law"
-msgstr ""
+msgstr "매부"
 
 #: app/Functions/Functions.php:1274
 msgctxt "sister’s husband’s brother"
 msgid "brother-in-law"
-msgstr ""
+msgstr "시돈총각"
 
 #: app/Functions/Functions.php:880
 msgctxt "spouse’s brother"
@@ -16415,12 +16416,12 @@ msgstr ""
 #: app/Functions/Functions.php:898
 msgctxt "wife’s brother"
 msgid "brother-in-law"
-msgstr ""
+msgstr "처남"
 
 #: app/Functions/Functions.php:1330
 msgctxt "wife’s sister’s husband"
 msgid "brother-in-law"
-msgstr ""
+msgstr "동서"
 
 #: app/Functions/Functions.php:976
 msgctxt "brother’s wife’s sibling"
@@ -16455,21 +16456,21 @@ msgstr ""
 #. I18N: An option in a list-box
 #: app/Module/TopSurnamesModule.php:239
 msgid "bullet list"
-msgstr ""
+msgstr "글 머리 기호 목록"
 
 #: app/Statistics/Repository/EventRepository.php:327
 msgid "burial"
-msgstr ""
+msgstr "매장"
 
 #: app/GedcomTag.php:2026
 msgid "by"
-msgstr ""
+msgstr "으로"
 
 #. I18N: Gedcom CAL dates
 #: app/Date.php:345
 #, php-format
 msgid "calculated %s"
-msgstr ""
+msgstr "계산 된 %s"
 
 #. I18N: A button label.
 #: resources/views/admin/analytics-edit.phtml:36
@@ -16509,32 +16510,32 @@ msgstr ""
 #: resources/views/modules/stories/edit.phtml:65
 #: resources/views/modules/user_blog/edit.phtml:46
 msgid "cancel"
-msgstr ""
+msgstr "취소"
 
 #: app/Statistics/Repository/EventRepository.php:328
 msgid "census added"
-msgstr ""
+msgstr "인구 조사 추가"
 
 #. I18N: A name chosen by an individual, to replace their existing name (whether legal or otherwise)
 #: app/GedcomCode/GedcomCodeName.php:115
 msgid "change of name"
-msgstr ""
+msgstr "이름 변경"
 
 #. I18N: A name chosen by an individual, to replace their existing name (whether legal or otherwise)
 #: app/GedcomCode/GedcomCodeName.php:111
 msgctxt "FEMALE"
 msgid "change of name"
-msgstr ""
+msgstr "이름 변경"
 
 #. I18N: A name chosen by an individual, to replace their existing name (whether legal or otherwise)
 #: app/GedcomCode/GedcomCodeName.php:106
 msgctxt "MALE"
 msgid "change of name"
-msgstr ""
+msgstr "이름 변경"
 
 #: app/Functions/Functions.php:685
 msgid "child"
-msgstr ""
+msgstr "아이"
 
 #: resources/views/components/alert-warning-dismissible.phtml:10
 #: resources/views/layouts/administration.phtml:76
@@ -16545,7 +16546,7 @@ msgstr ""
 #: resources/views/modals/header.phtml:11
 #: resources/views/modules/privacy-policy/footer.phtml:17
 msgid "close"
-msgstr ""
+msgstr "닫기"
 
 #. I18N: Name of a theme.
 #: app/Module/CloudsTheme.php:43
@@ -16560,7 +16561,7 @@ msgstr ""
 #. I18N: An option in a list-box
 #: app/Module/TopSurnamesModule.php:241
 msgid "compact list"
-msgstr ""
+msgstr "컴팩트 목록"
 
 #. I18N: A button label.
 #: app/Http/Controllers/Admin/UpgradeController.php:387
@@ -16583,58 +16584,58 @@ msgstr ""
 #: resources/views/register-page.phtml:99
 #: resources/views/report-select-page.phtml:32
 msgid "continue"
-msgstr ""
+msgstr "계속"
 
 #. I18N: A button label.
 #: resources/views/admin/trees-create.phtml:52
 msgid "create"
-msgstr ""
+msgstr "만들기"
 
 #: resources/views/modules/statistics-chart/custom.phtml:85
 msgid "date periods"
-msgstr ""
+msgstr "날짜 기간"
 
 #: app/Functions/Functions.php:683
 msgid "daughter"
-msgstr ""
+msgstr "딸"
 
 #: resources/xml/reports/descendancy_report.xml:226
 msgid "daughter of"
-msgstr ""
+msgstr "의 딸"
 
 #: app/Functions/Functions.php:770
 msgctxt "child’s wife"
 msgid "daughter-in-law"
-msgstr ""
+msgstr "며느리"
 
 #: app/Functions/Functions.php:878
 msgctxt "son’s wife"
 msgid "daughter-in-law"
-msgstr ""
+msgstr "며느리"
 
 #: app/Functions/Functions.php:1322
 msgctxt "son’s wife’s father"
 msgid "daughter-in-law’s father"
-msgstr ""
+msgstr "며느리의 아버지"
 
 #: app/Functions/Functions.php:1324
 msgctxt "son’s wife’s mother"
 msgid "daughter-in-law’s mother"
-msgstr ""
+msgstr "며느리의 어머니"
 
 #: app/Functions/Functions.php:1326
 msgctxt "son’s wife’s parent"
 msgid "daughter-in-law’s parent"
-msgstr ""
+msgstr "며느리의 부모"
 
 #: app/Statistics/Repository/EventRepository.php:324
 msgid "death"
-msgstr ""
+msgstr "사망"
 
 #: resources/views/admin/location-edit.phtml:49
 #: resources/views/admin/location-edit.phtml:60
 msgid "degrees"
-msgstr ""
+msgstr "계급"
 
 #. I18N: A button label.
 #: resources/views/admin/changes-log.phtml:96
@@ -16643,23 +16644,23 @@ msgstr ""
 #: resources/views/admin/users-cleanup.phtml:65
 #: resources/views/admin/webtrees1-thumbnails-form.phtml:27
 msgid "delete"
-msgstr ""
+msgstr "삭제"
 
 #: resources/xml/reports/descendancy_report.xml:137
 #: resources/xml/reports/descendancy_report.xml:365
 msgctxt "FEMALE"
 msgid "died"
-msgstr ""
+msgstr "사망"
 
 #: resources/xml/reports/descendancy_report.xml:134
 #: resources/xml/reports/descendancy_report.xml:435
 msgctxt "MALE"
 msgid "died"
-msgstr ""
+msgstr "사망"
 
 #: resources/views/modules/pedigree-chart/page.phtml:37
 msgid "down"
-msgstr ""
+msgstr "아래"
 
 #. I18N: A button label.
 #: resources/views/admin/changes-log.phtml:91
@@ -16667,11 +16668,11 @@ msgstr ""
 #: resources/views/modules/clippings/download.phtml:61
 #: resources/views/report-setup-page.phtml:70
 msgid "download"
-msgstr ""
+msgstr "다운로드"
 
 #: resources/views/modules/descendancy_chart/tree.phtml:17
 msgid "d’Aboville number"
-msgstr ""
+msgstr "d’Aboville 번호"
 
 #: resources/views/admin/components.phtml:114
 #: resources/views/family-page-menu.phtml:14
@@ -16683,177 +16684,177 @@ msgstr ""
 #: resources/views/source-page-menu.phtml:13
 #: resources/views/submitter-page-menu.phtml:13
 msgid "edit"
-msgstr ""
+msgstr "편집"
 
 #: app/Functions/Functions.php:476
 msgid "eighth cousin"
-msgstr ""
+msgstr "여덟 번째 사촌"
 
 #: app/Functions/Functions.php:440
 msgctxt "FEMALE"
 msgid "eighth cousin"
-msgstr ""
+msgstr "여덟 번째 사촌"
 
 #. I18N: Note that for Italian and Polish, “N’th cousins” are different from English “N’th cousins”, and the software has already generated the correct “N” for your language. You only need to translate - you do not need to convert. For other languages, if your cousin rules are different from English, please contact the developers.
 #: app/Functions/Functions.php:395
 msgctxt "MALE"
 msgid "eighth cousin"
-msgstr ""
+msgstr "여덟 번째 사촌"
 
 #: app/Functions/Functions.php:701
 msgid "elder brother"
-msgstr ""
+msgstr "손윗남자형제"
 
 #: app/Functions/Functions.php:743
 msgid "elder sibling"
-msgstr ""
+msgstr "손윗형제"
 
 #: app/Functions/Functions.php:722
 msgid "elder sister"
-msgstr ""
+msgstr "손윗여자형제"
 
 #: app/Functions/Functions.php:482
 msgid "eleventh cousin"
-msgstr ""
+msgstr "열한 번째 사촌"
 
 #: app/Functions/Functions.php:446
 msgctxt "FEMALE"
 msgid "eleventh cousin"
-msgstr ""
+msgstr "열한 번째 사촌"
 
 #. I18N: Note that for Italian and Polish, “N’th cousins” are different from English “N’th cousins”, and the software has already generated the correct “N” for your language. You only need to translate - you do not need to convert. For other languages, if your cousin rules are different from English, please contact the developers.
 #: app/Functions/Functions.php:404
 msgctxt "MALE"
 msgid "eleventh cousin"
-msgstr ""
+msgstr "열한 번째 사촌"
 
 #. I18N: A name given to an individual, from the farm or estate on which they lived or worked
 #: app/GedcomCode/GedcomCodeName.php:129
 msgid "estate name"
-msgstr ""
+msgstr "부동산 이름"
 
 #. I18N: A name given to an individual, from the farm or estate on which they lived or worked
 #: app/GedcomCode/GedcomCodeName.php:125
 msgctxt "FEMALE"
 msgid "estate name"
-msgstr ""
+msgstr "부동산 이름"
 
 #. I18N: A name given to an individual, from the farm or estate on which they lived or worked
 #: app/GedcomCode/GedcomCodeName.php:120
 msgctxt "MALE"
 msgid "estate name"
-msgstr ""
+msgstr "부동산 이름"
 
 #. I18N: Gedcom EST dates
 #: app/Date.php:349
 #, php-format
 msgid "estimated %s"
-msgstr ""
+msgstr "예상 %s"
 
 #: app/Functions/Functions.php:626
 msgid "ex-husband"
-msgstr ""
+msgstr "전 남편"
 
 #: app/Functions/Functions.php:673
 msgid "ex-partner"
-msgstr ""
+msgstr "전 파트너"
 
 #: app/Functions/Functions.php:653
 msgctxt "FEMALE"
 msgid "ex-partner"
-msgstr ""
+msgstr "전 파트너"
 
 #: app/Functions/Functions.php:633
 msgctxt "MALE"
 msgid "ex-partner"
-msgstr ""
+msgstr "전 파트너"
 
 #: app/Functions/Functions.php:666
 msgid "ex-spouse"
-msgstr ""
+msgstr "전 배우자"
 
 #: app/Functions/Functions.php:646
 msgid "ex-wife"
-msgstr ""
+msgstr "전 부인"
 
 #. I18N: A button label.
 #: resources/views/admin/locations.phtml:107
 msgid "export file"
-msgstr ""
+msgstr "파일 내보내기"
 
 #: app/Http/Controllers/AdminTreesController.php:752
 #: resources/xml/reports/fact_sources.xml:6
 msgid "facts"
-msgstr ""
+msgstr "정보"
 
 #: app/Functions/Functions.php:617
 msgid "father"
-msgstr ""
+msgstr "아버지"
 
 #: app/Functions/Functions.php:806
 msgctxt "husband’s father"
 msgid "father-in-law"
-msgstr ""
+msgstr "시아버지"
 
 #: app/Functions/Functions.php:886
 msgctxt "spouse’s father"
 msgid "father-in-law"
-msgstr ""
+msgstr "시아버지/장인어른"
 
 #: app/Functions/Functions.php:904
 msgctxt "wife’s father"
 msgid "father-in-law"
-msgstr ""
+msgstr "장인어른"
 
 #: app/Functions/Functions.php:490
 msgid "fifteenth cousin"
-msgstr ""
+msgstr "15 번째 사촌"
 
 #: app/Functions/Functions.php:454
 msgctxt "FEMALE"
 msgid "fifteenth cousin"
-msgstr ""
+msgstr "15 번째 사촌"
 
 #. I18N: Note that for Italian and Polish, “N’th cousins” are different from English “N’th cousins”, and the software has already generated the correct “N” for your language. You only need to translate - you do not need to convert. For other languages, if your cousin rules are different from English, please contact the developers.
 #: app/Functions/Functions.php:416
 msgctxt "MALE"
 msgid "fifteenth cousin"
-msgstr ""
+msgstr "15 번째 사촌"
 
 #. I18N: A Spanish relationship name, such as third great-nephew
 #: app/Functions/Functions.php:569
 #, php-format
 msgid "fifth %s"
-msgstr ""
+msgstr "다섯 번째 %s"
 
 #. I18N: A Spanish relationship name, such as third great-nephew
 #: app/Functions/Functions.php:547
 #, php-format
 msgctxt "FEMALE"
 msgid "fifth %s"
-msgstr ""
+msgstr "다섯 번째 %s"
 
 #. I18N: A Spanish relationship name, such as third great-nephew
 #: app/Functions/Functions.php:524
 #, php-format
 msgctxt "MALE"
 msgid "fifth %s"
-msgstr ""
+msgstr "다섯 번째 %s"
 
 #: app/Functions/Functions.php:470
 msgid "fifth cousin"
-msgstr ""
+msgstr "다섯 번째 사촌"
 
 #: app/Functions/Functions.php:434
 msgctxt "FEMALE"
 msgid "fifth cousin"
-msgstr ""
+msgstr "다섯 번째 사촌"
 
 #. I18N: Note that for Italian and Polish, “N’th cousins” are different from English “N’th cousins”, and the software has already generated the correct “N” for your language. You only need to translate - you do not need to convert. For other languages, if your cousin rules are different from English, please contact the developers.
 #: app/Functions/Functions.php:386
 msgctxt "MALE"
 msgid "fifth cousin"
-msgstr ""
+msgstr "다섯 번째 사촌"
 
 #. I18N: A button label, first page
 #: resources/views/admin/trees-preferences.phtml:575
@@ -16861,277 +16862,277 @@ msgstr ""
 #: resources/views/modules/media-list/page.phtml:79
 #: resources/views/modules/media-list/page.phtml:178
 msgid "first"
-msgstr ""
+msgstr "첫번째"
 
 #: resources/views/admin/trees-preferences.phtml:584
 msgctxt "Show the [first/last] [N] parts of a place name."
 msgid "first"
-msgstr ""
+msgstr "첫번째"
 
 #. I18N: A Spanish relationship name, such as third great-nephew
 #: app/Functions/Functions.php:557
 #, php-format
 msgid "first %s"
-msgstr ""
+msgstr "첫번째 %s"
 
 #. I18N: A Spanish relationship name, such as third great-nephew
 #: app/Functions/Functions.php:535
 #, php-format
 msgctxt "FEMALE"
 msgid "first %s"
-msgstr ""
+msgstr "첫번째 %s"
 
 #. I18N: A Spanish relationship name, such as third great-nephew
 #: app/Functions/Functions.php:512
 #, php-format
 msgctxt "MALE"
 msgid "first %s"
-msgstr ""
+msgstr "첫번째 %s"
 
 #: app/Functions/Functions.php:462
 msgid "first cousin"
-msgstr ""
+msgstr "첫번째 사촌"
 
 #: app/Functions/Functions.php:426
 msgctxt "FEMALE"
 msgid "first cousin"
-msgstr ""
+msgstr "첫번째 사촌"
 
 #. I18N: Note that for Italian and Polish, “N’th cousins” are different from English “N’th cousins”, and the software has already generated the correct “N” for your language. You only need to translate - you do not need to convert. For other languages, if your cousin rules are different from English, please contact the developers.
 #: app/Functions/Functions.php:374
 msgctxt "MALE"
 msgid "first cousin"
-msgstr ""
+msgstr "첫번째 사촌"
 
 #: app/Functions/Functions.php:1030
 msgctxt "father’s brother’s child"
 msgid "first cousin"
-msgstr ""
+msgstr "첫번째 사촌"
 
 #: app/Functions/Functions.php:1032
 msgctxt "father’s brother’s daughter"
 msgid "first cousin"
-msgstr ""
+msgstr "첫번째 사촌"
 
 #: app/Functions/Functions.php:1034
 msgctxt "father’s brother’s son"
 msgid "first cousin"
-msgstr ""
+msgstr "첫번째 사촌"
 
 #: app/Functions/Functions.php:1074
 msgctxt "father’s sister’s child"
 msgid "first cousin"
-msgstr ""
+msgstr "첫번째 사촌"
 
 #: app/Functions/Functions.php:1076
 msgctxt "father’s sister’s daughter"
 msgid "first cousin"
-msgstr ""
+msgstr 첫번째 사촌""
 
 #: app/Functions/Functions.php:1080
 msgctxt "father’s sister’s son"
 msgid "first cousin"
-msgstr ""
+msgstr "첫번째 사촌"
 
 #: app/Functions/Functions.php:1110
 msgctxt "mother’s brother’s child"
 msgid "first cousin"
-msgstr ""
+msgstr "첫번째 사촌"
 
 #: app/Functions/Functions.php:1112
 msgctxt "mother’s brother’s daughter"
 msgid "first cousin"
-msgstr ""
+msgstr "첫번째 사촌"
 
 #: app/Functions/Functions.php:1114
 msgctxt "mother’s brother’s son"
 msgid "first cousin"
-msgstr ""
+msgstr "첫번째 사촌"
 
 #: app/Functions/Functions.php:1160
 msgctxt "mother’s sister’s child"
 msgid "first cousin"
-msgstr ""
+msgstr "첫번째 사촌"
 
 #: app/Functions/Functions.php:1162
 msgctxt "mother’s sister’s daughter"
 msgid "first cousin"
-msgstr ""
+msgstr "첫번째 사촌"
 
 #: app/Functions/Functions.php:1166
 msgctxt "mother’s sister’s son"
 msgid "first cousin"
-msgstr ""
+msgstr "첫번째 사촌"
 
 #: app/Functions/Functions.php:1410
 msgctxt "father’s father’s brother’s child"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1406
 msgctxt "father’s father’s brother’s daughter"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1408
 msgctxt "father’s father’s brother’s son"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1416
 msgctxt "father’s father’s sister’s child"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1412
 msgctxt "father’s father’s sister’s daughter"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1414
 msgctxt "father’s father’s sister’s son"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1422
 msgctxt "father’s mother’s brother’s child"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1418
 msgctxt "father’s mother’s brother’s daughter"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1420
 msgctxt "father’s mother’s brother’s son"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1428
 msgctxt "father’s mother’s sister’s child"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1424
 msgctxt "father’s mother’s sister’s daughter"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1426
 msgctxt "father’s mother’s sister’s son"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1434
 msgctxt "mother’s father’s brother’s child"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1430
 msgctxt "mother’s father’s brother’s daughter"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1432
 msgctxt "mother’s father’s brother’s son"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1440
 msgctxt "mother’s father’s sister’s child"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1436
 msgctxt "mother’s father’s sister’s daughter"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1438
 msgctxt "mother’s father’s sister’s son"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1446
 msgctxt "mother’s mother’s brother’s child"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1442
 msgctxt "mother’s mother’s brother’s daughter"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1444
 msgctxt "mother’s mother’s brother’s son"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1452
 msgctxt "mother’s mother’s sister’s child"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1448
 msgctxt "mother’s mother’s sister’s daughter"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:1450
 msgctxt "mother’s mother’s sister’s son"
 msgid "first cousin once removed ascending"
-msgstr ""
+msgstr "첫 번째 사촌은 일단 오름차순을 제거"
 
 #: app/Functions/Functions.php:488
 msgid "fourteenth cousin"
-msgstr ""
+msgstr "14번째 사촌"
 
 #: app/Functions/Functions.php:452
 msgctxt "FEMALE"
 msgid "fourteenth cousin"
-msgstr ""
+msgstr "14번째 사촌"
 
 #. I18N: Note that for Italian and Polish, “N’th cousins” are different from English “N’th cousins”, and the software has already generated the correct “N” for your language. You only need to translate - you do not need to convert. For other languages, if your cousin rules are different from English, please contact the developers.
 #: app/Functions/Functions.php:413
 msgctxt "MALE"
 msgid "fourteenth cousin"
-msgstr ""
+msgstr "14번째 사촌"
 
 #. I18N: A Spanish relationship name, such as third great-nephew
 #: app/Functions/Functions.php:566
 #, php-format
 msgid "fourth %s"
-msgstr ""
+msgstr "네 번째 %s"
 
 #. I18N: A Spanish relationship name, such as third great-nephew
 #: app/Functions/Functions.php:544
 #, php-format
 msgctxt "FEMALE"
 msgid "fourth %s"
-msgstr ""
+msgstr "네 번째 %s"
 
 #. I18N: A Spanish relationship name, such as third great-nephew
 #: app/Functions/Functions.php:521
 #, php-format
 msgctxt "MALE"
 msgid "fourth %s"
-msgstr ""
+msgstr "네 번째 %s"
 
 #: app/Functions/Functions.php:468
 msgid "fourth cousin"
-msgstr ""
+msgstr "네 번째 사촌"
 
 #: app/Functions/Functions.php:432
 msgctxt "FEMALE"
 msgid "fourth cousin"
-msgstr ""
+msgstr "네 번째 사촌"
 
 #. I18N: Note that for Italian and Polish, “N’th cousins” are different from English “N’th cousins”, and the software has already generated the correct “N” for your language. You only need to translate - you do not need to convert. For other languages, if your cousin rules are different from English, please contact the developers.
 #: app/Functions/Functions.php:383
 msgctxt "MALE"
 msgid "fourth cousin"
-msgstr ""
+msgstr "네 번째 사촌"
 
 #. I18N: from 1700 interval 50 years
 #: resources/views/modules/statistics-chart/custom.phtml:93
@@ -17143,151 +17144,151 @@ msgstr ""
 #, php-format
 msgid "from %1$s interval %2$s year"
 msgid_plural "from %1$s interval %2$s years"
-msgstr[0] ""
+msgstr[0] "%1$s 간격 %2$s 년"
 
 #. I18N: Gedcom FROM dates
 #: app/Date.php:365
 #, php-format
 msgid "from %s"
-msgstr ""
+msgstr "%s에서"
 
 #. I18N: Gedcom FROM-TO dates
 #: app/Date.php:377
 #, php-format
 msgid "from %s to %s"
-msgstr ""
+msgstr "%s에서 %s까지"
 
 #. I18N: layout option for the fan chart
 #: app/Module/FanChartModule.php:579
 msgid "full circle"
-msgstr ""
+msgstr "full circle"
 
 #: resources/views/modules/statistics-chart/custom.phtml:80
 msgid "gender"
-msgstr ""
+msgstr "성별"
 
 #. I18N: A button label.
 #: resources/views/edit/new-individual.phtml:316
 msgid "go to new individual"
-msgstr ""
+msgstr "새로운 인물 만들기"
 
 #: app/Functions/Functions.php:760
 msgctxt "child’s child"
 msgid "grandchild"
-msgstr ""
+msgstr "손주"
 
 #: app/Functions/Functions.php:772
 msgctxt "daughter’s child"
 msgid "grandchild"
-msgstr ""
+msgstr "손주"
 
 #: app/Functions/Functions.php:872
 msgctxt "son’s child"
 msgid "grandchild"
-msgstr ""
+msgstr "손주"
 
 #: app/Functions/Functions.php:762
 msgctxt "child’s daughter"
 msgid "granddaughter"
-msgstr ""
+msgstr "손녀"
 
 #: app/Functions/Functions.php:774
 msgctxt "daughter’s daughter"
 msgid "granddaughter"
-msgstr ""
+msgstr "손녀"
 
 #: app/Functions/Functions.php:874
 msgctxt "son’s daughter"
 msgid "granddaughter"
-msgstr ""
+msgstr "손녀"
 
 #: app/Functions/Functions.php:990
 msgctxt "child’s daughter’s husband"
 msgid "granddaughter’s husband"
-msgstr ""
+msgstr "손녀사위"
 
 #: app/Functions/Functions.php:1012
 msgctxt "daughter’s daughter’s husband"
 msgid "granddaughter’s husband"
-msgstr ""
+msgstr "손녀사위"
 
 #: app/Functions/Functions.php:1310
 msgctxt "son’s daughter’s husband"
 msgid "granddaughter’s husband"
-msgstr ""
+msgstr "손녀사위"
 
 #: app/Functions/Functions.php:842
 msgctxt "parent’s father"
 msgid "grandfather"
-msgstr ""
+msgstr "조부"
 
 #: app/Functions/Functions.php:844
 msgctxt "parent’s mother"
 msgid "grandmother"
-msgstr ""
+msgstr "조모"
 
 #: app/Functions/Functions.php:846
 msgctxt "parent’s parent"
 msgid "grandparent"
-msgstr ""
+msgstr "조부모"
 
 #: app/Functions/Functions.php:766
 msgctxt "child’s son"
 msgid "grandson"
-msgstr ""
+msgstr "손자"
 
 #: app/Functions/Functions.php:778
 msgctxt "daughter’s son"
 msgid "grandson"
-msgstr ""
+msgstr "손자"
 
 #: app/Functions/Functions.php:876
 msgctxt "son’s son"
 msgid "grandson"
-msgstr ""
+msgstr "손자"
 
 #: app/Functions/Functions.php:1000
 msgctxt "child’s son’s wife"
 msgid "grandson’s wife"
-msgstr ""
+msgstr "손자며느리"
 
 #: app/Functions/Functions.php:1028
 msgctxt "daughter’s son’s wife"
 msgid "grandson’s wife"
-msgstr ""
+msgstr "손자며느리"
 
 #: app/Functions/Functions.php:1320
 msgctxt "son’s son’s wife"
 msgid "grandson’s wife"
-msgstr ""
+msgstr "손자며느리"
 
 #: app/Functions/Functions.php:1696 app/Functions/Functions.php:1715
 #: app/Functions/Functions.php:1727 app/Functions/Functions.php:1738
 #: app/Functions/Functions.php:1754
 #, php-format
 msgid "great ×%s aunt"
-msgstr ""
+msgstr "증 ×%s 이모(고모/숙모)"
 
 #: app/Functions/Functions.php:1699 app/Functions/Functions.php:1718
 #: app/Functions/Functions.php:1730 app/Functions/Functions.php:1741
 #: app/Functions/Functions.php:1757
 #, php-format
 msgid "great ×%s aunt/uncle"
-msgstr ""
+msgstr "증 ×%s 이모(고모/숙모)/숙부"
 
 #. I18N: if you need a different number for %s, contact the developers, as a code-change is required
 #: app/Functions/Functions.php:2249 app/Functions/Functions.php:2259
 #: app/Functions/Functions.php:2280
 #, php-format
 msgid "great ×%s grandchild"
-msgstr ""
+msgstr "증 ×%s 손주"
 
 #. I18N: if you need a different number for %s, contact the developers, as a code-change is required
 #: app/Functions/Functions.php:2246 app/Functions/Functions.php:2257
 #: app/Functions/Functions.php:2276
 #, php-format
 msgid "great ×%s granddaughter"
-msgstr ""
+msgstr "증 ×%s 손녀"
 
 #. I18N: if you need a different number for %s, contact the developers, as a code-change is required
 #: app/Functions/Functions.php:2094 app/Functions/Functions.php:2108
@@ -17295,7 +17296,7 @@ msgstr ""
 #: app/Functions/Functions.php:2149
 #, php-format
 msgid "great ×%s grandfather"
-msgstr ""
+msgstr "증 ×%s 조부"
 
 #. I18N: if you need a different number for %s, contact the developers, as a code-change is required
 #: app/Functions/Functions.php:2098 app/Functions/Functions.php:2112
@@ -17303,7 +17304,7 @@ msgstr ""
 #: app/Functions/Functions.php:2154
 #, php-format
 msgid "great ×%s grandmother"
-msgstr ""
+msgstr "증 ×%s 조모"
 
 #. I18N: if you need a different number for %s, contact the developers, as a code-change is required
 #: app/Functions/Functions.php:2101 app/Functions/Functions.php:2115
@@ -17311,480 +17312,480 @@ msgstr ""
 #: app/Functions/Functions.php:2158
 #, php-format
 msgid "great ×%s grandparent"
-msgstr ""
+msgstr "증 ×%s 조부모"
 
 #. I18N: if you need a different number for %s, contact the developers, as a code-change is required
 #: app/Functions/Functions.php:2242 app/Functions/Functions.php:2254
 #: app/Functions/Functions.php:2271
 #, php-format
 msgid "great ×%s grandson"
-msgstr ""
+msgstr "증 ×%s 손자"
 
 #. I18N: if you need a different number for %s, contact the developers, as a code-change is required
 #: app/Functions/Functions.php:1977 app/Functions/Functions.php:1989
 #: app/Functions/Functions.php:2005
 #, php-format
 msgid "great ×%s nephew"
-msgstr ""
+msgstr "증 ×%s 조카"
 
 #: app/Functions/Functions.php:1915 app/Functions/Functions.php:1951
 #, php-format
 msgctxt "(a man’s) brother’s great ×(%s-1) grandson"
 msgid "great ×%s nephew"
-msgstr ""
+msgstr "증 ×%s 조카"
 
 #: app/Functions/Functions.php:1919 app/Functions/Functions.php:1954
 #, php-format
 msgctxt "(a man’s) sister’s great ×(%s-1) grandson"
 msgid "great ×%s nephew"
-msgstr ""
+msgstr "증 ×%s 조카"
 
 #: app/Functions/Functions.php:1922 app/Functions/Functions.php:1956
 #, php-format
 msgctxt "(a woman’s) great ×%s nephew"
 msgid "great ×%s nephew"
-msgstr ""
+msgstr "증 ×%s 조카"
 
 #: app/Functions/Functions.php:1984 app/Functions/Functions.php:1996
 #: app/Functions/Functions.php:2012
 #, php-format
 msgid "great ×%s nephew/niece"
-msgstr ""
+msgstr "증 ×%s 조카/조카딸"
 
 #: app/Functions/Functions.php:1938 app/Functions/Functions.php:1968
 #, php-format
 msgctxt "(a man’s) brother’s great ×(%s-1) grandchild"
 msgid "great ×%s nephew/niece"
-msgstr ""
+msgstr "증 ×%s 조카/조카딸"
 
 #: app/Functions/Functions.php:1942 app/Functions/Functions.php:1971
 #, php-format
 msgctxt "(a man’s) sister’s great ×(%s-1) grandchild"
 msgid "great ×%s nephew/niece"
-msgstr ""
+msgstr "증 ×%s 조카/조카딸"
 
 #: app/Functions/Functions.php:1945 app/Functions/Functions.php:1973
 #, php-format
 msgctxt "(a woman’s) great ×%s nephew/niece"
 msgid "great ×%s nephew/niece"
-msgstr ""
+msgstr "증 ×%s 조카/조카딸"
 
 #: app/Functions/Functions.php:1981 app/Functions/Functions.php:1993
 #: app/Functions/Functions.php:2009
 #, php-format
 msgid "great ×%s niece"
-msgstr ""
+msgstr "증 ×%s 조카딸"
 
 #: app/Functions/Functions.php:1927 app/Functions/Functions.php:1960
 #, php-format
 msgctxt "(a man’s) brother’s great ×(%s-1) granddaughter"
 msgid "great ×%s niece"
-msgstr ""
+msgstr "증 ×%s 조카딸"
 
 #: app/Functions/Functions.php:1931 app/Functions/Functions.php:1963
 #, php-format
 msgctxt "(a man’s) sister’s great ×(%s-1) granddaughter"
 msgid "great ×%s niece"
-msgstr ""
+msgstr "증 ×%s 조카딸"
 
 #: app/Functions/Functions.php:1934 app/Functions/Functions.php:1965
 #, php-format
 msgctxt "(a woman’s) great ×%s niece"
 msgid "great ×%s niece"
-msgstr ""
+msgstr "증 ×%s 조카딸"
 
 #. I18N: if you need a different number for %s, contact the developers, as a code-change is required
 #: app/Functions/Functions.php:1692 app/Functions/Functions.php:1723
 #: app/Functions/Functions.php:1735 app/Functions/Functions.php:1750
 #, php-format
 msgid "great ×%s uncle"
-msgstr ""
+msgstr "증 ×%s 숙부"
 
 #: app/Functions/Functions.php:1704
 #, php-format
 msgctxt "great ×(%s-1) grandfather’s brother"
 msgid "great ×%s uncle"
-msgstr ""
+msgstr "증 ×%s 숙부"
 
 #: app/Functions/Functions.php:1708
 #, php-format
 msgctxt "great ×(%s-1) grandmother’s brother"
 msgid "great ×%s uncle"
-msgstr ""
+msgstr "증 ×%s 숙부"
 
 #: app/Functions/Functions.php:1711
 #, php-format
 msgctxt "great ×(%s-1) grandparent’s brother"
 msgid "great ×%s uncle"
-msgstr ""
+msgstr "증 ×%s 숙부"
 
 #: app/Functions/Functions.php:1622
 msgid "great ×4 aunt"
-msgstr ""
+msgstr "증 ×4 이모/고모"
 
 #: app/Functions/Functions.php:1625
 msgid "great ×4 aunt/uncle"
-msgstr ""
+msgstr "증 ×4 이모/고모/삼촌"
 
 #: app/Functions/Functions.php:2197
 msgid "great ×4 grandchild"
-msgstr ""
+msgstr "증 x4 손주"
 
 #: app/Functions/Functions.php:2194
 msgid "great ×4 granddaughter"
-msgstr ""
+msgstr "증 x4 손녀"
 
 #: app/Functions/Functions.php:2044
 msgid "great ×4 grandfather"
-msgstr ""
+msgstr "증 x4 조부"
 
 #: app/Functions/Functions.php:2048
 msgid "great ×4 grandmother"
-msgstr ""
+msgstr "증 x4 조모"
 
 #: app/Functions/Functions.php:2051
 msgid "great ×4 grandparent"
-msgstr ""
+msgstr "증 x4 조부모"
 
 #: app/Functions/Functions.php:2190
 msgid "great ×4 grandson"
-msgstr ""
+msgstr "증 x4 손자"
 
 #: app/Functions/Functions.php:1839
 msgctxt "(a man’s) brother’s great-great-great-grandson"
 msgid "great ×4 nephew"
-msgstr ""
+msgstr "증 x4 조카"
 
 #: app/Functions/Functions.php:1843
 msgctxt "(a man’s) sister’s great-great-great-grandson"
 msgid "great ×4 nephew"
-msgstr ""
+msgstr "증 x4 조카"
 
 #: app/Functions/Functions.php:1846
 msgctxt "(a woman’s) great ×4 nephew"
 msgid "great ×4 nephew"
-msgstr ""
+msgstr "증 x4 조카"
 
 #: app/Functions/Functions.php:1862
 msgctxt "(a man’s) brother’s great-great-great-grandchild"
 msgid "great ×4 nephew/niece"
-msgstr ""
+msgstr "증 x4 조카/조카딸"
 
 #: app/Functions/Functions.php:1866
 msgctxt "(a man’s) sister’s great-great-great-grandchild"
 msgid "great ×4 nephew/niece"
-msgstr ""
+msgstr "증 x4 조카/조카딸"
 
 #: app/Functions/Functions.php:1869
 msgctxt "(a woman’s) great ×4 nephew/niece"
 msgid "great ×4 nephew/niece"
-msgstr ""
+msgstr 증 x4 조카/조카딸""
 
 #: app/Functions/Functions.php:1851
 msgctxt "(a man’s) brother’s great-great-great-granddaughter"
 msgid "great ×4 niece"
-msgstr ""
+msgstr "증 x4 조카딸"
 
 #: app/Functions/Functions.php:1855
 msgctxt "(a man’s) sister’s great-great-great-granddaughter"
 msgid "great ×4 niece"
-msgstr ""
+msgstr "증 x4 조카딸"
 
 #: app/Functions/Functions.php:1858
 msgctxt "(a woman’s) great ×4 niece"
 msgid "great ×4 niece"
-msgstr ""
+msgstr "증 x4 조카딸"
 
 #: app/Functions/Functions.php:1611
 msgctxt "great-great-great-grandfather’s brother"
 msgid "great ×4 uncle"
-msgstr ""
+msgstr "증 x4 조카딸"
 
 #: app/Functions/Functions.php:1615
 msgctxt "great-great-great-grandmother’s brother"
 msgid "great ×4 uncle"
-msgstr ""
+msgstr "증 x4 숙부"
 
 #: app/Functions/Functions.php:1618
 msgctxt "great-great-great-grandparent’s brother"
 msgid "great ×4 uncle"
-msgstr ""
+msgstr "증 x4 숙부"
 
 #: app/Functions/Functions.php:1641
 msgid "great ×5 aunt"
-msgstr ""
+msgstr "증 x5 이모/고모/숙모"
 
 #: app/Functions/Functions.php:1644
 msgid "great ×5 aunt/uncle"
-msgstr ""
+msgstr "증 x5 이모/고모/숙모/숙부"
 
 #: app/Functions/Functions.php:2208
 msgid "great ×5 grandchild"
-msgstr ""
+msgstr "증 x5 손주"
 
 #: app/Functions/Functions.php:2205
 msgid "great ×5 granddaughter"
-msgstr ""
+msgstr "증 x5 손녀"
 
 #: app/Functions/Functions.php:2055
 msgid "great ×5 grandfather"
-msgstr ""
+msgstr "증 x5 조부"
 
 #: app/Functions/Functions.php:2059
 msgid "great ×5 grandmother"
-msgstr ""
+msgstr "증 x5 조모"
 
 #: app/Functions/Functions.php:2062
 msgid "great ×5 grandparent"
-msgstr ""
+msgstr "증 x5 조부모"
 
 #: app/Functions/Functions.php:2201
 msgid "great ×5 grandson"
-msgstr ""
+msgstr "증 x5 손자"
 
 #: app/Functions/Functions.php:1874
 msgctxt "(a man’s) brother’s great ×4 grandson"
 msgid "great ×5 nephew"
-msgstr ""
+msgstr "증 x5 조카"
 
 #: app/Functions/Functions.php:1878
 msgctxt "(a man’s) sister’s great ×4 grandson"
 msgid "great ×5 nephew"
-msgstr ""
+msgstr "증 x5 조카"
 
 #: app/Functions/Functions.php:1881
 msgctxt "(a woman’s) great ×5 nephew"
 msgid "great ×5 nephew"
-msgstr ""
+msgstr "증 x5 조카"
 
 #: app/Functions/Functions.php:1897
 msgctxt "(a man’s) brother’s great ×4 grandchild"
 msgid "great ×5 nephew/niece"
-msgstr ""
+msgstr "증 x5 조카/조카딸"
 
 #: app/Functions/Functions.php:1901
 msgctxt "(a man’s) sister’s great ×4 grandchild"
 msgid "great ×5 nephew/niece"
-msgstr ""
+msgstr "증 x5 조카/조카딸"
 
 #: app/Functions/Functions.php:1904
 msgctxt "(a woman’s) great ×5 nephew/niece"
 msgid "great ×5 nephew/niece"
-msgstr ""
+msgstr "증 x5 조카/조카딸"
 
 #: app/Functions/Functions.php:1886
 msgctxt "(a man’s) brother’s great ×4 granddaughter"
 msgid "great ×5 niece"
-msgstr ""
+msgstr "증 x5 조카딸"
 
 #: app/Functions/Functions.php:1890
 msgctxt "(a man’s) sister’s great ×4 granddaughter"
 msgid "great ×5 niece"
-msgstr ""
+msgstr "증 x5 조카딸"
 
 #: app/Functions/Functions.php:1893
 msgctxt "(a woman’s) great ×5 niece"
 msgid "great ×5 niece"
-msgstr ""
+msgstr "증 x5 조카딸"
 
 #: app/Functions/Functions.php:1630
 msgctxt "great ×4 grandfather’s brother"
 msgid "great ×5 uncle"
-msgstr ""
+msgstr "증 x5 숙부"
 
 #: app/Functions/Functions.php:1634
 msgctxt "great ×4 grandmother’s brother"
 msgid "great ×5 uncle"
-msgstr ""
+msgstr "증 x5 숙부"
 
 #: app/Functions/Functions.php:1637
 msgctxt "great ×4 grandparent’s brother"
 msgid "great ×5 uncle"
-msgstr ""
+msgstr "증 x5 숙부"
 
 #: app/Functions/Functions.php:1660
 msgid "great ×6 aunt"
-msgstr ""
+msgstr "증 x6 이모/고모/숙모"
 
 #: app/Functions/Functions.php:1663
 msgid "great ×6 aunt/uncle"
-msgstr ""
+msgstr "증 x6 이모/고모/숙모/숙부"
 
 #: app/Functions/Functions.php:2219
 msgid "great ×6 grandchild"
-msgstr ""
+msgstr "증 x6 손주"
 
 #: app/Functions/Functions.php:2216
 msgid "great ×6 granddaughter"
-msgstr ""
+msgstr "증 x6 손녀"
 
 #: app/Functions/Functions.php:2066
 msgid "great ×6 grandfather"
-msgstr ""
+msgstr "증 x6 조부"
 
 #: app/Functions/Functions.php:2070
 msgid "great ×6 grandmother"
-msgstr ""
+msgstr "증 x6 조모"
 
 #: app/Functions/Functions.php:2073
 msgid "great ×6 grandparent"
-msgstr ""
+msgstr "증 x6 조부모"
 
 #: app/Functions/Functions.php:2212
 msgid "great ×6 grandson"
-msgstr ""
+msgstr "증 x6 손자"
 
 #: app/Functions/Functions.php:1649
 msgctxt "great ×5 grandfather’s brother"
 msgid "great ×6 uncle"
-msgstr ""
+msgstr "증 x6 숙부"
 
 #: app/Functions/Functions.php:1653
 msgctxt "great ×5 grandmother’s brother"
 msgid "great ×6 uncle"
-msgstr ""
+msgstr "증 x6 숙부"
 
 #: app/Functions/Functions.php:1656
 msgctxt "great ×5 grandparent’s brother"
 msgid "great ×6 uncle"
-msgstr ""
+msgstr "증 x6 숙부"
 
 #: app/Functions/Functions.php:1679
 msgid "great ×7 aunt"
-msgstr ""
+msgstr "증 x7 이모/고모/숙모"
 
 #: app/Functions/Functions.php:1682
 msgid "great ×7 aunt/uncle"
-msgstr ""
+msgstr "증 x7 이모/고모/숙모/숙부"
 
 #: app/Functions/Functions.php:2230
 msgid "great ×7 grandchild"
-msgstr ""
+msgstr "증 x7 손주"
 
 #: app/Functions/Functions.php:2227
 msgid "great ×7 granddaughter"
-msgstr ""
+msgstr "증 x7 손녀"
 
 #: app/Functions/Functions.php:2077
 msgid "great ×7 grandfather"
-msgstr ""
+msgstr "증 x7 조부"
 
 #: app/Functions/Functions.php:2081
 msgid "great ×7 grandmother"
-msgstr ""
+msgstr "증 x7 조모"
 
 #: app/Functions/Functions.php:2084
 msgid "great ×7 grandparent"
-msgstr ""
+msgstr "증 x7 조부모"
 
 #: app/Functions/Functions.php:2223
 msgid "great ×7 grandson"
-msgstr ""
+msgstr "증 x7 손자"
 
 #: app/Functions/Functions.php:1668
 msgctxt "great ×6 grandfather’s brother"
 msgid "great ×7 uncle"
-msgstr ""
+msgstr "증 x7 숙부"
 
 #: app/Functions/Functions.php:1672
 msgctxt "great ×6 grandmother’s brother"
 msgid "great ×7 uncle"
-msgstr ""
+msgstr "증 x7 숙부"
 
 #: app/Functions/Functions.php:1675
 msgctxt "great ×6 grandparent’s brother"
 msgid "great ×7 uncle"
-msgstr ""
+msgstr "증 x7 숙부"
 
 #: app/Functions/Functions.php:1352
 msgctxt "father’s father’s brother’s wife"
 msgid "great-aunt"
-msgstr ""
+msgstr "아버지의 아버지의 형제의 아내"
 
 #: app/Functions/Functions.php:1048
 msgctxt "father’s father’s sister"
 msgid "great-aunt"
-msgstr ""
+msgstr "아버지의 아버지의 여동생"
 
 #: app/Functions/Functions.php:1358
 msgctxt "father’s mother’s brother’s wife"
 msgid "great-aunt"
-msgstr ""
+msgstr "아버지의 어머니의 형제의 아내"
 
 #: app/Functions/Functions.php:1060
 msgctxt "father’s mother’s sister"
 msgid "great-aunt"
-msgstr ""
+msgstr "아버지의 어머니의 여동생"
 
 #: app/Functions/Functions.php:1364
 msgctxt "father’s parent’s brother’s wife"
 msgid "great-aunt"
-msgstr ""
+msgstr "아버지의 부모의 형제의 아내"
 
 #: app/Functions/Functions.php:1072
 msgctxt "father’s parent’s sister"
 msgid "great-aunt"
-msgstr ""
+msgstr "아버지의 부모의 자매"
 
 #: app/Functions/Functions.php:1370
 msgctxt "mother’s father’s brother’s wife"
 msgid "great-aunt"
-msgstr ""
+msgstr "어머니의 아버지의 형제의 아내"
 
 #: app/Functions/Functions.php:1128
 msgctxt "mother’s father’s sister"
 msgid "great-aunt"
-msgstr ""
+msgstr "어머니의 아버지의 여동생"
 
 #: app/Functions/Functions.php:1376
 msgctxt "mother’s mother’s brother’s wife"
 msgid "great-aunt"
-msgstr ""
+msgstr "어머니의 어머니의 형제의 아내"
 
 #: app/Functions/Functions.php:1146
 msgctxt "mother’s mother’s sister"
 msgid "great-aunt"
-msgstr ""
+msgstr "어머니의 어머니의 여동생"
 
 #: app/Functions/Functions.php:1382
 msgctxt "mother’s parent’s brother’s wife"
 msgid "great-aunt"
-msgstr ""
+msgstr "어머니의 부모의 형제의 아내"
 
 #: app/Functions/Functions.php:1158
 msgctxt "mother’s parent’s sister"
 msgid "great-aunt"
-msgstr ""
+msgstr "어머니의 부모의 자매"
 
 #: app/Functions/Functions.php:1388
 msgctxt "parent’s father’s brother’s wife"
 msgid "great-aunt"
-msgstr ""
+msgstr "부모의 아버지의 형제의 아내"
 
 #: app/Functions/Functions.php:1180
 msgctxt "parent’s father’s sister"
 msgid "great-aunt"
-msgstr ""
+msgstr "부모의 아버지의 자매"
 
 #: app/Functions/Functions.php:1394
 msgctxt "parent’s mother’s brother’s wife"
 msgid "great-aunt"
-msgstr ""
+msgstr "부모의 어머니의 형제의 아내"
 
 #: app/Functions/Functions.php:1192
 msgctxt "parent’s mother’s sister"
 msgid "great-aunt"
-msgstr ""
+msgstr "부모님의 어머니의 여동생"
 
 #: app/Functions/Functions.php:1400
 msgctxt "parent’s parent’s brother’s wife"
 msgid "great-aunt"
-msgstr ""
+msgstr "부모의 부모의 형제의 아내"
 
 #: app/Functions/Functions.php:1204
 msgctxt "parent’s parent’s sister"
 msgid "great-aunt"
-msgstr ""
+msgstr "부모의 부모의 여자형제"
 
 #: app/Functions/Functions.php:1046
 msgctxt "father’s father’s sibling"
@@ -17879,771 +17880,771 @@ msgstr ""
 #: app/Functions/Functions.php:980
 msgctxt "child’s child’s child"
 msgid "great-grandchild"
-msgstr ""
+msgstr "증손주"
 
 #: app/Functions/Functions.php:986
 msgctxt "child’s daughter’s child"
 msgid "great-grandchild"
-msgstr ""
+msgstr "증손주"
 
 #: app/Functions/Functions.php:994
 msgctxt "child’s son’s child"
 msgid "great-grandchild"
-msgstr ""
+msgstr "증손주"
 
 #: app/Functions/Functions.php:1002
 msgctxt "daughter’s child’s child"
 msgid "great-grandchild"
-msgstr ""
+msgstr "증손주"
 
 #: app/Functions/Functions.php:1008
 msgctxt "daughter’s daughter’s child"
 msgid "great-grandchild"
-msgstr ""
+msgstr "증손주"
 
 #: app/Functions/Functions.php:1022
 msgctxt "daughter’s son’s child"
 msgid "great-grandchild"
-msgstr ""
+msgstr "증손주"
 
 #: app/Functions/Functions.php:1300
 msgctxt "son’s child’s child"
 msgid "great-grandchild"
-msgstr ""
+msgstr "증손주"
 
 #: app/Functions/Functions.php:1306
 msgctxt "son’s daughter’s child"
 msgid "great-grandchild"
-msgstr ""
+msgstr "증손주"
 
 #: app/Functions/Functions.php:1314
 msgctxt "son’s son’s child"
 msgid "great-grandchild"
-msgstr ""
+msgstr "증손주"
 
 #: app/Functions/Functions.php:982
 msgctxt "child’s child’s daughter"
 msgid "great-granddaughter"
-msgstr ""
+msgstr "증손녀"
 
 #: app/Functions/Functions.php:988
 msgctxt "child’s daughter’s daughter"
 msgid "great-granddaughter"
-msgstr ""
+msgstr "증손녀"
 
 #: app/Functions/Functions.php:996
 msgctxt "child’s son’s daughter"
 msgid "great-granddaughter"
-msgstr ""
+msgstr "증손녀"
 
 #: app/Functions/Functions.php:1004
 msgctxt "daughter’s child’s daughter"
 msgid "great-granddaughter"
-msgstr ""
+msgstr "증손녀"
 
 #: app/Functions/Functions.php:1010
 msgctxt "daughter’s daughter’s daughter"
 msgid "great-granddaughter"
-msgstr ""
+msgstr "증손녀"
 
 #: app/Functions/Functions.php:1024
 msgctxt "daughter’s son’s daughter"
 msgid "great-granddaughter"
-msgstr ""
+msgstr "증손녀"
 
 #: app/Functions/Functions.php:1302
 msgctxt "son’s child’s daughter"
 msgid "great-granddaughter"
-msgstr ""
+msgstr "증손녀"
 
 #: app/Functions/Functions.php:1308
 msgctxt "son’s daughter’s daughter"
 msgid "great-granddaughter"
-msgstr ""
+msgstr "증손녀"
 
 #: app/Functions/Functions.php:1316
 msgctxt "son’s son’s daughter"
 msgid "great-granddaughter"
-msgstr ""
+msgstr "증손녀"
 
 #: app/Functions/Functions.php:1040
 msgctxt "father’s father’s father"
 msgid "great-grandfather"
-msgstr ""
+msgstr "증손녀"
 
 #: app/Functions/Functions.php:1052
 msgctxt "father’s mother’s father"
 msgid "great-grandfather"
-msgstr ""
+msgstr "증조부"
 
 #: app/Functions/Functions.php:1064
 msgctxt "father’s parent’s father"
 msgid "great-grandfather"
-msgstr ""
+msgstr "증조부"
 
 #: app/Functions/Functions.php:1120
 msgctxt "mother’s father’s father"
 msgid "great-grandfather"
-msgstr ""
+msgstr "외증조부"
 
 #: app/Functions/Functions.php:1138
 msgctxt "mother’s mother’s father"
 msgid "great-grandfather"
-msgstr ""
+msgstr "외증조부"
 
 #: app/Functions/Functions.php:1150
 msgctxt "mother’s parent’s father"
 msgid "great-grandfather"
-msgstr ""
+msgstr "외증조부"
 
 #: app/Functions/Functions.php:1172
 msgctxt "parent’s father’s father"
 msgid "great-grandfather"
-msgstr ""
+msgstr "증조부"
 
 #: app/Functions/Functions.php:1184
 msgctxt "parent’s mother’s father"
 msgid "great-grandfather"
-msgstr ""
+msgstr "증조부"
 
 #: app/Functions/Functions.php:1196
 msgctxt "parent’s parent’s father"
 msgid "great-grandfather"
-msgstr ""
+msgstr "증조부"
 
 #: app/Functions/Functions.php:1042
 msgctxt "father’s father’s mother"
 msgid "great-grandmother"
-msgstr ""
+msgstr "증조모"
 
 #: app/Functions/Functions.php:1054
 msgctxt "father’s mother’s mother"
 msgid "great-grandmother"
-msgstr ""
+msgstr "증조모"
 
 #: app/Functions/Functions.php:1066
 msgctxt "father’s parent’s mother"
 msgid "great-grandmother"
-msgstr ""
+msgstr "증조모"
 
 #: app/Functions/Functions.php:1122
 msgctxt "mother’s father’s mother"
 msgid "great-grandmother"
-msgstr ""
+msgstr "외증조모"
 
 #: app/Functions/Functions.php:1140
 msgctxt "mother’s mother’s mother"
 msgid "great-grandmother"
-msgstr ""
+msgstr "외증조모"
 
 #: app/Functions/Functions.php:1152
 msgctxt "mother’s parent’s mother"
 msgid "great-grandmother"
-msgstr ""
+msgstr "외증조모"
 
 #: app/Functions/Functions.php:1174
 msgctxt "parent’s father’s mother"
 msgid "great-grandmother"
-msgstr ""
+msgstr "증조모"
 
 #: app/Functions/Functions.php:1186
 msgctxt "parent’s mother’s mother"
 msgid "great-grandmother"
-msgstr ""
+msgstr "증조모"
 
 #: app/Functions/Functions.php:1198
 msgctxt "parent’s parent’s mother"
 msgid "great-grandmother"
-msgstr ""
+msgstr "증조모"
 
 #: app/Functions/Functions.php:1044
 msgctxt "father’s father’s parent"
 msgid "great-grandparent"
-msgstr ""
+msgstr "증조부모"
 
 #: app/Functions/Functions.php:1056
 msgctxt "father’s mother’s parent"
 msgid "great-grandparent"
-msgstr ""
+msgstr "증조부모"
 
 #: app/Functions/Functions.php:1068
 msgctxt "father’s parent’s parent"
 msgid "great-grandparent"
-msgstr ""
+msgstr "증조부모"
 
 #: app/Functions/Functions.php:1124
 msgctxt "mother’s father’s parent"
 msgid "great-grandparent"
-msgstr ""
+msgstr "증조부모"
 
 #: app/Functions/Functions.php:1142
 msgctxt "mother’s mother’s parent"
 msgid "great-grandparent"
-msgstr ""
+msgstr "증조부모"
 
 #: app/Functions/Functions.php:1154
 msgctxt "mother’s parent’s parent"
 msgid "great-grandparent"
-msgstr ""
+msgstr "증조부모"
 
 #: app/Functions/Functions.php:1176
 msgctxt "parent’s father’s parent"
 msgid "great-grandparent"
-msgstr ""
+msgstr "증조부모"
 
 #: app/Functions/Functions.php:1188
 msgctxt "parent’s mother’s parent"
 msgid "great-grandparent"
-msgstr ""
+msgstr "증조부모"
 
 #: app/Functions/Functions.php:1200
 msgctxt "parent’s parent’s parent"
 msgid "great-grandparent"
-msgstr ""
+msgstr "증조부모"
 
 #: app/Functions/Functions.php:984
 msgctxt "child’s child’s son"
 msgid "great-grandson"
-msgstr ""
+msgstr "증손자"
 
 #: app/Functions/Functions.php:992
 msgctxt "child’s daughter’s son"
 msgid "great-grandson"
-msgstr ""
+msgstr "증손자"
 
 #: app/Functions/Functions.php:998
 msgctxt "child’s son’s son"
 msgid "great-grandson"
-msgstr ""
+msgstr "증손자"
 
 #: app/Functions/Functions.php:1006
 msgctxt "daughter’s child’s son"
 msgid "great-grandson"
-msgstr ""
+msgstr "증손자"
 
 #: app/Functions/Functions.php:1014
 msgctxt "daughter’s daughter’s son"
 msgid "great-grandson"
-msgstr ""
+msgstr "증손자"
 
 #: app/Functions/Functions.php:1026
 msgctxt "daughter’s son’s son"
 msgid "great-grandson"
-msgstr ""
+msgstr "증손자"
 
 #: app/Functions/Functions.php:1304
 msgctxt "son’s child’s son"
 msgid "great-grandson"
-msgstr ""
+msgstr "증손자"
 
 #: app/Functions/Functions.php:1312
 msgctxt "son’s daughter’s son"
 msgid "great-grandson"
-msgstr ""
+msgstr "증손자"
 
 #: app/Functions/Functions.php:1318
 msgctxt "son’s son’s son"
 msgid "great-grandson"
-msgstr ""
+msgstr "증손자"
 
 #: app/Functions/Functions.php:1584
 msgid "great-great-aunt"
-msgstr ""
+msgstr "증손자"
 
 #: app/Functions/Functions.php:1587
 msgid "great-great-aunt/uncle"
-msgstr ""
+msgstr "고조 이모/고모/숙모/숙부"
 
 #: app/Functions/Functions.php:2175
 msgid "great-great-grandchild"
-msgstr ""
+msgstr "고손주"
 
 #: app/Functions/Functions.php:2172
 msgid "great-great-granddaughter"
-msgstr ""
+msgstr "고손녀"
 
 #: app/Functions/Functions.php:2022
 msgid "great-great-grandfather"
-msgstr ""
+msgstr "고조부"
 
 #: app/Functions/Functions.php:2026
 msgid "great-great-grandmother"
-msgstr ""
+msgstr "고조모"
 
 #: app/Functions/Functions.php:2029
 msgid "great-great-grandparent"
-msgstr ""
+msgstr "고조부모"
 
 #: app/Functions/Functions.php:2168
 msgid "great-great-grandson"
-msgstr ""
+msgstr "고손자"
 
 #: app/Functions/Functions.php:1603
 msgid "great-great-great-aunt"
-msgstr ""
+msgstr "고조 이모/고모/숙모"
 
 #: app/Functions/Functions.php:1606
 msgid "great-great-great-aunt/uncle"
-msgstr ""
+msgstr "현(玄)조 이모/고모/숙모/숙부"
 
 #: app/Functions/Functions.php:2186
 msgid "great-great-great-grandchild"
-msgstr ""
+msgstr "현(玄)손주"
 
 #: app/Functions/Functions.php:2183
 msgid "great-great-great-granddaughter"
-msgstr ""
+msgstr "현(玄)손녀"
 
 #: app/Functions/Functions.php:2033
 msgid "great-great-great-grandfather"
-msgstr ""
+msgstr "현(玄)조부"
 
 #: app/Functions/Functions.php:2037
 msgid "great-great-great-grandmother"
-msgstr ""
+msgstr "현(玄)조모"
 
 #: app/Functions/Functions.php:2040
 msgid "great-great-great-grandparent"
-msgstr ""
+msgstr "현(玄)조부모"
 
 #: app/Functions/Functions.php:2179
 msgid "great-great-great-grandson"
-msgstr ""
+msgstr "현(玄)손자"
 
 #: app/Functions/Functions.php:1804
 msgctxt "(a man’s) brother’s great-great-grandson"
 msgid "great-great-great-nephew"
-msgstr ""
+msgstr "현(玄)조카"
 
 #: app/Functions/Functions.php:1808
 msgctxt "(a man’s) sister’s great-great-grandson"
 msgid "great-great-great-nephew"
-msgstr ""
+msgstr "현(玄)조카"
 
 #: app/Functions/Functions.php:1811
 msgctxt "(a woman’s) great-great-great-nephew"
 msgid "great-great-great-nephew"
-msgstr ""
+msgstr "현(玄)조카"
 
 #: app/Functions/Functions.php:1827
 msgctxt "(a man’s) brother’s great-great-grandchild"
 msgid "great-great-great-nephew/niece"
-msgstr ""
+msgstr "현(玄)조카/조카딸"
 
 #: app/Functions/Functions.php:1831
 msgctxt "(a man’s) sister’s great-great-grandchild"
 msgid "great-great-great-nephew/niece"
-msgstr ""
+msgstr "현(玄)조카/조카딸"
 
 #: app/Functions/Functions.php:1834
 msgctxt "(a woman’s) great-great-great-nephew/niece"
 msgid "great-great-great-nephew/niece"
-msgstr ""
+msgstr "현(玄)조카/조카딸"
 
 #: app/Functions/Functions.php:1816
 msgctxt "(a man’s) brother’s great-great-granddaughter"
 msgid "great-great-great-niece"
-msgstr ""
+msgstr "현(玄)조카딸"
 
 #: app/Functions/Functions.php:1820
 msgctxt "(a man’s) sister’s great-great-granddaughter"
 msgid "great-great-great-niece"
-msgstr ""
+msgstr "현(玄)조카딸"
 
 #: app/Functions/Functions.php:1823
 msgctxt "(a woman’s) great-great-great-niece"
 msgid "great-great-great-niece"
-msgstr ""
+msgstr "현(玄)조카딸"
 
 #: app/Functions/Functions.php:1592
 msgctxt "great-great-grandfather’s brother"
 msgid "great-great-great-uncle"
-msgstr ""
+msgstr "현(玄)숙부"
 
 #: app/Functions/Functions.php:1596
 msgctxt "great-great-grandmother’s brother"
 msgid "great-great-great-uncle"
-msgstr ""
+msgstr "현(玄)숙부"
 
 #: app/Functions/Functions.php:1599
 msgctxt "great-great-grandparent’s brother"
 msgid "great-great-great-uncle"
-msgstr ""
+msgstr "현(玄)숙부"
 
 #: app/Functions/Functions.php:1769
 msgctxt "(a man’s) brother’s great-grandson"
 msgid "great-great-nephew"
-msgstr ""
+msgstr "고(高)조카"
 
 #: app/Functions/Functions.php:1773
 msgctxt "(a man’s) sister’s great-grandson"
 msgid "great-great-nephew"
-msgstr ""
+msgstr "고(高)조카"
 
 #: app/Functions/Functions.php:1776
 msgctxt "(a woman’s) great-great-nephew"
 msgid "great-great-nephew"
-msgstr ""
+msgstr "고(高)조카"
 
 #: app/Functions/Functions.php:1792
 msgctxt "(a man’s) brother’s great-grandchild"
 msgid "great-great-nephew/niece"
-msgstr ""
+msgstr "고(高)조카/조카딸"
 
 #: app/Functions/Functions.php:1796
 msgctxt "(a man’s) sister’s great-grandchild"
 msgid "great-great-nephew/niece"
-msgstr ""
+msgstr "고(高)조카/조카딸"
 
 #: app/Functions/Functions.php:1799
 msgctxt "(a woman’s) great-great-nephew/niece"
 msgid "great-great-nephew/niece"
-msgstr ""
+msgstr "고(高)조카/조카딸"
 
 #: app/Functions/Functions.php:1781
 msgctxt "(a man’s) brother’s great-granddaughter"
 msgid "great-great-niece"
-msgstr ""
+msgstr "고(高)조카딸"
 
 #: app/Functions/Functions.php:1785
 msgctxt "(a man’s) sister’s great-granddaughter"
 msgid "great-great-niece"
-msgstr ""
+msgstr "고(高)조카딸"
 
 #: app/Functions/Functions.php:1788
 msgctxt "(a woman’s) great-great-niece"
 msgid "great-great-niece"
-msgstr ""
+msgstr "고(高)조카딸"
 
 #: app/Functions/Functions.php:1573
 msgctxt "great-grandfather’s brother"
 msgid "great-great-uncle"
-msgstr ""
+msgstr "고(高)숙부"
 
 #: app/Functions/Functions.php:1577
 msgctxt "great-grandmother’s brother"
 msgid "great-great-uncle"
-msgstr ""
+msgstr "고(高)숙부"
 
 #: app/Functions/Functions.php:1580
 msgctxt "great-grandparent’s brother"
 msgid "great-great-uncle"
-msgstr ""
+msgstr "고(高)숙부"
 
 #: app/Functions/Functions.php:929
 msgctxt "(a man’s) brother’s child’s son"
 msgid "great-nephew"
-msgstr ""
+msgstr "증조카"
 
 #: app/Functions/Functions.php:949
 msgctxt "(a man’s) brother’s daughter’s son"
 msgid "great-nephew"
-msgstr ""
+msgstr "증조카"
 
 #: app/Functions/Functions.php:967
 msgctxt "(a man’s) brother’s son’s son"
 msgid "great-nephew"
-msgstr ""
+msgstr "증조카"
 
 #: app/Functions/Functions.php:1249
 msgctxt "(a man’s) sister’s child’s son"
 msgid "great-nephew"
-msgstr ""
+msgstr "증조카"
 
 #: app/Functions/Functions.php:1269
 msgctxt "(a man’s) sister’s daughter’s son"
 msgid "great-nephew"
-msgstr ""
+msgstr "증조카"
 
 #: app/Functions/Functions.php:1293
 msgctxt "(a man’s) sister’s son’s son"
 msgid "great-nephew"
-msgstr ""
+msgstr "증조카"
 
 #: app/Functions/Functions.php:932
 msgctxt "(a woman’s) brother’s child’s son"
 msgid "great-nephew"
-msgstr ""
+msgstr "증조카"
 
 #: app/Functions/Functions.php:952
 msgctxt "(a woman’s) brother’s daughter’s son"
 msgid "great-nephew"
-msgstr ""
+msgstr "증조카"
 
 #: app/Functions/Functions.php:970
 msgctxt "(a woman’s) brother’s son’s son"
 msgid "great-nephew"
-msgstr ""
+msgstr "증조카"
 
 #: app/Functions/Functions.php:1252
 msgctxt "(a woman’s) sister’s child’s son"
 msgid "great-nephew"
-msgstr ""
+msgstr "증조카"
 
 #: app/Functions/Functions.php:1272
 msgctxt "(a woman’s) sister’s daughter’s son"
 msgid "great-nephew"
-msgstr ""
+msgstr "증조카"
 
 #: app/Functions/Functions.php:1296
 msgctxt "(a woman’s) sister’s son’s son"
 msgid "great-nephew"
-msgstr ""
+msgstr "증조카"
 
 #: app/Functions/Functions.php:1218
 msgctxt "sibling’s child’s son"
 msgid "great-nephew"
-msgstr ""
+msgstr "증조카"
 
 #: app/Functions/Functions.php:1226
 msgctxt "sibling’s daughter’s son"
 msgid "great-nephew"
-msgstr ""
+msgstr "증조카"
 
 #: app/Functions/Functions.php:1232
 msgctxt "sibling’s son’s son"
 msgid "great-nephew"
-msgstr ""
+msgstr "증조카"
 
 #: app/Functions/Functions.php:917
 msgctxt "(a man’s) brother’s child’s child"
 msgid "great-nephew/niece"
-msgstr ""
+msgstr "증조카/조카딸"
 
 #: app/Functions/Functions.php:935
 msgctxt "(a man’s) brother’s daughter’s child"
 msgid "great-nephew/niece"
-msgstr ""
+msgstr "증조카/조카딸"
 
 #: app/Functions/Functions.php:955
 msgctxt "(a man’s) brother’s son’s child"
 msgid "great-nephew/niece"
-msgstr ""
+msgstr "증조카/조카딸"
 
 #: app/Functions/Functions.php:1237
 msgctxt "(a man’s) sister’s child’s child"
 msgid "great-nephew/niece"
-msgstr ""
+msgstr "증조카/조카딸"
 
 #: app/Functions/Functions.php:1255
 msgctxt "(a man’s) sister’s daughter’s child"
 msgid "great-nephew/niece"
-msgstr ""
+msgstr "증조카/조카딸"
 
 #: app/Functions/Functions.php:1281
 msgctxt "(a man’s) sister’s son’s child"
 msgid "great-nephew/niece"
-msgstr ""
+msgstr "증조카/조카딸"
 
 #: app/Functions/Functions.php:920
 msgctxt "(a woman’s) brother’s child’s child"
 msgid "great-nephew/niece"
-msgstr ""
+msgstr "증조카/조카딸"
 
 #: app/Functions/Functions.php:938
 msgctxt "(a woman’s) brother’s daughter’s child"
 msgid "great-nephew/niece"
-msgstr ""
+msgstr "증조카/조카딸"
 
 #: app/Functions/Functions.php:958
 msgctxt "(a woman’s) brother’s son’s child"
 msgid "great-nephew/niece"
-msgstr ""
+msgstr "증조카/조카딸"
 
 #: app/Functions/Functions.php:1240
 msgctxt "(a woman’s) sister’s child’s child"
 msgid "great-nephew/niece"
-msgstr ""
+msgstr "증조카/조카딸"
 
 #: app/Functions/Functions.php:1258
 msgctxt "(a woman’s) sister’s daughter’s child"
 msgid "great-nephew/niece"
-msgstr ""
+msgstr "증조카/조카딸"
 
 #: app/Functions/Functions.php:1284
 msgctxt "(a woman’s) sister’s son’s child"
 msgid "great-nephew/niece"
-msgstr ""
+msgstr "증조카/조카딸"
 
 #: app/Functions/Functions.php:1214
 msgctxt "sibling’s child’s child"
 msgid "great-nephew/niece"
-msgstr ""
+msgstr "증조카/조카딸"
 
 #: app/Functions/Functions.php:1220
 msgctxt "sibling’s daughter’s child"
 msgid "great-nephew/niece"
-msgstr ""
+msgstr "증조카/조카딸"
 
 #: app/Functions/Functions.php:1228
 msgctxt "sibling’s son’s child"
 msgid "great-nephew/niece"
-msgstr ""
+msgstr "증조카/조카딸"
 
 #: app/Functions/Functions.php:923
 msgctxt "(a man’s) brother’s child’s daughter"
 msgid "great-niece"
-msgstr ""
+msgstr "증조카딸"
 
 #: app/Functions/Functions.php:941
 msgctxt "(a man’s) brother’s daughter’s daughter"
 msgid "great-niece"
-msgstr ""
+msgstr "증조카딸"
 
 #: app/Functions/Functions.php:961
 msgctxt "(a man’s) brother’s son’s daughter"
 msgid "great-niece"
-msgstr ""
+msgstr "증조카딸"
 
 #: app/Functions/Functions.php:1243
 msgctxt "(a man’s) sister’s child’s daughter"
 msgid "great-niece"
-msgstr ""
+msgstr "증조카딸"
 
 #: app/Functions/Functions.php:1261
 msgctxt "(a man’s) sister’s daughter’s daughter"
 msgid "great-niece"
-msgstr ""
+msgstr "증조카딸"
 
 #: app/Functions/Functions.php:1287
 msgctxt "(a man’s) sister’s son’s daughter"
 msgid "great-niece"
-msgstr ""
+msgstr "증조카딸"
 
 #: app/Functions/Functions.php:926
 msgctxt "(a woman’s) brother’s child’s daughter"
 msgid "great-niece"
-msgstr ""
+msgstr "증조카딸"
 
 #: app/Functions/Functions.php:944
 msgctxt "(a woman’s) brother’s daughter’s daughter"
 msgid "great-niece"
-msgstr ""
+msgstr "증조카딸"
 
 #: app/Functions/Functions.php:964
 msgctxt "(a woman’s) brother’s son’s daughter"
 msgid "great-niece"
-msgstr ""
+msgstr "증조카딸"
 
 #: app/Functions/Functions.php:1246
 msgctxt "(a woman’s) sister’s child’s daughter"
 msgid "great-niece"
-msgstr ""
+msgstr "증조카딸"
 
 #: app/Functions/Functions.php:1264
 msgctxt "(a woman’s) sister’s daughter’s daughter"
 msgid "great-niece"
-msgstr ""
+msgstr "증조카딸"
 
 #: app/Functions/Functions.php:1290
 msgctxt "(a woman’s) sister’s son’s daughter"
 msgid "great-niece"
-msgstr ""
+msgstr "증조카딸"
 
 #: app/Functions/Functions.php:1216
 msgctxt "sibling’s child’s daughter"
 msgid "great-niece"
-msgstr ""
+msgstr "증조카딸"
 
 #: app/Functions/Functions.php:1222
 msgctxt "sibling’s daughter’s daughter"
 msgid "great-niece"
-msgstr ""
+msgstr "증조카딸"
 
 #: app/Functions/Functions.php:1230
 msgctxt "sibling’s son’s daughter"
 msgid "great-niece"
-msgstr ""
+msgstr "증조카딸"
 
 #: app/Functions/Functions.php:1038
 msgctxt "father’s father’s brother"
 msgid "great-uncle"
-msgstr ""
+msgstr "증숙부"
 
 #: app/Functions/Functions.php:1356
 msgctxt "father’s father’s sister’s husband"
 msgid "great-uncle"
-msgstr ""
+msgstr "증숙부"
 
 #: app/Functions/Functions.php:1050
 msgctxt "father’s mother’s brother"
 msgid "great-uncle"
-msgstr ""
+msgstr "증숙부"
 
 #: app/Functions/Functions.php:1362
 msgctxt "father’s mother’s sister’s husband"
 msgid "great-uncle"
-msgstr ""
+msgstr "증숙부"
 
 #: app/Functions/Functions.php:1062
 msgctxt "father’s parent’s brother"
 msgid "great-uncle"
-msgstr ""
+msgstr "증숙부"
 
 #: app/Functions/Functions.php:1368
 msgctxt "father’s parent’s sister’s husband"
 msgid "great-uncle"
-msgstr ""
+msgstr "증숙부"
 
 #: app/Functions/Functions.php:1118
 msgctxt "mother’s father’s brother"
 msgid "great-uncle"
-msgstr ""
+msgstr "증숙부"
 
 #: app/Functions/Functions.php:1374
 msgctxt "mother’s father’s sister’s husband"
 msgid "great-uncle"
-msgstr ""
+msgstr "증숙부"
 
 #: app/Functions/Functions.php:1136
 msgctxt "mother’s mother’s brother"
 msgid "great-uncle"
-msgstr ""
+msgstr "증숙부"
 
 #: app/Functions/Functions.php:1380
 msgctxt "mother’s mother’s sister’s husband"
 msgid "great-uncle"
-msgstr ""
+msgstr "증숙부"
 
 #: app/Functions/Functions.php:1148
 msgctxt "mother’s parent’s brother"
 msgid "great-uncle"
-msgstr ""
+msgstr "증숙부"
 
 #: app/Functions/Functions.php:1386
 msgctxt "mother’s parent’s sister’s husband"
 msgid "great-uncle"
-msgstr ""
+msgstr "증숙부"
 
 #: app/Functions/Functions.php:1170
 msgctxt "parent’s father’s brother"
 msgid "great-uncle"
-msgstr ""
+msgstr "증숙부"
 
 #: app/Functions/Functions.php:1392
 msgctxt "parent’s father’s sister’s husband"
 msgid "great-uncle"
-msgstr ""
+msgstr "증숙부"
 
 #: app/Functions/Functions.php:1182
 msgctxt "parent’s mother’s brother"
 msgid "great-uncle"
-msgstr ""
+msgstr "증숙부"
 
 #: app/Functions/Functions.php:1398
 msgctxt "parent’s mother’s sister’s husband"
 msgid "great-uncle"
-msgstr ""
+msgstr "증숙부"
 
 #: app/Functions/Functions.php:1194
 msgctxt "parent’s parent’s brother"
 msgid "great-uncle"
-msgstr ""
+msgstr "증숙부"
 
 #: app/Functions/Functions.php:1404
 msgctxt "parent’s parent’s sister’s husband"
 msgid "great-uncle"
-msgstr ""
+msgstr "증숙부"
 
 #. I18N: layout option for the fan chart
 #: app/Module/FanChartModule.php:575
@@ -18698,7 +18699,7 @@ msgstr ""
 #. I18N: reflexive pronoun
 #: app/Functions/Functions.php:190
 msgid "herself"
-msgstr ""
+msgstr "그녀 자신"
 
 #. I18N: Examples of valid time formats (hours:minutes:seconds)
 #: app/Functions/FunctionsEdit.php:583
@@ -18713,54 +18714,54 @@ msgstr ""
 #: resources/views/admin/trees-preferences.phtml:638
 #: resources/views/admin/trees-preferences.phtml:653
 msgid "hide"
-msgstr ""
+msgstr "숨김"
 
 #. I18N: reflexive pronoun
 #: app/Functions/Functions.php:187
 msgid "himself"
-msgstr ""
+msgstr "그 자신"
 
 #: app/Functions/Functions.php:629
 msgid "husband"
-msgstr ""
+msgstr "남편"
 
 #. I18N: A name taken on immigration - e.g. migrants to the USA frequently anglicized their names
 #: app/GedcomCode/GedcomCodeName.php:143
 msgid "immigration name"
-msgstr ""
+msgstr "이민 이름"
 
 #. I18N: A name taken on immigration - e.g. migrants to the USA frequently anglicized their names
 #: app/GedcomCode/GedcomCodeName.php:139
 msgctxt "FEMALE"
 msgid "immigration name"
-msgstr ""
+msgstr "이민 이름"
 
 #. I18N: A name taken on immigration - e.g. migrants to the USA frequently anglicized their names
 #: app/GedcomCode/GedcomCodeName.php:134
 msgctxt "MALE"
 msgid "immigration name"
-msgstr ""
+msgstr "이민 이름"
 
 #. I18N: A button label.
 #: resources/views/admin/locations.phtml:141
 msgid "import"
-msgstr ""
+msgstr "가져오기"
 
 #. I18N: A button label.
 #: resources/views/admin/locations.phtml:120
 msgid "import file"
-msgstr ""
+msgstr "파일 가져오기"
 
 #. I18N: Gedcom INT dates
 #: app/Date.php:353
 #, php-format
 msgid "interpreted %s (%s)"
-msgstr ""
+msgstr "해석 된 %s (%s)"
 
 #: resources/views/search-general-page.phtml:92
 #: resources/views/search-phonetic-page.phtml:93
 msgid "invert selection"
-msgstr ""
+msgstr "반전 선택"
 
 #. I18N: a month in the French republican calendar
 #: app/Date/FrenchDate.php:159
@@ -18792,16 +18793,16 @@ msgstr ""
 #: resources/views/modules/media-list/page.phtml:103
 #: resources/views/modules/media-list/page.phtml:202
 msgid "last"
-msgstr ""
+msgstr "마지막"
 
 #: resources/views/admin/trees-preferences.phtml:584
 msgctxt "Show the [first/last] [N] parts of a place name."
 msgid "last"
-msgstr ""
+msgstr "마지막"
 
 #: resources/views/modules/pedigree-chart/page.phtml:37
 msgid "left"
-msgstr ""
+msgstr "왼쪽"
 
 #. I18N: Layout option for lists of names
 #. I18N: An option in a list-box
@@ -18811,17 +18812,17 @@ msgstr ""
 #: app/Module/UpcomingAnniversariesModule.php:268
 #: app/Module/YahrzeitModule.php:252
 msgid "list"
-msgstr ""
+msgstr "목록"
 
 #: app/Http/Controllers/Admin/LocationController.php:772
 #, php-format
 msgid "locations updated: %s, locations added: %s"
-msgstr ""
+msgstr "업데이트 된 위치 : %s, 추가 된 위치 : %s "
 
 #. I18N: A woman’s name, before she marries (in cultures where women take their new husband’s name on marriage)
 #: app/GedcomCode/GedcomCodeName.php:148
 msgid "maiden name"
-msgstr ""
+msgstr "결혼 전의 이름"
 
 #: resources/views/admin/trees-privacy.phtml:130
 msgid "managers"
@@ -18830,58 +18831,58 @@ msgstr ""
 #. I18N: https://en.wikipedia.org/wiki/Markdown
 #: app/Http/Controllers/AdminTreesController.php:747
 msgid "markdown"
-msgstr ""
+msgstr "마크다운"
 
 #: app/Statistics/Repository/EventRepository.php:325
 msgid "marriage"
-msgstr ""
+msgstr "결혼"
 
 #: resources/xml/reports/descendancy_report.xml:245
 msgctxt "FEMALE"
 msgid "married"
-msgstr ""
+msgstr "결혼"
 
 #: resources/xml/reports/descendancy_report.xml:176
 msgctxt "MALE"
 msgid "married"
-msgstr ""
+msgstr "결혼"
 
 #. I18N: A name taken on marriage - usually the wife takes the husband’s surname
 #: app/GedcomCode/GedcomCodeName.php:162
 msgid "married name"
-msgstr ""
+msgstr "결혼 후 이름"
 
 #. I18N: A name taken on marriage - usually the wife takes the husband’s surname
 #: app/GedcomCode/GedcomCodeName.php:158
 msgctxt "FEMALE"
 msgid "married name"
-msgstr ""
+msgstr "결혼 후 이름"
 
 #. I18N: A name taken on marriage - usually the wife takes the husband’s surname
 #: app/GedcomCode/GedcomCodeName.php:153
 msgctxt "MALE"
 msgid "married name"
-msgstr ""
+msgstr "결혼 후 이름"
 
 #: app/Functions/Functions.php:822
 msgctxt "mother’s father"
 msgid "maternal grandfather"
-msgstr ""
+msgstr "외조부"
 
 #: app/Functions/Functions.php:826
 msgctxt "mother’s mother"
 msgid "maternal grandmother"
-msgstr ""
+msgstr "외조모"
 
 #: app/Functions/Functions.php:828
 msgctxt "mother’s parent"
 msgid "maternal grandparent"
-msgstr ""
+msgstr "외조부모"
 
 #. I18N: A system where children take their mother’s surname
 #: app/SurnameTradition.php:88
 msgid "matrilineal"
-msgstr ""
+msgstr "모계"
 
 #: resources/views/modules/recent_changes/config.phtml:13
 #: resources/views/modules/upcoming_events/config.phtml:13
@@ -18889,7 +18890,7 @@ msgstr ""
 #, php-format
 msgid "maximum %s day"
 msgid_plural "maximum %s days"
-msgstr[0] ""
+msgstr[0] "최대 %s 일"
 
 #: resources/views/admin/trees-privacy.phtml:26
 #: resources/views/admin/trees-privacy.phtml:45
@@ -18897,7 +18898,7 @@ msgstr[0] ""
 #: resources/views/admin/trees-privacy.phtml:129
 #: resources/views/admin/trees-privacy.phtml:149
 msgid "members"
-msgstr ""
+msgstr "회원"
 
 #. I18N: Name of a theme.
 #: app/Module/MinimalTheme.php:39
@@ -18906,136 +18907,136 @@ msgstr ""
 
 #: app/Functions/Functions.php:615
 msgid "mother"
-msgstr ""
+msgstr "어머니"
 
 #: app/Functions/Functions.php:808
 msgctxt "husband’s mother"
 msgid "mother-in-law"
-msgstr ""
+msgstr "시어머니"
 
 #: app/Functions/Functions.php:888
 msgctxt "spouse’s mother"
 msgid "mother-in-law"
-msgstr ""
+msgstr "배우자의 어머니"
 
 #: app/Functions/Functions.php:906
 msgctxt "wife’s mother"
 msgid "mother-in-law"
-msgstr ""
+msgstr "장모"
 
 #: app/Functions/Functions.php:894
 msgctxt "spouse’s parent"
 msgid "mother/father-in-law"
-msgstr ""
+msgstr "배우자의 부모"
 
 #: app/Functions/Functions.php:756
 msgctxt "brother’s son"
 msgid "nephew"
-msgstr ""
+msgstr "조카"
 
 #: app/Functions/Functions.php:1108
 msgctxt "husband’s brother’s son"
 msgid "nephew"
-msgstr ""
+msgstr "조카"
 
 #: app/Functions/Functions.php:1104
 msgctxt "husband’s sibling’s son"
 msgid "nephew"
-msgstr ""
+msgstr "조카"
 
 #: app/Functions/Functions.php:1106
 msgctxt "husband’s sister’s son"
 msgid "nephew"
-msgstr ""
+msgstr "조카"
 
 #: app/Functions/Functions.php:860
 msgctxt "sibling’s son"
 msgid "nephew"
-msgstr ""
+msgstr "조카"
 
 #: app/Functions/Functions.php:870
 msgctxt "sister’s son"
 msgid "nephew"
-msgstr ""
+msgstr "조카"
 
 #: app/Functions/Functions.php:1348
 msgctxt "wife’s brother’s son"
 msgid "nephew"
-msgstr ""
+msgstr 조카""
 
 #: app/Functions/Functions.php:1344
 msgctxt "wife’s sibling’s son"
 msgid "nephew"
-msgstr ""
+msgstr "조카"
 
 #: app/Functions/Functions.php:1346
 msgctxt "wife’s sister’s son"
 msgid "nephew"
-msgstr ""
+msgstr "조카"
 
 #: app/Functions/Functions.php:946
 msgctxt "brother’s daughter’s husband"
 msgid "nephew-in-law"
-msgstr ""
+msgstr "조카사위"
 
 #: app/Functions/Functions.php:1224
 msgctxt "sibling’s daughter’s husband"
 msgid "nephew-in-law"
-msgstr ""
+msgstr "조카사위"
 
 #: app/Functions/Functions.php:1266
 msgctxt "sisters’s daughter’s husband"
 msgid "nephew-in-law"
-msgstr ""
+msgstr "조카사위"
 
 #: app/Functions/Functions.php:752
 msgctxt "brother’s child"
 msgid "nephew/niece"
-msgstr ""
+msgstr "조카"
 
 #: app/Functions/Functions.php:1096
 msgctxt "husband’s brother’s child"
 msgid "nephew/niece"
-msgstr ""
+msgstr "조카"
 
 #: app/Functions/Functions.php:1092
 msgctxt "husband’s sibling’s child"
 msgid "nephew/niece"
-msgstr ""
+msgstr "조카"
 
 #: app/Functions/Functions.php:1094
 msgctxt "husband’s sister’s child"
 msgid "nephew/niece"
-msgstr ""
+msgstr "조카"
 
 #: app/Functions/Functions.php:856
 msgctxt "sibling’s child"
 msgid "nephew/niece"
-msgstr ""
+msgstr "조카"
 
 #: app/Functions/Functions.php:864
 msgctxt "sister’s child"
 msgid "nephew/niece"
-msgstr ""
+msgstr "조카"
 
 #: app/Functions/Functions.php:1336
 msgctxt "wife’s brother’s child"
 msgid "nephew/niece"
-msgstr ""
+msgstr "조카"
 
 #: app/Functions/Functions.php:1332
 msgctxt "wife’s sibling’s child"
 msgid "nephew/niece"
-msgstr ""
+msgstr "조카"
 
 #: app/Functions/Functions.php:1334
 msgctxt "wife’s sister’s child"
 msgid "nephew/niece"
-msgstr ""
+msgstr "조카"
 
 #: app/Functions/FunctionsEdit.php:587
 msgid "never"
-msgstr ""
+msgstr "할수없음"
 
 #. I18N: A button label, next page
 #: resources/views/admin/data-fix-select.phtml:49
@@ -19060,77 +19061,77 @@ msgstr "다음"
 #: app/Functions/Functions.php:754
 msgctxt "brother’s daughter"
 msgid "niece"
-msgstr ""
+msgstr "조카딸"
 
 #: app/Functions/Functions.php:1102
 msgctxt "husband’s brother’s daughter"
 msgid "niece"
-msgstr ""
+msgstr "조카딸"
 
 #: app/Functions/Functions.php:1098
 msgctxt "husband’s sibling’s daughter"
 msgid "niece"
-msgstr ""
+msgstr "조카딸"
 
 #: app/Functions/Functions.php:1100
 msgctxt "husband’s sister’s daughter"
 msgid "niece"
-msgstr ""
+msgstr "조카딸"
 
 #: app/Functions/Functions.php:858
 msgctxt "sibling’s daughter"
 msgid "niece"
-msgstr ""
+msgstr "조카딸"
 
 #: app/Functions/Functions.php:866
 msgctxt "sister’s daughter"
 msgid "niece"
-msgstr ""
+msgstr "조카딸"
 
 #: app/Functions/Functions.php:1342
 msgctxt "wife’s brother’s daughter"
 msgid "niece"
-msgstr ""
+msgstr "조카딸"
 
 #: app/Functions/Functions.php:1338
 msgctxt "wife’s sibling’s daughter"
 msgid "niece"
-msgstr ""
+msgstr "조카딸"
 
 #: app/Functions/Functions.php:1340
 msgctxt "wife’s sister’s daughter"
 msgid "niece"
-msgstr ""
+msgstr "조카딸"
 
 #: app/Functions/Functions.php:972
 msgctxt "brother’s son’s wife"
 msgid "niece-in-law"
-msgstr ""
+msgstr "조카며느리"
 
 #: app/Functions/Functions.php:1234
 msgctxt "sibling’s son’s wife"
 msgid "niece-in-law"
-msgstr ""
+msgstr 조카며느리""
 
 #: app/Functions/Functions.php:1298
 msgctxt "sisters’s son’s wife"
 msgid "niece-in-law"
-msgstr ""
+msgstr "조카며느리"
 
 #: app/Functions/Functions.php:478
 msgid "ninth cousin"
-msgstr ""
+msgstr "9번째 사촌"
 
 #: app/Functions/Functions.php:442
 msgctxt "FEMALE"
 msgid "ninth cousin"
-msgstr ""
+msgstr "9번째 사촌"
 
 #. I18N: Note that for Italian and Polish, “N’th cousins” are different from English “N’th cousins”, and the software has already generated the correct “N” for your language. You only need to translate - you do not need to convert. For other languages, if your cousin rules are different from English, please contact the developers.
 #: app/Functions/Functions.php:398
 msgctxt "MALE"
 msgid "ninth cousin"
-msgstr ""
+msgstr "9번째 사촌"
 
 #: app/Functions/FunctionsEdit.php:179 app/Functions/FunctionsEdit.php:213
 #: app/Http/Controllers/Admin/UsersController.php:190
@@ -19182,11 +19183,11 @@ msgstr "없음"
 #: app/SurnameTradition.php:114
 msgctxt "Surname tradition"
 msgid "none"
-msgstr ""
+msgstr "없음"
 
 #: resources/views/modules/statistics-chart/custom.phtml:118
 msgid "numbers"
-msgstr ""
+msgstr "번호"
 
 #: resources/xml/reports/ahnentafel_report.xml:56
 #: resources/xml/reports/bdm_report.xml:42
@@ -19202,63 +19203,63 @@ msgstr ""
 #: resources/xml/reports/occupation_report.xml:38
 #: resources/xml/reports/relative_ext_report.xml:44
 msgid "of"
-msgstr ""
+msgstr "의"
 
 #: app/Functions/FunctionsPrint.php:278
 msgid "on the date of death"
-msgstr ""
+msgstr "사망일에"
 
 #: app/Functions/Functions.php:619
 msgid "parent"
-msgstr ""
+msgstr "부모"
 
 #: app/Functions/Functions.php:679
 msgid "partner"
-msgstr ""
+msgstr "파트너"
 
 #: app/Functions/Functions.php:659
 msgctxt "FEMALE"
 msgid "partner"
-msgstr ""
+msgstr "파트너"
 
 #: app/Functions/Functions.php:639
 msgctxt "MALE"
 msgid "partner"
-msgstr ""
+msgstr "파트너"
 
 #: app/SurnameTradition.php:77
 msgctxt "Surname tradition"
 msgid "paternal"
-msgstr ""
+msgstr "아버지"
 
 #: app/Functions/Functions.php:786
 msgctxt "father’s father"
 msgid "paternal grandfather"
-msgstr ""
+msgstr "친할아버지"
 
 #: app/Functions/Functions.php:788
 msgctxt "father’s mother"
 msgid "paternal grandmother"
-msgstr ""
+msgstr "친할머니"
 
 #: app/Functions/Functions.php:790
 msgctxt "father’s parent"
 msgid "paternal grandparent"
-msgstr ""
+msgstr "친조부모"
 
 #. I18N: A system where children take their father’s surname
 #: app/SurnameTradition.php:84
 msgid "patrilineal"
-msgstr ""
+msgstr "부계"
 
 #. I18N: the status of an edit accepted/rejected/pending
 #: app/Http/RequestHandlers/PendingChangesLogPage.php:126
 msgid "pending"
-msgstr ""
+msgstr "보류 중"
 
 #: resources/views/modules/statistics-chart/custom.phtml:123
 msgid "percentage"
-msgstr ""
+msgstr "백분율"
 
 #. I18N: A button label, previous page
 #: resources/views/individual-page.phtml:75
@@ -19281,17 +19282,17 @@ msgstr "이전"
 #. I18N: Quality of source information - GEDCOM tag “QUAY 3”
 #: app/GedcomCode/GedcomCodeQuay.php:49
 msgid "primary evidence"
-msgstr ""
+msgstr "주요 증거"
 
 #. I18N: Quality of source information - GEDCOM tag “QUAY 1”
 #: app/GedcomCode/GedcomCodeQuay.php:55
 msgid "questionable evidence"
-msgstr ""
+msgstr "의심스러운 증거"
 
 #: app/Http/Controllers/AdminTreesController.php:753
 #: resources/xml/reports/fact_sources.xml:6
 msgid "records"
-msgstr ""
+msgstr "자료"
 
 #: resources/views/family-page.phtml:22
 #: resources/views/gedcom-record-page.phtml:20
@@ -19300,7 +19301,7 @@ msgstr ""
 #: resources/views/source-page.phtml:21 resources/views/submitter-page.phtml:20
 msgctxt "You should review the changes and then accept or reject them."
 msgid "reject"
-msgstr ""
+msgstr "거절"
 
 #: resources/views/family-page.phtml:16
 #: resources/views/gedcom-record-page.phtml:14
@@ -19309,34 +19310,34 @@ msgstr ""
 #: resources/views/source-page.phtml:15 resources/views/submitter-page.phtml:14
 msgctxt "You should review the deletion and then accept or reject it."
 msgid "reject"
-msgstr ""
+msgstr "거절"
 
 #. I18N: the status of an edit accepted/rejected/pending
 #: app/Http/RequestHandlers/PendingChangesLogPage.php:124
 msgid "rejected"
-msgstr ""
+msgstr "거부"
 
 #. I18N: A name taken when entering a religion or a religious order
 #: app/GedcomCode/GedcomCodeName.php:176
 msgid "religious name"
-msgstr ""
+msgstr "종교적인 이름"
 
 #. I18N: A name taken when entering a religion or a religious order
 #: app/GedcomCode/GedcomCodeName.php:172
 msgctxt "FEMALE"
 msgid "religious name"
-msgstr ""
+msgstr "종교적인 이름"
 
 #. I18N: A name taken when entering a religion or a religious order
 #: app/GedcomCode/GedcomCodeName.php:167
 msgctxt "MALE"
 msgid "religious name"
-msgstr ""
+msgstr "종교적인 이름"
 
 #. I18N: A button label.
 #: resources/views/search-replace-page.phtml:44
 msgid "replace"
-msgstr ""
+msgstr "바꾸다"
 
 #. I18N: A button label.
 #: resources/views/admin/changes-log.phtml:87
@@ -19345,11 +19346,11 @@ msgstr ""
 #: resources/views/modules/media-list/page.phtml:65
 #: resources/views/modules/timeline-chart/page.phtml:30
 msgid "reset"
-msgstr ""
+msgstr "리셋"
 
 #: resources/views/modules/pedigree-chart/page.phtml:37
 msgid "right"
-msgstr ""
+msgstr "오른쪽"
 
 #. I18N: A button label.
 #: resources/views/admin/analytics-edit.phtml:31
@@ -19392,7 +19393,7 @@ msgstr ""
 #: resources/views/modules/stories/edit.phtml:60
 #: resources/views/modules/user_blog/edit.phtml:42
 msgid "save"
-msgstr ""
+msgstr "저장"
 
 #. I18N: A button label.
 #: resources/views/admin/changes-log.phtml:82
@@ -19402,213 +19403,213 @@ msgstr ""
 #: resources/views/search-general-page.phtml:105
 #: resources/views/search-phonetic-page.phtml:106
 msgid "search"
-msgstr ""
+msgstr "검색"
 
 #. I18N: A Spanish relationship name, such as third great-nephew
 #: app/Functions/Functions.php:560
 #, php-format
 msgid "second %s"
-msgstr ""
+msgstr "두 번째 %s"
 
 #. I18N: A Spanish relationship name, such as third great-nephew
 #: app/Functions/Functions.php:538
 #, php-format
 msgctxt "FEMALE"
 msgid "second %s"
-msgstr ""
+msgstr "두 번째 %s"
 
 #. I18N: A Spanish relationship name, such as third great-nephew
 #: app/Functions/Functions.php:515
 #, php-format
 msgctxt "MALE"
 msgid "second %s"
-msgstr ""
+msgstr "두 번째 %s"
 
 #: app/Functions/Functions.php:464
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:428
 msgctxt "FEMALE"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #. I18N: Note that for Italian and Polish, “N’th cousins” are different from English “N’th cousins”, and the software has already generated the correct “N” for your language. You only need to translate - you do not need to convert. For other languages, if your cousin rules are different from English, please contact the developers.
 #: app/Functions/Functions.php:377
 msgctxt "MALE"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1465
 msgctxt "grandfather’s brother’s grandchild"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1457
 msgctxt "grandfather’s brother’s granddaughter"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1461
 msgctxt "grandfather’s brother’s grandson"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1489
 msgctxt "grandfather’s sibling’s grandchild"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1481
 msgctxt "grandfather’s sibling’s granddaughter"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1485
 msgctxt "grandfather’s sibling’s grandson"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1477
 msgctxt "grandfather’s sister’s grandchild"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1469
 msgctxt "grandfather’s sister’s granddaughter"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1473
 msgctxt "grandfather’s sister’s grandson"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1501
 msgctxt "grandmother’s brother’s grandchild"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1493
 msgctxt "grandmother’s brother’s granddaughter"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1497
 msgctxt "grandmother’s brother’s grandson"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1525
 msgctxt "grandmother’s sibling’s grandchild"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1517
 msgctxt "grandmother’s sibling’s granddaughter"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1521
 msgctxt "grandmother’s sibling’s grandson"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1513
 msgctxt "grandmother’s sister’s grandchild"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1505
 msgctxt "grandmother’s sister’s granddaughter"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1509
 msgctxt "grandmother’s sister’s grandson"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1537
 msgctxt "grandparent’s brother’s grandchild"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1529
 msgctxt "grandparent’s brother’s granddaughter"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1533
 msgctxt "grandparent’s brother’s grandson"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1561
 msgctxt "grandparent’s sibling’s grandchild"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1553
 msgctxt "grandparent’s sibling’s granddaughter"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1557
 msgctxt "grandparent’s sibling’s grandson"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1549
 msgctxt "grandparent’s sister’s grandchild"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1541
 msgctxt "grandparent’s sister’s granddaughter"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #: app/Functions/Functions.php:1545
 msgctxt "grandparent’s sister’s grandson"
 msgid "second cousin"
-msgstr ""
+msgstr "두 번째 사촌"
 
 #. I18N: Quality of source information - GEDCOM tag “QUAY 2”
 #: app/GedcomCode/GedcomCodeQuay.php:52
 msgid "secondary evidence"
-msgstr ""
+msgstr "2차 증거"
 
 #. I18N: select all (of the family trees)
 #: resources/views/search-general-page.phtml:89
 #: resources/views/search-phonetic-page.phtml:90
 msgid "select all"
-msgstr ""
+msgstr "모두 선택"
 
 #. I18N: select none (of the family trees)
 #: resources/views/search-general-page.phtml:90
 #: resources/views/search-phonetic-page.phtml:91
 msgid "select none"
-msgstr ""
+msgstr "선택 없음"
 
 #: app/Functions/Functions.php:612
 msgid "self"
-msgstr ""
+msgstr "본인"
 
 #: app/Functions/Functions.php:474
 msgid "seventh cousin"
-msgstr ""
+msgstr "7번째 사촌"
 
 #: app/Functions/Functions.php:438
 msgctxt "FEMALE"
 msgid "seventh cousin"
-msgstr ""
+msgstr "7번째 사촌"
 
 #. I18N: Note that for Italian and Polish, “N’th cousins” are different from English “N’th cousins”, and the software has already generated the correct “N” for your language. You only need to translate - you do not need to convert. For other languages, if your cousin rules are different from English, please contact the developers.
 #: app/Functions/Functions.php:392
 msgctxt "MALE"
 msgid "seventh cousin"
-msgstr ""
+msgstr "7번째 사촌"
 
 #: resources/views/admin/trees-preferences.phtml:290
 #: resources/views/admin/trees-preferences.phtml:370
@@ -19620,22 +19621,22 @@ msgstr ""
 #: resources/views/modules/faq/config.phtml:26
 #: resources/views/modules/stories/config.phtml:21
 msgid "show"
-msgstr ""
+msgstr "보기"
 
 #. I18N: button label
 #: resources/views/lists/anniversaries-list.phtml:23
 #: resources/views/modules/recent_changes/changes-list.phtml:21
 #: resources/views/modules/yahrzeit/list.phtml:20
 msgid "show more"
-msgstr ""
+msgstr "자세히보기"
 
 #: resources/views/modules/statistics-chart/custom.phtml:200
 msgid "show the chart"
-msgstr ""
+msgstr "차트 보기"
 
 #: app/Functions/Functions.php:748
 msgid "sibling"
-msgstr ""
+msgstr "형제"
 
 #. I18N: A button label.
 #: resources/views/login-page.phtml:56
@@ -19650,95 +19651,95 @@ msgstr "로그아웃"
 
 #: app/Functions/Functions.php:727
 msgid "sister"
-msgstr ""
+msgstr "여자형제"
 
 #: app/Functions/Functions.php:758
 msgctxt "brother’s wife"
 msgid "sister-in-law"
-msgstr ""
+msgstr "형수/제수"
 
 #: app/Functions/Functions.php:978
 msgctxt "brother’s wife’s sister"
 msgid "sister-in-law"
-msgstr ""
+msgstr "매부"
 
 #: app/Functions/Functions.php:1088
 msgctxt "husband’s brother’s wife"
 msgid "sister-in-law"
-msgstr ""
+msgstr "동서"
 
 #: app/Functions/Functions.php:812
 msgctxt "husband’s sister"
 msgid "sister-in-law"
-msgstr ""
+msgstr "시누"
 
 #: app/Functions/Functions.php:1278
 msgctxt "sister’s husband’s sister"
 msgid "sister-in-law"
-msgstr ""
+msgstr "여자형제 남편의 여자형제"
 
 #: app/Functions/Functions.php:890
 msgctxt "spouse’s sister"
 msgid "sister-in-law"
-msgstr ""
+msgstr "배우자의 여자형제"
 
 #: app/Functions/Functions.php:1328
 msgctxt "wife’s brother’s wife"
 msgid "sister-in-law"
-msgstr ""
+msgstr "부인의 남자형제의 부인"
 
 #: app/Functions/Functions.php:910
 msgctxt "wife’s sister"
 msgid "sister-in-law"
-msgstr ""
+msgstr "처제"
 
 #: app/Functions/Functions.php:472
 msgid "sixth cousin"
-msgstr ""
+msgstr "6번째 사촌"
 
 #: app/Functions/Functions.php:436
 msgctxt "FEMALE"
 msgid "sixth cousin"
-msgstr ""
+msgstr "6번째 사촌"
 
 #. I18N: Note that for Italian and Polish, “N’th cousins” are different from English “N’th cousins”, and the software has already generated the correct “N” for your language. You only need to translate - you do not need to convert. For other languages, if your cousin rules are different from English, please contact the developers.
 #: app/Functions/Functions.php:389
 msgctxt "MALE"
 msgid "sixth cousin"
-msgstr ""
+msgstr "6번째 사촌"
 
 #: app/Functions/Functions.php:681
 msgid "son"
-msgstr ""
+msgstr "아들"
 
 #: resources/xml/reports/descendancy_report.xml:295
 msgid "son of"
-msgstr ""
+msgstr "~의 아들"
 
 #: app/Functions/Functions.php:764
 msgctxt "child’s husband"
 msgid "son-in-law"
-msgstr ""
+msgstr "사위"
 
 #: app/Functions/Functions.php:776
 msgctxt "daughter’s husband"
 msgid "son-in-law"
-msgstr ""
+msgstr "사위"
 
 #: app/Functions/Functions.php:1016
 msgctxt "daughter’s husband’s father"
 msgid "son-in-law’s father"
-msgstr ""
+msgstr "사돈"
 
 #: app/Functions/Functions.php:1018
 msgctxt "daughter’s husband’s mother"
 msgid "son-in-law’s mother"
-msgstr ""
+msgstr "사돈"
 
 #: app/Functions/Functions.php:1020
 msgctxt "daughter’s husband’s parent"
 msgid "son-in-law’s parent"
-msgstr ""
+msgstr "사돈"
 
 #: app/Functions/Functions.php:768
 msgctxt "child’s spouse"
@@ -19750,7 +19751,7 @@ msgstr ""
 #: app/Module/UpcomingAnniversariesModule.php:277
 #: resources/xml/reports/change_report.xml:7
 msgid "sort by date"
-msgstr ""
+msgstr "날짜별 정렬"
 
 #. I18N: A button label.
 #: resources/views/edit/reorder-children.phtml:41
@@ -19762,30 +19763,30 @@ msgstr ""
 #: resources/xml/reports/occupation_report.xml:6
 #: resources/xml/reports/relative_ext_report.xml:7
 msgid "sort by date of birth"
-msgstr ""
+msgstr "생년월일로 정렬"
 
 #: resources/xml/reports/bdm_report.xml:11
 #: resources/xml/reports/cemetery_report.xml:6
 #: resources/xml/reports/death_report.xml:9
 #: resources/xml/reports/relative_ext_report.xml:7
 msgid "sort by date of death"
-msgstr ""
+msgstr "생년월일로 정렬"
 
 #. I18N: A button label.
 #: resources/views/edit/reorder-families.phtml:30
 #: resources/xml/reports/marriage_report.xml:9
 msgid "sort by date of marriage"
-msgstr ""
+msgstr "결혼날짜별로 정렬"
 
 #. I18N: An option in a list-box
 #: app/Module/RecentChangesModule.php:232
 msgid "sort by date, newest first"
-msgstr ""
+msgstr "날짜순으로 정렬"
 
 #. I18N: An option in a list-box
 #: app/Module/RecentChangesModule.php:230
 msgid "sort by date, oldest first"
-msgstr ""
+msgstr "가장 오래된 것부터 날짜별로 정렬"
 
 #. I18N: An option in a list-box
 #: app/Module/OnThisDayModule.php:254 app/Module/RecentChangesModule.php:228
@@ -19801,7 +19802,7 @@ msgstr ""
 #: resources/xml/reports/occupation_report.xml:6
 #: resources/xml/reports/relative_ext_report.xml:7
 msgid "sort by name"
-msgstr ""
+msgstr "이름순으로 정렬"
 
 #: app/Functions/Functions.php:669
 msgid "spouse"
@@ -19925,99 +19926,99 @@ msgstr ""
 #: app/Module/UpcomingAnniversariesModule.php:270
 #: app/Module/YahrzeitModule.php:254
 msgid "table"
-msgstr ""
+msgstr "테이블"
 
 #. I18N: Layout option for lists of names
 #. I18N: An option in a list-box
 #: app/Http/Controllers/AdminTreesController.php:733
 #: app/Module/TopSurnamesModule.php:245
 msgid "tag cloud"
-msgstr ""
+msgstr "태그 클라우드"
 
 #: app/Functions/Functions.php:480
 msgid "tenth cousin"
-msgstr ""
+msgstr "10번째 사촌"
 
 #: app/Functions/Functions.php:444
 msgctxt "FEMALE"
 msgid "tenth cousin"
-msgstr ""
+msgstr "10번째 사촌"
 
 #. I18N: Note that for Italian and Polish, “N’th cousins” are different from English “N’th cousins”, and the software has already generated the correct “N” for your language. You only need to translate - you do not need to convert. For other languages, if your cousin rules are different from English, please contact the developers.
 #: app/Functions/Functions.php:401
 msgctxt "MALE"
 msgid "tenth cousin"
-msgstr ""
+msgstr "10번째 사촌"
 
 #. I18N: [you should check that:] ...
 #: resources/views/errors/database-connection.phtml:20
 msgid "the database connection settings in the file “/data/config.ini.php” are still correct"
-msgstr ""
+msgstr "/data/config.ini.php”파일의 데이터베이스 연결 설정이 여전히 정확합니다"
 
 #. I18N: [you should check that:] ...
 #: resources/views/errors/database-connection.phtml:23
 msgid "the folder “/data” and the file “/data/config.ini.php” have access permissions that allow the webserver to read them"
-msgstr ""
+msgstr "“/data” 폴더와 “/data/config.ini.php” 파일에는 웹 서버가 읽을 수 있는 액세스 권한이 있습니다"
 
 #. I18N: reflexive pronoun - gender neutral version of himself/herself
 #: app/Functions/Functions.php:193
 msgid "themself"
-msgstr ""
+msgstr "그들 자신"
 
 #. I18N: A Spanish relationship name, such as third great-nephew
 #: app/Functions/Functions.php:563
 #, php-format
 msgid "third %s"
-msgstr ""
+msgstr "세 번째 %s"
 
 #. I18N: A Spanish relationship name, such as third great-nephew
 #: app/Functions/Functions.php:541
 #, php-format
 msgctxt "FEMALE"
 msgid "third %s"
-msgstr ""
+msgstr "세 번째 %s"
 
 #. I18N: A Spanish relationship name, such as third great-nephew
 #: app/Functions/Functions.php:518
 #, php-format
 msgctxt "MALE"
 msgid "third %s"
-msgstr ""
+msgstr "세 번째 %s"
 
 #: app/Functions/Functions.php:466
 msgid "third cousin"
-msgstr ""
+msgstr "세 번째 사촌"
 
 #: app/Functions/Functions.php:430
 msgctxt "FEMALE"
 msgid "third cousin"
-msgstr ""
+msgstr "세 번째 사촌"
 
 #. I18N: Note that for Italian and Polish, “N’th cousins” are different from English “N’th cousins”, and the software has already generated the correct “N” for your language. You only need to translate - you do not need to convert. For other languages, if your cousin rules are different from English, please contact the developers.
 #: app/Functions/Functions.php:380
 msgctxt "MALE"
 msgid "third cousin"
-msgstr ""
+msgstr "세 번째 사촌"
 
 #: app/Functions/Functions.php:486
 msgid "thirteenth cousin"
-msgstr ""
+msgstr "13번째 사촌"
 
 #: app/Functions/Functions.php:450
 msgctxt "FEMALE"
 msgid "thirteenth cousin"
-msgstr ""
+msgstr "13번째 사촌"
 
 #. I18N: Note that for Italian and Polish, “N’th cousins” are different from English “N’th cousins”, and the software has already generated the correct “N” for your language. You only need to translate - you do not need to convert. For other languages, if your cousin rules are different from English, please contact the developers.
 #: app/Functions/Functions.php:410
 msgctxt "MALE"
 msgid "thirteenth cousin"
-msgstr ""
+msgstr "13번째 사촌"
 
 #. I18N: layout option for the fan chart
 #: app/Module/FanChartModule.php:577
 msgid "three-quarter circle"
-msgstr ""
+msgstr "3/4 서클"
 
 #. I18N: Transport Layer Security - a secure communications protocol
 #: app/Services/EmailService.php:225 resources/views/admin/site-mail.phtml:43
@@ -20028,68 +20029,68 @@ msgstr ""
 #: app/Date.php:369
 #, php-format
 msgid "to %s"
-msgstr ""
+msgstr "~ %s"
 
 #: app/Functions/Functions.php:484
 msgid "twelfth cousin"
-msgstr ""
+msgstr "12번째 사촌"
 
 #: app/Functions/Functions.php:448
 msgctxt "FEMALE"
 msgid "twelfth cousin"
-msgstr ""
+msgstr "12번째 사촌"
 
 #. I18N: Note that for Italian and Polish, “N’th cousins” are different from English “N’th cousins”, and the software has already generated the correct “N” for your language. You only need to translate - you do not need to convert. For other languages, if your cousin rules are different from English, please contact the developers.
 #: app/Functions/Functions.php:407
 msgctxt "MALE"
 msgid "twelfth cousin"
-msgstr ""
+msgstr "12번째 사촌"
 
 #: app/Functions/Functions.php:693
 msgid "twin brother"
-msgstr ""
+msgstr "쌍둥이 남자형제"
 
 #: app/Functions/Functions.php:735
 msgid "twin sibling"
-msgstr ""
+msgstr "쌍둥이 형제"
 
 #: app/Functions/Functions.php:714
 msgid "twin sister"
-msgstr ""
+msgstr "쌍둥이 여자형제"
 
 #: app/Functions/Functions.php:780
 msgctxt "father’s brother"
 msgid "uncle"
-msgstr ""
+msgstr "숙부"
 
 #: app/Functions/Functions.php:1078
 msgctxt "father’s sister’s husband"
 msgid "uncle"
-msgstr ""
+msgstr "고모부"
 
 #: app/Functions/Functions.php:816
 msgctxt "mother’s brother"
 msgid "uncle"
-msgstr ""
+msgstr "외숙부"
 
 #: app/Functions/Functions.php:1164
 msgctxt "mother’s sister’s husband"
 msgid "uncle"
-msgstr ""
+msgstr "이모부"
 
 #: app/Functions/Functions.php:836
 msgctxt "parent’s brother"
 msgid "uncle"
-msgstr ""
+msgstr "숙부"
 
 #: app/Functions/Functions.php:1206
 msgctxt "parent’s sister’s husband"
 msgid "uncle"
-msgstr ""
+msgstr "고모부/이모부"
 
 #: app/Place.php:234
 msgid "unknown"
-msgstr ""
+msgstr "알 수 없음"
 
 #: app/Module/InteractiveTree/TreeView.php:352
 msgctxt "unknown family"
@@ -20098,16 +20099,16 @@ msgstr "알 수 없음"
 
 #: app/Module/RelationshipsChartModule.php:460
 msgid "unlimited"
-msgstr ""
+msgstr "무제한"
 
 #. I18N: Quality of source information - GEDCOM tag “QUAY 0”
 #: app/GedcomCode/GedcomCodeQuay.php:58
 msgid "unreliable evidence"
-msgstr ""
+msgstr "신뢰할 수 없는 증거"
 
 #: resources/views/modules/pedigree-chart/page.phtml:37
 msgid "up"
-msgstr ""
+msgstr "위"
 
 #: resources/views/admin/trees-unconnected.phtml:28
 msgid "update"
@@ -20116,7 +20117,7 @@ msgstr "업데이트"
 #. I18N: A button label.
 #: resources/views/admin/media-upload.phtml:64
 msgid "upload"
-msgstr ""
+msgstr "업로드"
 
 #. I18N: A button label.
 #: resources/views/branches-page.phtml:40
@@ -20132,7 +20133,7 @@ msgstr ""
 #: resources/views/modules/relationships-chart/page.phtml:67
 #: resources/views/report-setup-page.phtml:66
 msgid "view"
-msgstr ""
+msgstr "보기"
 
 #: resources/views/admin/trees-privacy.phtml:25
 #: resources/views/admin/trees-privacy.phtml:44
@@ -20140,48 +20141,48 @@ msgstr ""
 #: resources/views/admin/trees-privacy.phtml:128
 #: resources/views/admin/trees-privacy.phtml:148
 msgid "visitors"
-msgstr ""
+msgstr "방문자"
 
 #: resources/xml/reports/ahnentafel_report.xml:141
 #: resources/xml/reports/descendancy_report.xml:105
 msgctxt "FEMALE"
 msgid "was born"
-msgstr ""
+msgstr "태어났다"
 
 #: resources/xml/reports/ahnentafel_report.xml:140
 #: resources/xml/reports/descendancy_report.xml:102
 msgctxt "MALE"
 msgid "was born"
-msgstr ""
+msgstr "태어났다"
 
 #: app/Module/WebtreesTheme.php:38
 msgid "webtrees"
-msgstr ""
+msgstr "webtrees"
 
 #: app/Services/MessageService.php:127
 msgid "webtrees message"
-msgstr ""
+msgstr "webtrees 메시지"
 
 #: resources/views/setup/step-3-database-type.phtml:29
 msgid "webtrees needs a database to store your genealogy data."
-msgstr ""
+msgstr "webtrees에는 계보 데이터를 저장하기 위한 데이터베이스가 필요합니다."
 
 #. I18N: Help text for the “Messages” site configuration setting
 #: resources/views/admin/site-mail.phtml:67
 msgid "webtrees needs to send emails, such as password reminders and website notifications."
-msgstr ""
+msgstr "webtrees는 비밀번호 알림 및 웹 사이트 알림과 같은 이메일을 보내야 합니다."
 
 #: app/Functions/FunctionsEdit.php:165
 msgid "webtrees sends emails with no storage"
-msgstr ""
+msgstr "webtrees는 저장소 없이 이메일을 보냅니다."
 
 #: resources/views/help/iso-8859-1.phtml:8
 msgid "webtrees uses UTF-8 encoding for accented letters, special characters and non-Latin scripts. If you want to use this GEDCOM file with genealogy software that does not support UTF-8, then you can create it using ISO-8859-1 encoding."
-msgstr ""
+msgstr "webtrees는 강조 문자, 특수 문자 및 비 라틴 문자 스크립트에 UTF-8 인코딩을 사용합니다. UTF-8을 지원하지 않는 계보 소프트웨어와 함께이 GEDCOM 파일을 사용하려면 ISO-8859-1 인코딩을 사용하여 파일을 만들 수 있습니다."
 
 #: app/Functions/Functions.php:649
 msgid "wife"
-msgstr ""
+msgstr "부인"
 
 #. I18N: Name of a theme.
 #: app/Module/XeneaTheme.php:39
@@ -20190,7 +20191,7 @@ msgstr ""
 
 #: resources/views/modules/timeline-chart/chart.phtml:132
 msgid "years"
-msgstr ""
+msgstr "년"
 
 #: app/Functions/FunctionsEdit.php:180 app/Functions/FunctionsEdit.php:214
 #: app/Http/Controllers/Admin/UsersController.php:190
@@ -20233,19 +20234,19 @@ msgstr "예"
 #. I18N: [you should check that:] ...
 #: resources/views/errors/database-connection.phtml:26
 msgid "you can connect to the database using other applications, such as phpmyadmin"
-msgstr ""
+msgstr "phpmyadmin과 같은 다른 응용 프로그램을 사용하여 데이터베이스에 연결할 수 있습니다"
 
 #: app/Functions/Functions.php:697
 msgid "younger brother"
-msgstr ""
+msgstr "손아래 남자형제"
 
 #: app/Functions/Functions.php:739
 msgid "younger sibling"
-msgstr ""
+msgstr "손아래 형제"
 
 #: app/Functions/Functions.php:718
 msgid "younger sister"
-msgstr ""
+msgstr "손아래 여자"
 
 #: app/Http/RequestHandlers/SearchAdvancedPage.php:211
 #: app/Http/RequestHandlers/SearchAdvancedPage.php:212
@@ -20253,7 +20254,7 @@ msgstr ""
 #, php-format
 msgid "±%s year"
 msgid_plural "±%s years"
-msgstr[0] ""
+msgstr[0] "±%s 년"
 
 #: app/Individual.php:1168
 #, php-format
@@ -20264,12 +20265,12 @@ msgstr ""
 #: app/Http/RequestHandlers/PendingChangesAcceptRecord.php:66
 #, php-format
 msgid "“%s” has been deleted."
-msgstr ""
+msgstr "“%s” 이(가) 삭제되었습니다."
 
 #. I18N: Description of a “Data fix” module
 #: app/Module/FixPrimaryTag.php:60
 msgid "“Highlighted image” (_PRIM) tags are used by some genealogy applications to indicate the preferred image for an individual. An alternative is to re-order the images so that the preferred one is listed first."
-msgstr ""
+msgstr "강조된 이미지”(_PRIM) 태그는 일부 계보 응용 프로그램에서 개인의 선호 이미지를 나타내는 데 사용됩니다. 다른 방법은 선호하는 이미지가 먼저 나열되도록 이미지를 다시 정렬하는 것입니다."
 
 #: app/Functions/FunctionsPrint.php:93 app/Note.php:160
 #: app/Report/ReportParserGenerate.php:985
@@ -20293,7 +20294,7 @@ msgid "…"
 msgstr ""
 
 #~ msgid "Add a scrollbar when block contents grow"
-#~ msgstr "블록의 내용이 성장할 때 스크롤바를 추가"
+#~ msgstr "블록 내용이 커질 때 스크롤바 추가"
 
 #~ msgid "Configure"
 #~ msgstr "설정"


### PR DESCRIPTION
First Korean translate Complete.
Please convert messege.po-> messege.php.

Contents that are not used in Korean culture are not translated and kept in their original text.