### PR TITLE
Allow sendmail command to be configured

### DIFF
--- a/app/Http/RequestHandlers/EmailPreferencesAction.php
+++ b/app/Http/RequestHandlers/EmailPreferencesAction.php
@@ -63,6 +63,7 @@ class EmailPreferencesAction implements RequestHandlerInterface
 
         $params = (array) $request->getParsedBody();
 
+        Site::setPreference('SENDMAIL_COMMAND', $params['SENDMAIL_COMMAND']);
         Site::setPreference('SMTP_ACTIVE', $params['SMTP_ACTIVE']);
         Site::setPreference('SMTP_FROM_NAME', $params['SMTP_FROM_NAME']);
         Site::setPreference('SMTP_HOST', $params['SMTP_HOST']);

--- a/app/Http/RequestHandlers/EmailPreferencesPage.php
+++ b/app/Http/RequestHandlers/EmailPreferencesPage.php
@@ -63,17 +63,18 @@ class EmailPreferencesPage implements RequestHandlerInterface
 
         $title = I18N::translate('Sending email');
 
-        $SMTP_ACTIVE    = Site::getPreference('SMTP_ACTIVE');
-        $SMTP_AUTH      = Site::getPreference('SMTP_AUTH');
-        $SMTP_AUTH_USER = Site::getPreference('SMTP_AUTH_USER');
-        $SMTP_FROM_NAME = $this->email_service->senderEmail();
-        $SMTP_HELO      = $this->email_service->localDomain();
-        $SMTP_HOST      = Site::getPreference('SMTP_HOST');
-        $SMTP_PORT      = Site::getPreference('SMTP_PORT');
-        $SMTP_SSL       = Site::getPreference('SMTP_SSL');
-        $DKIM_DOMAIN    = Site::getPreference('DKIM_DOMAIN');
-        $DKIM_SELECTOR  = Site::getPreference('DKIM_SELECTOR');
-        $DKIM_KEY       = Site::getPreference('DKIM_KEY');
+        $SENDMAIL_COMMAND = Site::getPreference('SENDMAIL_COMMAND');
+        $SMTP_ACTIVE      = Site::getPreference('SMTP_ACTIVE');
+        $SMTP_AUTH        = Site::getPreference('SMTP_AUTH');
+        $SMTP_AUTH_USER   = Site::getPreference('SMTP_AUTH_USER');
+        $SMTP_FROM_NAME   = $this->email_service->senderEmail();
+        $SMTP_HELO        = $this->email_service->localDomain();
+        $SMTP_HOST        = Site::getPreference('SMTP_HOST');
+        $SMTP_PORT        = Site::getPreference('SMTP_PORT');
+        $SMTP_SSL         = Site::getPreference('SMTP_SSL');
+        $DKIM_DOMAIN      = Site::getPreference('DKIM_DOMAIN');
+        $DKIM_SELECTOR    = Site::getPreference('DKIM_SELECTOR');
+        $DKIM_KEY         = Site::getPreference('DKIM_KEY');
 
         $smtp_from_name_valid = $this->email_service->isValidEmail($SMTP_FROM_NAME);
         $smtp_helo_valid      = filter_var($SMTP_HELO, FILTER_VALIDATE_DOMAIN);
@@ -86,6 +87,7 @@ class EmailPreferencesPage implements RequestHandlerInterface
             'title'                  => $title,
             'smtp_helo_valid'        => $smtp_helo_valid,
             'smtp_from_name_valid'   => $smtp_from_name_valid,
+            'SENDMAIL_COMMAND'       => $SENDMAIL_COMMAND,
             'SMTP_ACTIVE'            => $SMTP_ACTIVE,
             'SMTP_AUTH'              => $SMTP_AUTH,
             'SMTP_AUTH_USER'         => $SMTP_AUTH_USER,

--- a/app/Services/EmailService.php
+++ b/app/Services/EmailService.php
@@ -123,7 +123,15 @@ class EmailService
         switch (Site::getPreference('SMTP_ACTIVE')) {
             case 'sendmail':
                 // Local sendmail (requires PHP proc_* functions)
-                return new Swift_SendmailTransport();
+                $sendmail_command = Site::getPreference('SENDMAIL_COMMAND');
+
+                $transport = new Swift_SendmailTransport();
+
+                if ($sendmail_command) {
+                    $transport->setCommand($sendmail_command);
+                }
+
+                return $transport;
 
             case 'external':
                 // SMTP

--- a/resources/views/admin/site-mail.phtml
+++ b/resources/views/admin/site-mail.phtml
@@ -9,6 +9,7 @@ use Fisharebest\Webtrees\View;
  * @var string   $DKIM_DOMAIN
  * @var string   $DKIM_KEY
  * @var string   $DKIM_SELECTOR
+ * @var string   $SENDMAIL_COMMAND
  * @var string   $SMTP_ACTIVE
  * @var string   $SMTP_AUTH
  * @var string   $SMTP_AUTH_USER
@@ -86,6 +87,22 @@ use Fisharebest\Webtrees\View;
                     <?= I18N::translate('Most mail servers require a valid email address.') ?>
                 </p>
             <?php endif ?>
+        </div>
+    </div>
+
+    <h2><?= I18N::translate('Sendmail') ?></h2>
+
+    <div class="row form-group">
+        <label for="SENDMAIL_COMMAND" class="col-sm-3 col-form-label">
+            <?= /* I18N: A configuration setting */
+            I18N::translate('Sendmail command') ?>
+        </label>
+        <div class="col-sm-9">
+            <input type="text" class="form-control" id="SENDMAIL_COMMAND" name="SENDMAIL_COMMAND" value="<?= e($SENDMAIL_COMMAND) ?>" placeholder="/usr/sbin/sendmail -bs" maxlength="255">
+            <p class="small text-muted">
+                <?= /* I18N: Help text for the “Server name” site configuration setting */
+                I18N::translate('The path to the sendmail command on your web server, including any additional flags.') ?>
+            </p>
         </div>
     </div>
 


### PR DESCRIPTION
Swift Mailer's default of `/usr/sbin/sendmail -bs` isn't always sufficient.