### PR TITLE
Fix Places Map Load Failure

### DIFF
--- a/resources/views/individual-page.phtml
+++ b/resources/views/individual-page.phtml
@@ -153,7 +153,10 @@ use Illuminate\Support\Collection;
   "use strict";
 
   // Bootstrap tabs - load content dynamically using AJAX
-  $('a[data-toggle="tab"][data-href]').on('show.bs.tab', function () {
+  $('a[data-toggle="tab"][data-href][href!="#places"]').on('show.bs.tab', function () {
+    $(this.getAttribute('href') + ':empty').load($(this).data('href'));
+  });
+  $('a[href="#places"]').on('shown.bs.tab', function () {
     $(this.getAttribute('href') + ':empty').load($(this).data('href'));
   });
 

--- a/resources/views/individual-page.phtml
+++ b/resources/views/individual-page.phtml
@@ -153,11 +153,19 @@ use Illuminate\Support\Collection;
   "use strict";
 
   // Bootstrap tabs - load content dynamically using AJAX
-  $('a[data-toggle="tab"][data-href][href!="#places"]').on('show.bs.tab', function () {
-    $(this.getAttribute('href') + ':empty').load($(this).data('href'));
-  });
-  $('a[href="#places"]').on('shown.bs.tab', function () {
-    $(this.getAttribute('href') + ':empty').load($(this).data('href'));
+  $('a[data-toggle="tab"][data-href]').on('show.bs.tab', function () {
+      let target = $(this.hash + ':empty');
+      if (target) {
+          // Start the download immediately...
+          let download = fetch(this.dataset.href);
+
+          // ...but don't insert it until the tab is ready.
+          $(this).one('shown.bs.tab', () => {
+              download
+                  .then(data => data.text())
+                  .then(data => target.html(data));
+          });
+      }
   });
 
   // If the URL contains a fragment, then activate the corresponding tab.

--- a/resources/views/modules/places/tab.phtml
+++ b/resources/views/modules/places/tab.phtml
@@ -94,6 +94,8 @@ use Fisharebest\Webtrees\I18N;
          * @private
          */
         let _buildMapData = function() {
+            $('a[href="#places"]').unbind('shown.bs.tab', _buildMapData);
+
             let sidebar_content = "";
             let data            = <?= json_encode($data) ?>;
 
@@ -185,7 +187,7 @@ use Fisharebest\Webtrees\I18N;
         });
 
         _drawMap();
-        _buildMapData();
+        $('a[href="#places"]').on('shown.bs.tab', _buildMapData);
 
         return "Leaflet map interface for webtrees-2";
     })();

--- a/resources/views/modules/places/tab.phtml
+++ b/resources/views/modules/places/tab.phtml
@@ -94,8 +94,6 @@ use Fisharebest\Webtrees\I18N;
          * @private
          */
         let _buildMapData = function() {
-            $('a[href="#places"]').unbind('shown.bs.tab', _buildMapData);
-
             let sidebar_content = "";
             let data            = <?= json_encode($data) ?>;
 
@@ -187,11 +185,7 @@ use Fisharebest\Webtrees\I18N;
         });
 
         _drawMap();
-        if ( ! $('#osm-map').prop('clientWidth') ) {
-                $('a[href="#places"]').on('shown.bs.tab', _buildMapData);
-        } else {
-                _buildMapData();
-        }
+        _buildMapData();
 
         return "Leaflet map interface for webtrees-2";
     })();

--- a/resources/views/modules/places/tab.phtml
+++ b/resources/views/modules/places/tab.phtml
@@ -187,7 +187,11 @@ use Fisharebest\Webtrees\I18N;
         });
 
         _drawMap();
-        $('a[href="#places"]').on('shown.bs.tab', _buildMapData);
+        if ( ! $('#osm-map').prop('clientWidth') ) {
+                $('a[href="#places"]').on('shown.bs.tab', _buildMapData);
+        } else {
+                _buildMapData();
+        }
 
         return "Leaflet map interface for webtrees-2";
     })();


### PR DESCRIPTION
Because the XHR script sometimes runs prior to rendering the osm-map element, it is necessary to bind _buildMapData to a different event named shown.bs.tab, and then unbind it later so it won't run more than one time.

See https://github.com/fisharebest/webtrees/issues/3255