### PR TITLE
make ClippingsCart more extensible

### DIFF
--- a/app/Module/ClippingsCartModule.php
+++ b/app/Module/ClippingsCartModule.php
@@ -433,6 +433,7 @@ class ClippingsCartModule extends AbstractModule implements ModuleMenuInterface
         assert($tree instanceof Tree);
 
         return $this->viewResponse('modules/clippings/show', [
+            'module'  => $this->name(),
             'records' => $this->allRecordsInCart($tree),
             'title'   => I18N::translate('Family tree clippings cart'),
             'tree'    => $tree,

--- a/resources/views/modules/clippings/download.phtml
+++ b/resources/views/modules/clippings/download.phtml
@@ -82,7 +82,7 @@ use Fisharebest\Webtrees\I18N;
                 <?= view('icons/download') ?>
                 <?= I18N::translate('download') ?>
             </button>
-            <a href="<?= e(route('module', ['module' => 'clippings', 'action' => 'Show', 'tree' => $tree->name()])) ?>" class="btn btn-secondary">
+            <a href="<?= e(route('module', ['module' => $module, 'action' => 'Show', 'tree' => $tree->name()])) ?>" class="btn btn-secondary">
                 <?= view('icons/cancel') ?>
                 <?= I18N::translate('cancel') ?>
             </a>

--- a/resources/views/modules/clippings/show.phtml
+++ b/resources/views/modules/clippings/show.phtml
@@ -33,7 +33,7 @@ use Fisharebest\Webtrees\I18N;
                         </a>
                     </td>
                     <td>
-                        <form method="post" action="<?= e(route('module', ['module' => 'clippings', 'action' => 'Remove', 'tree' => $tree->name(), 'xref' => $record->xref()])) ?>">
+                        <form method="post" action="<?= e(route('module', ['module' => $module, 'action' => 'Remove', 'tree' => $tree->name(), 'xref' => $record->xref()])) ?>">
                             <?= csrf_field() ?>
                             <button type="submit" class="btn btn-link" title="<?= I18N::translate('Remove') ?>">
                                 <?= view('icons/delete') ?>


### PR DESCRIPTION
Make ClippingsCart more extensible by removing references to the static module name. Note that there was already one location in `download.phtml` [(here)](https://github.com/fisharebest/webtrees/blob/510d5393784510a2c189d8fd7cdda66f2530e5a5/resources/views/modules/clippings/download.phtml#L9) where this was the case, i.e. it was handled inconsistently.