### PR TITLE
Census assistant married name fix 

### DIFF
--- a/app/Census/AbstractCensusColumn.php
+++ b/app/Census/AbstractCensusColumn.php
@@ -120,6 +120,38 @@ class AbstractCensusColumn
     }
 
     /**
+     * What was an individual's likely name on a given date, allowing
+     * for marriages and married names.
+     *
+     * @param Individual $individual
+     *
+     * @return string[]
+     */
+    protected function nameAtCensusDate(Individual $individual): array
+    {
+        $names  = $individual->getAllNames();
+        $name   = $names[0];
+        $family = $this->spouseFamily($individual);
+
+        if ($family instanceof Family) {
+            foreach ($family->facts(['MARR']) as $marriage) {
+                if ($marriage->date()->isOK()) {
+                    $spouse = $family->spouse($individual);
+                    foreach ($names as $individual_name) {
+                        foreach ($spouse->getAllNames() as $spouse_name) {
+                            if ($individual_name['type'] === '_MARNM' && $individual_name['surn'] === $spouse_name['surn']) {
+                                return $individual_name;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return $name;
+    }
+
+    /**
      * When did this census occur
      *
      * @return Date

--- a/app/Census/CensusColumnFullName.php
+++ b/app/Census/CensusColumnFullName.php
@@ -19,7 +19,6 @@ declare(strict_types=1);
 
 namespace Fisharebest\Webtrees\Census;
 
-use Fisharebest\Webtrees\Date;
 use Fisharebest\Webtrees\Individual;
 
 /**
@@ -37,40 +36,8 @@ class CensusColumnFullName extends AbstractCensusColumn implements CensusColumnI
      */
     public function generate(Individual $individual, Individual $head): string
     {
-        $name = $this->nameAtCensusDate($individual, $this->date());
+        $name = $this->nameAtCensusDate($individual);
 
         return strip_tags($name['full']);
-    }
-
-    /**
-     * What was an individual's likely name on a given date, allowing
-     * for marriages and married names.
-     *
-     * @param Individual $individual
-     * @param Date       $census_date
-     *
-     * @return string[]
-     */
-    protected function nameAtCensusDate(Individual $individual, Date $census_date): array
-    {
-        $names = $individual->getAllNames();
-        $name  = $names[0];
-
-        foreach ($individual->spouseFamilies() as $family) {
-            foreach ($family->facts(['MARR']) as $marriage) {
-                if ($marriage->date()->isOK() && Date::compare($marriage->date(), $census_date) < 0) {
-                    $spouse = $family->spouse($individual);
-                    foreach ($names as $individual_name) {
-                        foreach ($spouse->getAllNames() as $spouse_name) {
-                            if ($individual_name['type'] === '_MARNM' && $individual_name['surn'] === $spouse_name['surn']) {
-                                return $individual_name;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        return $name;
     }
 }

--- a/app/Census/CensusColumnSurnameGivenNameInitial.php
+++ b/app/Census/CensusColumnSurnameGivenNameInitial.php
@@ -24,7 +24,7 @@ use Fisharebest\Webtrees\Individual;
 /**
  * The individual's full name.
  */
-class CensusColumnSurnameGivenNameInitial extends CensusColumnFullName
+class CensusColumnSurnameGivenNameInitial extends AbstractCensusColumn implements CensusColumnInterface
 {
     /**
      * Generate the likely value of this census column, based on available information.
@@ -36,7 +36,7 @@ class CensusColumnSurnameGivenNameInitial extends CensusColumnFullName
      */
     public function generate(Individual $individual, Individual $head): string
     {
-        $name  = $this->nameAtCensusDate($individual, $this->date());
+        $name  = $this->nameAtCensusDate($individual);
         $given = $name['givn'];
         $space_pos = strpos($given, ' ');
 

--- a/app/Census/CensusColumnSurnameGivenNames.php
+++ b/app/Census/CensusColumnSurnameGivenNames.php
@@ -36,10 +36,9 @@ class CensusColumnSurnameGivenNames extends AbstractCensusColumn implements Cens
      */
     public function generate(Individual $individual, Individual $head): string
     {
-        foreach ($individual->getAllNames() as $name) {
-            return $name['surname'] . ', ' . $name['givn'];
-        }
+        $name       = $this->nameAtCensusDate($individual);
+        $name_parts = explode(' ', strip_tags($name['full']));
 
-        return '';
+        return array_pop($name_parts) . ', ' . implode(' ', $name_parts);
     }
 }

--- a/tests/app/Census/CensusColumnSurnameGivenNamesTest.php
+++ b/tests/app/Census/CensusColumnSurnameGivenNamesTest.php
@@ -41,6 +41,7 @@ class CensusColumnSurnameGivenNamesTest extends TestCase
             [
                 'givn' => 'Joe',
                 'surname' => 'Sixpack',
+                'full' => '<span class="NAME" dir="auto" translate="no">Joe <span class="SURN">Sixpack</span></span>',
             ],
         ]);
         $individual->method('spouseFamilies')->willReturn(new Collection());
@@ -66,6 +67,7 @@ class CensusColumnSurnameGivenNamesTest extends TestCase
             [
                 'givn' => 'Joe Fred',
                 'surname' => 'Sixpack',
+                'full' => '<span class="NAME" dir="auto" translate="no">Joe Fred <span class="SURN">Sixpack</span></span>',
             ],
         ]);
         $individual->method('spouseFamilies')->willReturn(new Collection());
@@ -87,7 +89,14 @@ class CensusColumnSurnameGivenNamesTest extends TestCase
     public function testNoName(): void
     {
         $individual = $this->createMock(Individual::class);
-        $individual->method('getAllNames')->willReturn([]);
+        $individual->method('getAllNames')->willReturn([
+            [
+                'givn' => '@P.N.',
+                'surname' => '@N.N.',
+                'full' => '<span class="NAME" dir="auto" translate="no">… <span class="SURN">…</span></span>',
+            ]
+
+        ]);
         $individual->method('spouseFamilies')->willReturn(new Collection());
 
         $census = $this->createMock(CensusInterface::class);
@@ -95,6 +104,6 @@ class CensusColumnSurnameGivenNamesTest extends TestCase
 
         $column = new CensusColumnSurnameGivenNames($census, '', '');
 
-        $this->assertSame('', $column->generate($individual, $individual));
+        $this->assertSame('…, …', $column->generate($individual, $individual));
     }
 }


### PR DESCRIPTION
For females get correct married name when there is more than one marriage. Resolves issue https://github.com/fisharebest/webtrees/issues/3596