### PR TITLE
Treat empty values in coordinates like NULL values

### DIFF
--- a/app/Http/Controllers/Admin/LocationController.php
+++ b/app/Http/Controllers/Admin/LocationController.php
@@ -214,16 +214,16 @@ class LocationController extends AbstractAdminController
         $prefix = DB::connection()->getTablePrefix();
 
         $expression =
-            $prefix . 'p0.pl_place IS NOT NULL AND ' . $prefix . 'p0.pl_lati IS NULL OR ' .
-            $prefix . 'p1.pl_place IS NOT NULL AND ' . $prefix . 'p1.pl_lati IS NULL OR ' .
-            $prefix . 'p2.pl_place IS NOT NULL AND ' . $prefix . 'p2.pl_lati IS NULL OR ' .
-            $prefix . 'p3.pl_place IS NOT NULL AND ' . $prefix . 'p3.pl_lati IS NULL OR ' .
-            $prefix . 'p4.pl_place IS NOT NULL AND ' . $prefix . 'p4.pl_lati IS NULL OR ' .
-            $prefix . 'p5.pl_place IS NOT NULL AND ' . $prefix . 'p5.pl_lati IS NULL OR ' .
-            $prefix . 'p6.pl_place IS NOT NULL AND ' . $prefix . 'p6.pl_lati IS NULL OR ' .
-            $prefix . 'p7.pl_place IS NOT NULL AND ' . $prefix . 'p7.pl_lati IS NULL OR ' .
-            $prefix . 'p8.pl_place IS NOT NULL AND ' . $prefix . 'p8.pl_lati IS NULL OR ' .
-            $prefix . 'p9.pl_place IS NOT NULL AND ' . $prefix . 'p9.pl_lati IS NULL';
+            $prefix . 'p0.pl_place IS NOT NULL AND NULLIF(' . $prefix . 'p0.pl_lati, \'\') IS NULL OR ' .
+            $prefix . 'p1.pl_place IS NOT NULL AND NULLIF(' . $prefix . 'p1.pl_lati, \'\') IS NULL OR ' .
+            $prefix . 'p2.pl_place IS NOT NULL AND NULLIF(' . $prefix . 'p2.pl_lati, \'\') IS NULL OR ' .
+            $prefix . 'p3.pl_place IS NOT NULL AND NULLIF(' . $prefix . 'p3.pl_lati, \'\') IS NULL OR ' .
+            $prefix . 'p4.pl_place IS NOT NULL AND NULLIF(' . $prefix . 'p4.pl_lati, \'\') IS NULL OR ' .
+            $prefix . 'p5.pl_place IS NOT NULL AND NULLIF(' . $prefix . 'p5.pl_lati, \'\') IS NULL OR ' .
+            $prefix . 'p6.pl_place IS NOT NULL AND NULLIF(' . $prefix . 'p6.pl_lati, \'\') IS NULL OR ' .
+            $prefix . 'p7.pl_place IS NOT NULL AND NULLIF(' . $prefix . 'p7.pl_lati, \'\') IS NULL OR ' .
+            $prefix . 'p8.pl_place IS NOT NULL AND NULLIF(' . $prefix . 'p8.pl_lati, \'\') IS NULL OR ' .
+            $prefix . 'p9.pl_place IS NOT NULL AND NULLIF(' . $prefix . 'p9.pl_lati, \'\') IS NULL';
 
         return DB::table('placelocation AS p0')
             ->leftJoin('placelocation AS p1', 'p1.pl_parent_id', '=', 'p0.pl_id')

--- a/resources/views/admin/locations.phtml
+++ b/resources/views/admin/locations.phtml
@@ -35,7 +35,7 @@ use Fisharebest\Webtrees\Webtrees;
             </th>
 
             <td dir="ltr">
-                <?php if ($place->pl_lati === null) : ?>
+                <?php if (empty($place->pl_lati)) : ?>
                     <?= view('icons/warning') ?>
                 <?php else : ?>
                     <?= strtr($place->pl_lati, ['N' => '', 'S' => '-', ',' => '.']) ?>
@@ -43,7 +43,7 @@ use Fisharebest\Webtrees\Webtrees;
             </td>
 
             <td dir="ltr">
-                <?php if ($place->pl_long === null) : ?>
+                <?php if (empty($place->pl_long)) : ?>
                     <?= view('icons/warning') ?>
                 <?php else : ?>
                     <?= strtr($place->pl_long, ['E' => '', 'W' => '-', ',' => '.']) ?>
@@ -51,7 +51,7 @@ use Fisharebest\Webtrees\Webtrees;
             </td>
 
             <td dir="ltr">
-                <?php if ($place->pl_zoom === null) : ?>
+                <?php if (empty($place->pl_zoom)) : ?>
                     <?= view('icons/warning') ?>
                 <?php else : ?>
                     <?= $place->pl_zoom ?>


### PR DESCRIPTION
Fixes #3132 

While strictly speaking the error is caused by the id() function in webtrees/app/Location.php (which initializes a new location with an empty string instead of NULL values), fixing this would not fix existing data, and would also not prevent data coming from elsewhere (e.g. via migration) to be formatted properly. So I think it's best to fix the symptoms (treatment of empty strings in coordinates) in this case instead of searching for and fixing all current and future root causes.