### PR TITLE
Better method of determining ages

### DIFF
--- a/app/Age.php
+++ b/app/Age.php
@@ -22,7 +22,7 @@ namespace Fisharebest\Webtrees;
 use function view;
 
 /**
- * The different between to GEDCOM dates.
+ * The different between two GEDCOM dates.
  */
 class Age
 {
@@ -184,9 +184,11 @@ class Age
     /**
      * Similar to ageAtEvent, but for events such as burial, cremation, etc.
      *
+     * @param string $tag
+     *
      * @return string
      */
-    public function timeAfterDeath(): string
+    public function timeAfterDeath($tag = ''): string
     {
         if (!$this->is_valid) {
             return '';
@@ -200,6 +202,16 @@ class Age
             return '';
         }
 
-        return I18N::translate('(%s after death)', $this->ageString());
+        // could receive $fact->label() instead of the tag and build the string like
+        // return I18N::translate('(%s after %s)', $this->ageString(), $label);
+        // but not sure whether the grammar would be correct for all languages
+        switch ($tag) {
+            case 'BURI':
+                return I18N::translate('(%s after burial)', $this->ageString());
+            case 'CREM':
+                return I18N::translate('(%s after cremation)', $this->ageString());
+            default:
+                return I18N::translate('(%s after death)', $this->ageString());
+        }
     }
 }

--- a/tests/app/AgeTest.php
+++ b/tests/app/AgeTest.php
@@ -49,7 +49,7 @@ class AgeTest extends TestCase
         $this->assertSame('0 days', $age->ageString());
         $this->assertSame('(aged 0 days)', $age->ageAtEvent(false));
         $this->assertSame('(age 0 days)', $age->ageAtEvent(true));
-        $this->assertSame('(on the date of death)', $age->timeAfterDeath());
+        $this->assertSame('(on the date of death)', $age->timeAfterDeath(''));
     }
 
     /**
@@ -75,7 +75,7 @@ class AgeTest extends TestCase
         $this->assertSame('0', $age->ageString());
         $this->assertSame('(aged 0)', $age->ageAtEvent(false));
         $this->assertSame('(age 0)', $age->ageAtEvent(true));
-        $this->assertSame('', $age->timeAfterDeath());
+        $this->assertSame('', $age->timeAfterDeath(''));
     }
 
     /**
@@ -101,7 +101,7 @@ class AgeTest extends TestCase
         $this->assertSame('0', $age->ageString());
         $this->assertSame('(aged 0)', $age->ageAtEvent(false));
         $this->assertSame('(age 0)', $age->ageAtEvent(true));
-        $this->assertSame('', $age->timeAfterDeath());
+        $this->assertSame('', $age->timeAfterDeath(''));
     }
 
     /**
@@ -127,7 +127,7 @@ class AgeTest extends TestCase
         $this->assertSame(view('icons/warning'), $age->ageString());
         $this->assertSame('(aged ' . view('icons/warning') . ')', $age->ageAtEvent(false));
         $this->assertSame('(age ' . view('icons/warning') . ')', $age->ageAtEvent(true));
-        $this->assertSame('(' . view('icons/warning') . ' after death)', $age->timeAfterDeath());
+        $this->assertSame('(' . view('icons/warning') . ' after death)', $age->timeAfterDeath(''));
     }
 
     /**
@@ -153,7 +153,7 @@ class AgeTest extends TestCase
         $this->assertSame('', $age->ageString());
         $this->assertSame('', $age->ageAtEvent(false));
         $this->assertSame('', $age->ageAtEvent(true));
-        $this->assertSame('', $age->timeAfterDeath());
+        $this->assertSame('', $age->timeAfterDeath(''));
     }
 
     /**
@@ -179,7 +179,7 @@ class AgeTest extends TestCase
         $this->assertSame('', $age->ageString());
         $this->assertSame('', $age->ageAtEvent(false));
         $this->assertSame('', $age->ageAtEvent(true));
-        $this->assertSame('', $age->timeAfterDeath());
+        $this->assertSame('', $age->timeAfterDeath(''));
     }
 
     /**
@@ -205,7 +205,7 @@ class AgeTest extends TestCase
         $this->assertSame('0', $age->ageString());
         $this->assertSame('(aged 0)', $age->ageAtEvent(false));
         $this->assertSame('(age 0)', $age->ageAtEvent(true));
-        $this->assertSame('', $age->timeAfterDeath());
+        $this->assertSame('', $age->timeAfterDeath(''));
     }
 
     /**
@@ -231,7 +231,7 @@ class AgeTest extends TestCase
         $this->assertSame('0', $age->ageString());
         $this->assertSame('(aged 0)', $age->ageAtEvent(false));
         $this->assertSame('(age 0)', $age->ageAtEvent(true));
-        $this->assertSame('', $age->timeAfterDeath());
+        $this->assertSame('', $age->timeAfterDeath(''));
     }
 
     /**
@@ -257,7 +257,9 @@ class AgeTest extends TestCase
         $this->assertSame('14 days', $age->ageString());
         $this->assertSame('(aged 14 days)', $age->ageAtEvent(false));
         $this->assertSame('(age 14 days)', $age->ageAtEvent(true));
-        $this->assertSame('(14 days after death)', $age->timeAfterDeath());
+        $this->assertSame('(14 days after death)', $age->timeAfterDeath('DEAT'));
+        $this->assertSame('(14 days after burial)', $age->timeAfterDeath('BURI'));
+        $this->assertSame('(14 days after cremation)', $age->timeAfterDeath('CREM'));
     }
 
     /**
@@ -283,7 +285,9 @@ class AgeTest extends TestCase
         $this->assertSame('2 months', $age->ageString());
         $this->assertSame('(aged 2 months)', $age->ageAtEvent(false));
         $this->assertSame('(age 2 months)', $age->ageAtEvent(true));
-        $this->assertSame('(2 months after death)', $age->timeAfterDeath());
+        $this->assertSame('(2 months after death)', $age->timeAfterDeath('DEAT'));
+        $this->assertSame('(2 months after burial)', $age->timeAfterDeath('BURI'));
+        $this->assertSame('(2 months after cremation)', $age->timeAfterDeath('CREM'));
     }
 
     /**
@@ -309,6 +313,8 @@ class AgeTest extends TestCase
         $this->assertSame('7 years', $age->ageString());
         $this->assertSame('(aged 7 years)', $age->ageAtEvent(false));
         $this->assertSame('(age 7 years)', $age->ageAtEvent(true));
-        $this->assertSame('(7 years after death)', $age->timeAfterDeath());
+        $this->assertSame('(7 years after death)', $age->timeAfterDeath('DEAT'));
+        $this->assertSame('(7 years after burial)', $age->timeAfterDeath('BURI'));
+        $this->assertSame('(7 years after cremation)', $age->timeAfterDeath('CREM'));
     }
 }


### PR DESCRIPTION
fixes https://github.com/fisharebest/webtrees/issues/3218 and https://github.com/fisharebest/webtrees/issues/3225

determine actual events for "Birth" and "Death" from which ages can be calculated and for death, include an appropriate message of the form "nn days after {"Death event"}