### PR TITLE
Fix use of LocalizationService

### DIFF
--- a/app/Functions/FunctionsEdit.php
+++ b/app/Functions/FunctionsEdit.php
@@ -311,7 +311,7 @@ class FunctionsEdit
      */
     public static function addSimpleTag(Tree $tree, $tag, $upperlevel = '', $label = ''): string
     {
-        $localization_service = new LocalizationService();
+        $localization_service = app(LocalizationService::class);
 
         $request = app(ServerRequestInterface::class);
         $xref    = $request->getAttribute('xref', '');


### PR DESCRIPTION
Construct instance of LocalizationService via the app container, so that custom modules have a chance to replace this service (in this context, elsewhere it's already ok).