### PR TITLE
Support linkedLocations

### DIFF
--- a/app/GedcomRecord.php
+++ b/app/GedcomRecord.php
@@ -735,6 +735,31 @@ class GedcomRecord
     }
 
     /**
+     * Find locations linked to this record.
+     *
+     * @param string $link
+     *
+     * @return Collection<Location>
+     */
+    public function linkedLocations(string $link): Collection
+    {
+        return DB::table('other')
+            ->join('link', static function (JoinClause $join): void {
+                $join
+                    ->on('l_file', '=', 'o_file')
+                    ->on('l_from', '=', 'o_id');
+            })
+            ->where('o_file', '=', $this->tree->id())
+            ->where('o_type', '=', '_LOC')
+            ->where('l_type', '=', $link)
+            ->where('l_to', '=', $this->xref)
+            ->select(['other.*'])
+            ->get()
+            ->map(Factory::location()->mapper($this->tree))
+            ->filter(self::accessFilter());
+    }
+    
+    /**
      * Get all attributes (e.g. DATE or PLAC) from an event (e.g. BIRT or MARR).
      * This is used to display multiple events on the individual/family lists.
      * Multiple events can exist because of uncertainty in dates, dates in different

--- a/app/Http/Controllers/Admin/MediaController.php
+++ b/app/Http/Controllers/Admin/MediaController.php
@@ -321,6 +321,9 @@ class MediaController extends AbstractAdminController
             // Invalid GEDCOM - you cannot link a REPO to an OBJE
             $linked[] = '<a href="' . e($link->url()) . '">' . $link->fullName() . '</a>';
         }
+        foreach ($media->linkedLocations('OBJE') as $link) {
+            $linked[] = '<a href="' . e($link->url()) . '">' . $link->fullName() . '</a>';
+        }
         if ($linked !== []) {
             $html .= '<ul>';
             foreach ($linked as $link) {


### PR DESCRIPTION
I see you already implemented basic _LOC support via Location/LocationFactory after all - Big thumbs up! I can now remove all ugly hacks regarding class loading in my custom module, everything works smoothly.

It would be perfect if we could additionally support 'linkedLocations' similar to other 'linkedXxx', as suggested by this pull request (Edit: This doesn't address all places where a media object displays links to locations, but the others are views (media-page and media-list/page) which I can replace easily).