### PR TITLE
Adjust label for MAP (again)

### DIFF
--- a/app/GedcomTag.php
+++ b/app/GedcomTag.php
@@ -792,7 +792,7 @@ class GedcomTag
                 return I18N::translate('Longitude');
             case 'MAP':
                 /* I18N: gedcom tag MAP */
-                return I18N::translate('Location');
+                return I18N::translate('Coordinates');
             case 'MARB':
                 /* I18N: gedcom tag MARB */
                 return I18N::translate('Marriage banns');


### PR DESCRIPTION
We had adjusted this already in #2102. 
Now there is another conflict because we use "Location" as label for "_LOC".

This is actually confusing because _LOC records may have both MAP and _LOC (indicating a parent location) as child tags, so we should use different labels here.
