### PR TITLE
Sort Charts menu entries

### DIFF
--- a/app/Module/ChartsMenuModule.php
+++ b/app/Module/ChartsMenuModule.php
@@ -95,6 +95,9 @@ class ChartsMenuModule extends AbstractModule implements ModuleMenuInterface
         $submenus   = $this->module_service->findByComponent(ModuleChartInterface::class, $tree, Auth::user())
             ->map(static function (ModuleChartInterface $module) use ($individual): Menu {
                 return $module->chartMenu($individual);
+            })
+            ->sort(static function (Menu $x, Menu $y): int {
+                return $x->getLabel() <=> $y->getLabel();
             });
 
         if ($submenus->isEmpty()) {

--- a/app/Module/ListsMenuModule.php
+++ b/app/Module/ListsMenuModule.php
@@ -92,7 +92,6 @@ class ListsMenuModule extends AbstractModule implements ModuleMenuInterface
             ->map(static function (ModuleListInterface $module) use ($tree): ?Menu {
                 return $module->listMenu($tree);
             })
-            ->filter()
             ->sort(static function (Menu $x, Menu $y): int {
                 return $x->getLabel() <=> $y->getLabel();
             });


### PR DESCRIPTION
Sort Charts menu entries (just like Lists menu entries).
Without this, custom module charts appear at the top currently (as reported [here](https://github.com/vesta-webtrees-2-custom-modules/vesta_extended_relationships/issues/4)).

(the empty '->filter()' operation in ListsMenuModule doesn't seem to have any effect?)