### PR TITLE
Datatables - Provide option to duplicate paging top/bottom of table

### DIFF
--- a/resources/js/vendor.js
+++ b/resources/js/vendor.js
@@ -28,8 +28,9 @@ import {
 } from '@fortawesome/free-regular-svg-icons';
 import {
   // For resources/views/icons/*
-  faArrowDown, faArrowLeft, faArrowRight, faArrowUp, faArrowsAltV, faBan, faBars,
-  faCalendar, faCaretDown, faCaretUp, faCheck, faCodeBranch, faDownload, faExclamationTriangle, faGenderless,
+  faAngleLeft, faAngleDoubleLeft, faAngleRight, faAngleDoubleRight, faArrowDown, faArrowLeft,
+  faArrowRight, faArrowUp, faArrowsAltV, faBan, faBars, faCalendar, faCaretDown, faCaretUp,
+  faCheck, faCodeBranch, faDownload, faExclamationTriangle, faGenderless,
   faGripHorizontal, faGripLines, faHistory, faInfoCircle, faLanguage, faLink, faList,
   faLock, faMagic, faMap, faMapMarkerAlt, faMars, faMedkit, faPaintBrush, faPause, faPencilAlt,
   faPlay, faPlus, faPuzzlePiece, faQuestionCircle, faRedo, faSearch, faSearchMinus, faSearchPlus,
@@ -128,8 +129,9 @@ library.add(
 );
 library.add(
   // For resources/views/icons/*
-  faArrowDown, faArrowLeft, faArrowRight, faArrowUp, faArrowsAltV, faBan, faBars,
-  faCalendar, faCaretDown, faCaretUp, faCheck, faCodeBranch, faDownload, faExclamationTriangle, faGenderless,
+  faAngleLeft, faAngleDoubleLeft, faAngleRight, faAngleDoubleRight, faArrowDown, faArrowLeft,
+  faArrowRight, faArrowUp, faArrowsAltV, faBan, faBars, faCalendar, faCaretDown, faCaretUp,
+  faCheck, faCodeBranch, faDownload, faExclamationTriangle, faGenderless,
   faGripHorizontal, faGripLines, faHistory, faInfoCircle, faLanguage, faLink, faList,
   faLock, faMagic, faMap, faMapMarkerAlt, faMars, faMedkit, faPaintBrush, faPause, faPencilAlt,
   faPlay, faPlus, faPuzzlePiece, faQuestionCircle, faRedo, faSearch, faSearchMinus, faSearchPlus,

--- a/resources/views/icons/first.phtml
+++ b/resources/views/icons/first.phtml
@@ -1,0 +1,1 @@
+<span class="wt-icon-folder"><i class="fas fa-angle-double-<?= $direction ?> fa-fw" aria-hidden="true"></i></span>

--- a/resources/views/icons/last.phtml
+++ b/resources/views/icons/last.phtml
@@ -1,0 +1,1 @@
+<span class="wt-icon-folder"><i class="fas fa-angle-double-<?= $direction ?> fa-fw" aria-hidden="true"></i></span>

--- a/resources/views/icons/next.phtml
+++ b/resources/views/icons/next.phtml
@@ -1,0 +1,1 @@
+<span class="wt-icon-folder"><i class="fas fa-angle-<?= $direction ?> fa-fw" aria-hidden="true"></i></span>

--- a/resources/views/icons/previous.phtml
+++ b/resources/views/icons/previous.phtml
@@ -1,0 +1,1 @@
+<span class="wt-icon-folder"><i class="fas fa-angle-<?= $direction ?> fa-fw" aria-hidden="true"></i></span>

--- a/resources/views/lists/datatables-attributes.phtml
+++ b/resources/views/lists/datatables-attributes.phtml
@@ -2,22 +2,35 @@
 
 use Fisharebest\Webtrees\I18N;
 
+// Alternate layout duplicates pagination & display
+// controls below the data
+define('STANDARD_LAYOUT', true);
+
+$header_controls = STANDARD_LAYOUT ? 'pf'  : 'pfl';
+$footer_controls = STANDARD_LAYOUT ? 'irl' : 'pilr';
+$back            = I18N::direction() === 'ltr' ? 'left' : 'right';
+$forward         = I18N::direction() === 'ltr' ? 'right' : 'left';
 ?>
 
 data-auto-width="false"
-data-dom="<&quot;d-flex justify-content-between&quot;pf><t><&quot;d-flex justify-content-between&quot;irl>"
+data-dom="<&quot;d-flex justify-content-between&quot;<?= $header_controls ?>><t><&quot;d-flex justify-content-between&quot;<?= $footer_controls ?>>"
 data-state-save="true"
 data-length-menu="<?= e(json_encode([[10, 20, 50, 100, 500, 1000, -1], [I18N::number(10), I18N::number(20), I18N::number(50), I18N::number(100), I18N::number(500), I18N::number(1000), I18N::translate('All')]])) ?>"
+data-paging-type="full_numbers"
 data-language="<?= e(json_encode([
     'paginate'       => [
-        /* I18N: A button label, first page */
-        'first'    => I18N::translate('first'),
-        /* I18N: A button label, last page */
-        'last'     => I18N::translate('last'),
-        /* I18N: A button label, next page */
-        'next'     => I18N::translate('next'),
-        /* I18N: A button label, previous page */
-        'previous' => I18N::translate('previous'),
+        'first'    => view('icons/first', [
+                        'direction' => $back,
+                      ]),
+        'last'     => view('icons/last', [
+                        'direction' => $forward,
+                      ]),
+        'next'     => view('icons/next',[
+                        'direction' => $forward,
+                      ]),
+        'previous' => view('icons/previous',[
+                        'direction' => $back,
+                      ]),
     ],
     'emptyTable'     => I18N::translate('No records to display'),
     /* I18N: %s are placeholders for numbers */


### PR DESCRIPTION
Solution to https://github.com/fisharebest/webtrees/issues/3148
Avoids having to scroll back to top when table exceeds length of browser window
See also forum post https://www.webtrees.net/index.php/en/forum/help-for-2-0/34175-wish-list#75529, first entry

For Previous/First, Next/End button change text for icon (slightly reduces width of control)
