### PR TITLE
Correction of the census name

### DIFF
--- a/app/Census/Census.php
+++ b/app/Census/Census.php
@@ -37,7 +37,7 @@ class Census
                     new CensusOfCzechRepublic(),
                     new CensusOfSlovakia(),
                     new CensusOfDenmark(),
-                    new CensusOfDeutschland(),
+                    new CensusOfMecklenburg(),
                     new CensusOfEngland(),
                     new CensusOfFrance(),
                     new CensusOfScotland(),
@@ -54,7 +54,7 @@ class Census
                     new CensusOfUnitedStates(),
                     new CensusOfCzechRepublic(),
                     new CensusOfDenmark(),
-                    new CensusOfDeutschland(),
+                    new CensusOfMecklenburg(),
                     new CensusOfFrance(),
                     new CensusOfSlovakia(),
                 ];
@@ -64,7 +64,7 @@ class Census
                     new CensusOfUnitedStates(),
                     new CensusOfCzechRepublic(),
                     new CensusOfDenmark(),
-                    new CensusOfDeutschland(),
+                    new CensusOfMecklenburg(),
                     new CensusOfEngland(),
                     new CensusOfFrance(),
                     new CensusOfScotland(),
@@ -78,7 +78,7 @@ class Census
                     new CensusOfFrance(),
                     new CensusOfCzechRepublic(),
                     new CensusOfDenmark(),
-                    new CensusOfDeutschland(),
+                    new CensusOfMecklenburg(),
                     new CensusOfEngland(),
                     new CensusOfScotland(),
                     new CensusOfSlovakia(),
@@ -89,7 +89,7 @@ class Census
             case 'da':
                 return [
                     new CensusOfDenmark(),
-                    new CensusOfDeutschland(),
+                    new CensusOfMecklenburg(),
                     new CensusOfCzechRepublic(),
                     new CensusOfEngland(),
                     new CensusOfFrance(),
@@ -101,7 +101,7 @@ class Census
 
             case 'de':
                 return [
-                    new CensusOfDeutschland(),
+                    new CensusOfMecklenburg(),
                     new CensusOfCzechRepublic(),
                     new CensusOfDenmark(),
                     new CensusOfEngland(),
@@ -117,7 +117,7 @@ class Census
                     new CensusOfSlovakia(),
                     new CensusOfCzechRepublic(),
                     new CensusOfDenmark(),
-                    new CensusOfDeutschland(),
+                    new CensusOfMecklenburg(),
                     new CensusOfEngland(),
                     new CensusOfFrance(),
                     new CensusOfScotland(),
@@ -131,7 +131,7 @@ class Census
                     new CensusOfEngland(),
                     new CensusOfScotland(),
                     new CensusOfWales(),
-                    new CensusOfDeutschland(),
+                    new CensusOfMecklenburg(),
                     new CensusOfFrance(),
                     new CensusOfCzechRepublic(),
                     new CensusOfSlovakia(),

--- a/app/Census/CensusOfMecklenburg.php
+++ b/app/Census/CensusOfMecklenburg.php
@@ -22,7 +22,7 @@ namespace Fisharebest\Webtrees\Census;
 /**
  * Definitions for a census
  */
-class CensusOfDeutschland extends Census implements CensusPlaceInterface
+class CensusOfMecklenburg extends Census implements CensusPlaceInterface
 {
     /**
      * All available censuses for this census place.
@@ -32,11 +32,11 @@ class CensusOfDeutschland extends Census implements CensusPlaceInterface
     public function allCensusDates(): array
     {
         return [
-            new CensusOfDeutschland1819(),
-            new CensusOfDeutschland1867(),
-            new CensusOfDeutschlandNL1867(),
-            new CensusOfDeutschland1900(),
-            new CensusOfDeutschland1919(),
+            new CensusOfMecklenburg1819(),
+            new CensusOfMecklenburg1867(),
+            new CensusOfMecklenburg1867NL(),
+            new CensusOfMecklenburg1900(),
+            new CensusOfMecklenburg1919(),
         ];
     }
 
@@ -47,7 +47,7 @@ class CensusOfDeutschland extends Census implements CensusPlaceInterface
      */
     public function censusPlace(): string
     {
-        return 'Deutschland';
+        return 'Mecklenburg';
     }
 
     /**

--- a/app/Census/CensusOfMecklenburg1819.php
+++ b/app/Census/CensusOfMecklenburg1819.php
@@ -22,7 +22,7 @@ namespace Fisharebest\Webtrees\Census;
 /**
  * Definitions for a census
  */
-class CensusOfDeutschland1819 extends CensusOfDeutschland implements CensusInterface
+class CensusOfMecklenburg1819 extends CensusOfMecklenburg implements CensusInterface
 {
     /**
      * When did this census occur.

--- a/app/Census/CensusOfMecklenburg1867.php
+++ b/app/Census/CensusOfMecklenburg1867.php
@@ -22,7 +22,7 @@ namespace Fisharebest\Webtrees\Census;
 /**
  * Definitions for a census
  */
-class CensusOfDeutschland1867 extends CensusOfDeutschland implements CensusInterface
+class CensusOfMecklenburg1867 extends CensusOfMecklenburg implements CensusInterface
 {
     /**
      * When did this census occur.

--- a/app/Census/CensusOfMecklenburg1867NL.php
+++ b/app/Census/CensusOfMecklenburg1867NL.php
@@ -22,7 +22,7 @@ namespace Fisharebest\Webtrees\Census;
 /**
  * Definitions for a census
  */
-class CensusOfDeutschlandNL1867 extends CensusOfDeutschland implements CensusInterface
+class CensusOfMecklenburg1867NL extends CensusOfMecklenburg implements CensusInterface
 {
     /**
      * When did this census occur.

--- a/app/Census/CensusOfMecklenburg1900.php
+++ b/app/Census/CensusOfMecklenburg1900.php
@@ -22,7 +22,7 @@ namespace Fisharebest\Webtrees\Census;
 /**
  * Definitions for a census
  */
-class CensusOfDeutschland1900 extends CensusOfDeutschland implements CensusInterface
+class CensusOfMecklenburg1900 extends CensusOfMecklenburg implements CensusInterface
 {
     /**
      * When did this census occur.

--- a/app/Census/CensusOfMecklenburg1919.php
+++ b/app/Census/CensusOfMecklenburg1919.php
@@ -22,7 +22,7 @@ namespace Fisharebest\Webtrees\Census;
 /**
  * Definitions for a census
  */
-class CensusOfDeutschland1919 extends CensusOfDeutschland implements CensusInterface
+class CensusOfMecklenburg1919 extends CensusOfMecklenburg implements CensusInterface
 {
     /**
      * When did this census occur.

--- a/tests/app/Census/CensusOfMecklenburg1819Test.php
+++ b/tests/app/Census/CensusOfMecklenburg1819Test.php
@@ -22,20 +22,20 @@ namespace Fisharebest\Webtrees\Census;
 use Fisharebest\Webtrees\TestCase;
 
 /**
- * Test harness for the class CensusOfDeutschland1819
+ * Test harness for the class CensusOfMecklenburg1819
  */
-class CensusOfDeutschland1819Test extends TestCase
+class CensusOfMecklenburg1819Test extends TestCase
 {
     /**
      * Test the census place and date
      *
-     * @covers \Fisharebest\Webtrees\Census\CensusOfDeutschland1819
+     * @covers \Fisharebest\Webtrees\Census\CensusOfMecklenburg1819
      *
      * @return void
      */
     public function testPlaceAndDate(): void
     {
-        $census = new CensusOfDeutschland1819();
+        $census = new CensusOfMecklenburg1819();
 
         $this->assertSame('Mecklenburg-Schwerin, Deutschland', $census->censusPlace());
         $this->assertSame('AUG 1819', $census->censusDate());
@@ -44,14 +44,14 @@ class CensusOfDeutschland1819Test extends TestCase
     /**
      * Test the census columns
      *
-     * @covers \Fisharebest\Webtrees\Census\CensusOfDeutschland1819
+     * @covers \Fisharebest\Webtrees\Census\CensusOfMecklenburg1819
      * @covers \Fisharebest\Webtrees\Census\AbstractCensusColumn
      *
      * @return void
      */
     public function testColumns(): void
     {
-        $census  = new CensusOfDeutschland1819();
+        $census  = new CensusOfMecklenburg1819();
         $columns = $census->columns();
 
         $this->assertCount(13, $columns);

--- a/tests/app/Census/CensusOfMecklenburg1867NLTest.php
+++ b/tests/app/Census/CensusOfMecklenburg1867NLTest.php
@@ -22,39 +22,39 @@ namespace Fisharebest\Webtrees\Census;
 use Fisharebest\Webtrees\TestCase;
 
 /**
- * Test harness for the class CensusOfDeutschland1867
+ * Test harness for the class CensusOfMecklenburg1867NL
  */
-class CensusOfDeutschland1867Test extends TestCase
+class CensusOfMecklenburg1867NLTest extends TestCase
 {
     /**
      * Test the census place and date
      *
-     * @covers \Fisharebest\Webtrees\Census\CensusOfDeutschland1867
+     * @covers \Fisharebest\Webtrees\Census\CensusOfMecklenburg1867NL
      *
      * @return void
      */
     public function testPlaceAndDate(): void
     {
-        $census = new CensusOfDeutschland1867();
+        $census = new CensusOfMecklenburg1867NL();
 
-        $this->assertSame('Mecklenburg-Schwerin, Deutschland', $census->censusPlace());
+        $this->assertSame('Mecklenburg-Schwerin (Nachtragsliste), Deutschland', $census->censusPlace());
         $this->assertSame('03 DEC 1867', $census->censusDate());
     }
 
     /**
      * Test the census columns
      *
-     * @covers \Fisharebest\Webtrees\Census\CensusOfDeutschland1867
+     * @covers \Fisharebest\Webtrees\Census\CensusOfMecklenburg1867NL
      * @covers \Fisharebest\Webtrees\Census\AbstractCensusColumn
      *
      * @return void
-    */
+     */
     public function testColumns(): void
     {
-        $census  = new CensusOfDeutschland1867();
+        $census  = new CensusOfMecklenburg1867NL();
         $columns = $census->columns();
 
-        $this->assertCount(23, $columns);
+        $this->assertCount(18, $columns);
         $this->assertInstanceOf(CensusColumnNull::class, $columns[0]);
         $this->assertInstanceOf(CensusColumnGivenNames::class, $columns[1]);
         $this->assertInstanceOf(CensusColumnSurname::class, $columns[2]);
@@ -66,18 +66,13 @@ class CensusOfDeutschland1867Test extends TestCase
         $this->assertInstanceOf(CensusColumnNull::class, $columns[8]);
         $this->assertInstanceOf(CensusColumnNull::class, $columns[9]);
         $this->assertInstanceOf(CensusColumnNull::class, $columns[10]);
-        $this->assertInstanceOf(CensusColumnRelationToHeadGerman::class, $columns[11]);
-        $this->assertInstanceOf(CensusColumnOccupation::class, $columns[12]);
+        $this->assertInstanceOf(CensusColumnNull::class, $columns[11]);
+        $this->assertInstanceOf(CensusColumnNull::class, $columns[12]);
         $this->assertInstanceOf(CensusColumnNull::class, $columns[13]);
         $this->assertInstanceOf(CensusColumnNull::class, $columns[14]);
         $this->assertInstanceOf(CensusColumnNull::class, $columns[15]);
         $this->assertInstanceOf(CensusColumnNull::class, $columns[16]);
         $this->assertInstanceOf(CensusColumnNull::class, $columns[17]);
-        $this->assertInstanceOf(CensusColumnNull::class, $columns[18]);
-        $this->assertInstanceOf(CensusColumnNull::class, $columns[19]);
-        $this->assertInstanceOf(CensusColumnNull::class, $columns[20]);
-        $this->assertInstanceOf(CensusColumnNull::class, $columns[21]);
-        $this->assertInstanceOf(CensusColumnNull::class, $columns[22]);
 
         $this->assertSame('1.Nr.', $columns[0]->abbreviation());
         $this->assertSame('2.Vorname', $columns[1]->abbreviation());
@@ -90,22 +85,17 @@ class CensusOfDeutschland1867Test extends TestCase
         $this->assertSame('9.verehelicht', $columns[8]->abbreviation());
         $this->assertSame('10.verwittwet', $columns[9]->abbreviation());
         $this->assertSame('11.geschieden', $columns[10]->abbreviation());
-        $this->assertSame('12.Stellung', $columns[11]->abbreviation());
-        $this->assertSame('13.Stand/Beruf', $columns[12]->abbreviation());
-        $this->assertSame('14.StA_M-S', $columns[13]->abbreviation());
-        $this->assertSame('15.StA', $columns[14]->abbreviation());
+        $this->assertSame('12.StA_M-S', $columns[11]->abbreviation());
+        $this->assertSame('13.StA', $columns[12]->abbreviation());
+        $this->assertSame('14.', $columns[13]->abbreviation());
+        $this->assertSame('15.', $columns[14]->abbreviation());
         $this->assertSame('16.', $columns[15]->abbreviation());
         $this->assertSame('17.', $columns[16]->abbreviation());
-        $this->assertSame('18.', $columns[17]->abbreviation());
-        $this->assertSame('19.', $columns[18]->abbreviation());
-        $this->assertSame('20.blind', $columns[19]->abbreviation());
-        $this->assertSame('21.taubstumm', $columns[20]->abbreviation());
-        $this->assertSame('22.blödsinnig', $columns[21]->abbreviation());
-        $this->assertSame('23.irrsinnig', $columns[22]->abbreviation());
+        $this->assertSame('18.Aufenthaltsort', $columns[17]->abbreviation());
 
-        $this->assertSame('Ordnungs-Nummer (1-15).', $columns[0]->title());
-        $this->assertSame('I. Vor- und Familien-Name jeder Person. Vorname', $columns[1]->title());
-        $this->assertSame('I. Vor- und Familien-Name jeder Person. Familienname.', $columns[2]->title());
+        $this->assertSame('Ordnungs-Nummer.', $columns[0]->title());
+        $this->assertSame('I. Vor- und Familienname jeder Person. Vorname.', $columns[1]->title());
+        $this->assertSame('I. Vor- und Familienname jeder Person. Familienname.', $columns[2]->title());
         $this->assertSame('II. Geschlecht männlich.', $columns[3]->title());
         $this->assertSame('II. Geschlecht weiblich.', $columns[4]->title());
         $this->assertSame('III. Alter.', $columns[5]->title());
@@ -114,17 +104,12 @@ class CensusOfDeutschland1867Test extends TestCase
         $this->assertSame('V. Familienstand. verehelicht.', $columns[8]->title());
         $this->assertSame('V. Familienstand. verwittwet.', $columns[9]->title());
         $this->assertSame('V. Familienstand. geschieden.', $columns[10]->title());
-        $this->assertSame('V. Familienstand. Verhältnis der Familienglieder zum Haushaltungsvorstand.', $columns[11]->title());
-        $this->assertSame('VI. Stand, Beruf oder Vorbereitung zum Beruf, Arbeits- und Dienstverhältnis.', $columns[12]->title());
-        $this->assertSame('VII. Staatsangehörigkeit. Mecklenburg-Schwerinscher Unterthan.', $columns[13]->title());
-        $this->assertSame('VII. Staatsangehörigkeit. Anderen Staaten angehörig. Welchem Staat?', $columns[14]->title());
-        $this->assertSame('VIII. Art des Aufenthalts am Zählungsort. Norddeutscher und Zollvereins- See- und Flußschiffer.', $columns[15]->title());
-        $this->assertSame('VIII. Art des Aufenthalts am Zählungsort. Reisender im Gasthof.', $columns[16]->title());
-        $this->assertSame('VIII. Art des Aufenthalts am Zählungsort. Gast der Familie (zum Besuch aus).', $columns[17]->title());
-        $this->assertSame('VIII. Art des Aufenthalts am Zählungsort. Alle übrigen Anwesenden.', $columns[18]->title());
-        $this->assertSame('IX. Besondere Mängel einzelner Individuen. blind auf beiden Augen.', $columns[19]->title());
-        $this->assertSame('IX. Besondere Mängel einzelner Individuen. taubstumm.', $columns[20]->title());
-        $this->assertSame('IX. Besondere Mängel einzelner Individuen. blödsinnig.', $columns[21]->title());
-        $this->assertSame('IX. Besondere Mängel einzelner Individuen. irrsinnig.', $columns[22]->title());
+        $this->assertSame('VI. Staatsangehörigkeit. Mecklenburg-Schwerinscher Unterthan.', $columns[11]->title());
+        $this->assertSame('VI. Staatsangehörigkeit. Anderen Staaten angehörig. Welchem Staat?', $columns[12]->title());
+        $this->assertSame('VII. Art des Abwesenheit vom Zählungsorte. Nicht über ein Jahr Abwesende als See- oder Flußschiffer.', $columns[13]->title());
+        $this->assertSame('VII. Art des Abwesenheit vom Zählungsorte. Nicht über ein Jahr Abwesende auf Land- oder Seereisen.', $columns[14]->title());
+        $this->assertSame('VII. Art des Abwesenheit vom Zählungsorte. Nicht über ein Jahr Abwesende auf Besuch außerhalb des Orts.', $columns[15]->title());
+        $this->assertSame('VII. Art des Aufenthalts am Zählungsort. Ueber ein Jahr, oder in anderer Art als nach Spalte 14 bis 16 Abwesende.', $columns[16]->title());
+        $this->assertSame('VIII. Vermuthlicher Aufenthaltsort zur Zählungszeit.', $columns[17]->title());
     }
 }

--- a/tests/app/Census/CensusOfMecklenburg1867Test.php
+++ b/tests/app/Census/CensusOfMecklenburg1867Test.php
@@ -22,39 +22,39 @@ namespace Fisharebest\Webtrees\Census;
 use Fisharebest\Webtrees\TestCase;
 
 /**
- * Test harness for the class CensusOfDeutschlandNL1867
+ * Test harness for the class CensusOfMecklenburg1867
  */
-class CensusOfDeutschlandNL1867Test extends TestCase
+class CensusOfMecklenburg1867Test extends TestCase
 {
     /**
      * Test the census place and date
      *
-     * @covers \Fisharebest\Webtrees\Census\CensusOfDeutschlandNL1867
+     * @covers \Fisharebest\Webtrees\Census\CensusOfMecklenburg1867
      *
      * @return void
      */
     public function testPlaceAndDate(): void
     {
-        $census = new CensusOfDeutschlandNL1867();
+        $census = new CensusOfMecklenburg1867();
 
-        $this->assertSame('Mecklenburg-Schwerin (Nachtragsliste), Deutschland', $census->censusPlace());
+        $this->assertSame('Mecklenburg-Schwerin, Deutschland', $census->censusPlace());
         $this->assertSame('03 DEC 1867', $census->censusDate());
     }
 
     /**
      * Test the census columns
      *
-     * @covers \Fisharebest\Webtrees\Census\CensusOfDeutschlandNL1867
+     * @covers \Fisharebest\Webtrees\Census\CensusOfMecklenburg1867
      * @covers \Fisharebest\Webtrees\Census\AbstractCensusColumn
      *
      * @return void
-     */
+    */
     public function testColumns(): void
     {
-        $census  = new CensusOfDeutschlandNL1867();
+        $census  = new CensusOfMecklenburg1867();
         $columns = $census->columns();
 
-        $this->assertCount(18, $columns);
+        $this->assertCount(23, $columns);
         $this->assertInstanceOf(CensusColumnNull::class, $columns[0]);
         $this->assertInstanceOf(CensusColumnGivenNames::class, $columns[1]);
         $this->assertInstanceOf(CensusColumnSurname::class, $columns[2]);
@@ -66,13 +66,18 @@ class CensusOfDeutschlandNL1867Test extends TestCase
         $this->assertInstanceOf(CensusColumnNull::class, $columns[8]);
         $this->assertInstanceOf(CensusColumnNull::class, $columns[9]);
         $this->assertInstanceOf(CensusColumnNull::class, $columns[10]);
-        $this->assertInstanceOf(CensusColumnNull::class, $columns[11]);
-        $this->assertInstanceOf(CensusColumnNull::class, $columns[12]);
+        $this->assertInstanceOf(CensusColumnRelationToHeadGerman::class, $columns[11]);
+        $this->assertInstanceOf(CensusColumnOccupation::class, $columns[12]);
         $this->assertInstanceOf(CensusColumnNull::class, $columns[13]);
         $this->assertInstanceOf(CensusColumnNull::class, $columns[14]);
         $this->assertInstanceOf(CensusColumnNull::class, $columns[15]);
         $this->assertInstanceOf(CensusColumnNull::class, $columns[16]);
         $this->assertInstanceOf(CensusColumnNull::class, $columns[17]);
+        $this->assertInstanceOf(CensusColumnNull::class, $columns[18]);
+        $this->assertInstanceOf(CensusColumnNull::class, $columns[19]);
+        $this->assertInstanceOf(CensusColumnNull::class, $columns[20]);
+        $this->assertInstanceOf(CensusColumnNull::class, $columns[21]);
+        $this->assertInstanceOf(CensusColumnNull::class, $columns[22]);
 
         $this->assertSame('1.Nr.', $columns[0]->abbreviation());
         $this->assertSame('2.Vorname', $columns[1]->abbreviation());
@@ -85,17 +90,22 @@ class CensusOfDeutschlandNL1867Test extends TestCase
         $this->assertSame('9.verehelicht', $columns[8]->abbreviation());
         $this->assertSame('10.verwittwet', $columns[9]->abbreviation());
         $this->assertSame('11.geschieden', $columns[10]->abbreviation());
-        $this->assertSame('12.StA_M-S', $columns[11]->abbreviation());
-        $this->assertSame('13.StA', $columns[12]->abbreviation());
-        $this->assertSame('14.', $columns[13]->abbreviation());
-        $this->assertSame('15.', $columns[14]->abbreviation());
+        $this->assertSame('12.Stellung', $columns[11]->abbreviation());
+        $this->assertSame('13.Stand/Beruf', $columns[12]->abbreviation());
+        $this->assertSame('14.StA_M-S', $columns[13]->abbreviation());
+        $this->assertSame('15.StA', $columns[14]->abbreviation());
         $this->assertSame('16.', $columns[15]->abbreviation());
         $this->assertSame('17.', $columns[16]->abbreviation());
-        $this->assertSame('18.Aufenthaltsort', $columns[17]->abbreviation());
+        $this->assertSame('18.', $columns[17]->abbreviation());
+        $this->assertSame('19.', $columns[18]->abbreviation());
+        $this->assertSame('20.blind', $columns[19]->abbreviation());
+        $this->assertSame('21.taubstumm', $columns[20]->abbreviation());
+        $this->assertSame('22.blödsinnig', $columns[21]->abbreviation());
+        $this->assertSame('23.irrsinnig', $columns[22]->abbreviation());
 
-        $this->assertSame('Ordnungs-Nummer.', $columns[0]->title());
-        $this->assertSame('I. Vor- und Familienname jeder Person. Vorname.', $columns[1]->title());
-        $this->assertSame('I. Vor- und Familienname jeder Person. Familienname.', $columns[2]->title());
+        $this->assertSame('Ordnungs-Nummer (1-15).', $columns[0]->title());
+        $this->assertSame('I. Vor- und Familien-Name jeder Person. Vorname', $columns[1]->title());
+        $this->assertSame('I. Vor- und Familien-Name jeder Person. Familienname.', $columns[2]->title());
         $this->assertSame('II. Geschlecht männlich.', $columns[3]->title());
         $this->assertSame('II. Geschlecht weiblich.', $columns[4]->title());
         $this->assertSame('III. Alter.', $columns[5]->title());
@@ -104,12 +114,17 @@ class CensusOfDeutschlandNL1867Test extends TestCase
         $this->assertSame('V. Familienstand. verehelicht.', $columns[8]->title());
         $this->assertSame('V. Familienstand. verwittwet.', $columns[9]->title());
         $this->assertSame('V. Familienstand. geschieden.', $columns[10]->title());
-        $this->assertSame('VI. Staatsangehörigkeit. Mecklenburg-Schwerinscher Unterthan.', $columns[11]->title());
-        $this->assertSame('VI. Staatsangehörigkeit. Anderen Staaten angehörig. Welchem Staat?', $columns[12]->title());
-        $this->assertSame('VII. Art des Abwesenheit vom Zählungsorte. Nicht über ein Jahr Abwesende als See- oder Flußschiffer.', $columns[13]->title());
-        $this->assertSame('VII. Art des Abwesenheit vom Zählungsorte. Nicht über ein Jahr Abwesende auf Land- oder Seereisen.', $columns[14]->title());
-        $this->assertSame('VII. Art des Abwesenheit vom Zählungsorte. Nicht über ein Jahr Abwesende auf Besuch außerhalb des Orts.', $columns[15]->title());
-        $this->assertSame('VII. Art des Aufenthalts am Zählungsort. Ueber ein Jahr, oder in anderer Art als nach Spalte 14 bis 16 Abwesende.', $columns[16]->title());
-        $this->assertSame('VIII. Vermuthlicher Aufenthaltsort zur Zählungszeit.', $columns[17]->title());
+        $this->assertSame('V. Familienstand. Verhältnis der Familienglieder zum Haushaltungsvorstand.', $columns[11]->title());
+        $this->assertSame('VI. Stand, Beruf oder Vorbereitung zum Beruf, Arbeits- und Dienstverhältnis.', $columns[12]->title());
+        $this->assertSame('VII. Staatsangehörigkeit. Mecklenburg-Schwerinscher Unterthan.', $columns[13]->title());
+        $this->assertSame('VII. Staatsangehörigkeit. Anderen Staaten angehörig. Welchem Staat?', $columns[14]->title());
+        $this->assertSame('VIII. Art des Aufenthalts am Zählungsort. Norddeutscher und Zollvereins- See- und Flußschiffer.', $columns[15]->title());
+        $this->assertSame('VIII. Art des Aufenthalts am Zählungsort. Reisender im Gasthof.', $columns[16]->title());
+        $this->assertSame('VIII. Art des Aufenthalts am Zählungsort. Gast der Familie (zum Besuch aus).', $columns[17]->title());
+        $this->assertSame('VIII. Art des Aufenthalts am Zählungsort. Alle übrigen Anwesenden.', $columns[18]->title());
+        $this->assertSame('IX. Besondere Mängel einzelner Individuen. blind auf beiden Augen.', $columns[19]->title());
+        $this->assertSame('IX. Besondere Mängel einzelner Individuen. taubstumm.', $columns[20]->title());
+        $this->assertSame('IX. Besondere Mängel einzelner Individuen. blödsinnig.', $columns[21]->title());
+        $this->assertSame('IX. Besondere Mängel einzelner Individuen. irrsinnig.', $columns[22]->title());
     }
 }

--- a/tests/app/Census/CensusOfMecklenburg1900Test.php
+++ b/tests/app/Census/CensusOfMecklenburg1900Test.php
@@ -22,20 +22,20 @@ namespace Fisharebest\Webtrees\Census;
 use Fisharebest\Webtrees\TestCase;
 
 /**
- * Test harness for the class CensusOfDeutschland1900
+ * Test harness for the class CensusOfMecklenburg1900
  */
-class CensusOfDeutschland1900Test extends TestCase
+class CensusOfMecklenburg1900Test extends TestCase
 {
     /**
      * Test the census place and date
      *
-     * @covers \Fisharebest\Webtrees\Census\CensusOfDeutschland1900
+     * @covers \Fisharebest\Webtrees\Census\CensusOfMecklenburg1900
      *
      * @return void
      */
     public function testPlaceAndDate(): void
     {
-        $census = new CensusOfDeutschland1900();
+        $census = new CensusOfMecklenburg1900();
 
         $this->assertSame('Mecklenburg-Schwerin, Deutschland', $census->censusPlace());
         $this->assertSame('01 DEC 1900', $census->censusDate());
@@ -44,14 +44,14 @@ class CensusOfDeutschland1900Test extends TestCase
     /**
      * Test the census columns
      *
-     * @covers \Fisharebest\Webtrees\Census\CensusOfDeutschland1900
+     * @covers \Fisharebest\Webtrees\Census\CensusOfMecklenburg1900
      * @covers \Fisharebest\Webtrees\Census\AbstractCensusColumn
      *
      * @return void
      */
     public function testColumns(): void
     {
-        $census  = new CensusOfDeutschland1900();
+        $census  = new CensusOfMecklenburg1900();
         $columns = $census->columns();
 
         $this->assertCount(27, $columns);

--- a/tests/app/Census/CensusOfMecklenburg1919Test.php
+++ b/tests/app/Census/CensusOfMecklenburg1919Test.php
@@ -22,20 +22,20 @@ namespace Fisharebest\Webtrees\Census;
 use Fisharebest\Webtrees\TestCase;
 
 /**
- * Test harness for the class CensusOfDeutschland1919
+ * Test harness for the class CensusOfMecklenburg1919
  */
-class CensusOfDeutschland1919Test extends TestCase
+class CensusOfMecklenburg1919Test extends TestCase
 {
     /**
      * Test the census place and date
      *
-     * @covers \Fisharebest\Webtrees\Census\CensusOfDeutschland1919
+     * @covers \Fisharebest\Webtrees\Census\CensusOfMecklenburg1919
      *
      * @return void
      */
     public function testPlaceAndDate(): void
     {
-        $census = new CensusOfDeutschland1919();
+        $census = new CensusOfMecklenburg1919();
 
         $this->assertSame('Mecklenburg-Schwerin, Deutschland', $census->censusPlace());
         $this->assertSame('08 OCT 1919', $census->censusDate());
@@ -44,14 +44,14 @@ class CensusOfDeutschland1919Test extends TestCase
     /**
      * Test the census columns
      *
-     * @covers \Fisharebest\Webtrees\Census\CensusOfDeutschland1919
+     * @covers \Fisharebest\Webtrees\Census\CensusOfMecklenburg1919
      * @covers \Fisharebest\Webtrees\Census\AbstractCensusColumn
      *
      * @return void
      */
     public function testColumns(): void
     {
-        $census  = new CensusOfDeutschland1919();
+        $census  = new CensusOfMecklenburg1919();
         $columns = $census->columns();
 
         $this->assertCount(17, $columns);

--- a/tests/app/Census/CensusOfMecklenburgTest.php
+++ b/tests/app/Census/CensusOfMecklenburgTest.php
@@ -22,20 +22,20 @@ namespace Fisharebest\Webtrees\Census;
 use Fisharebest\Webtrees\TestCase;
 
 /**
- * Test harness for the class CensusOfDeutschland
+ * Test harness for the class CensusOfMecklenburg
  */
-class CensusOfDeutschlandTest extends TestCase
+class CensusOfMecklenburgTest extends TestCase
 {
     /**
      * Test the census place
      *
-     * @covers \Fisharebest\Webtrees\Census\CensusOfDeutschland
+     * @covers \Fisharebest\Webtrees\Census\CensusOfMecklenburg
      *
      * @return void
      */
     public function testPlace(): void
     {
-        $census = new CensusOfDeutschland();
+        $census = new CensusOfMecklenburg();
 
         $this->assertSame('Deutschland', $census->censusPlace());
     }
@@ -43,13 +43,13 @@ class CensusOfDeutschlandTest extends TestCase
     /**
      * Test the census language
      *
-     * @covers \Fisharebest\Webtrees\Census\CensusOfCzechRepublic
+     * @covers \Fisharebest\Webtrees\Census\CensusOfMecklenburg
      *
      * @return void
      */
     public function testLanguage(): void
     {
-        $census = new CensusOfDeutschland();
+        $census = new CensusOfMecklenburg();
 
         $this->assertSame('de', $census->censusLanguage());
     }
@@ -57,21 +57,21 @@ class CensusOfDeutschlandTest extends TestCase
     /**
      * Test the census dates
      *
-     * @covers \Fisharebest\Webtrees\Census\CensusOfDeutschland
+     * @covers \Fisharebest\Webtrees\Census\CensusOfMecklenburg
      *
      * @return void
      */
     public function testAllDates(): void
     {
-        $census = new CensusOfDeutschland();
+        $census = new CensusOfMecklenburg();
 
         $census_dates = $census->allCensusDates();
 
         $this->assertCount(5, $census_dates);
-        $this->assertInstanceOf(CensusOfDeutschland1819::class, $census_dates[0]);
-        $this->assertInstanceOf(CensusOfDeutschland1867::class, $census_dates[1]);
-        $this->assertInstanceOf(CensusOfDeutschlandNL1867::class, $census_dates[2]);
-        $this->assertInstanceOf(CensusOfDeutschland1900::class, $census_dates[3]);
-        $this->assertInstanceOf(CensusOfDeutschland1919::class, $census_dates[4]);
+        $this->assertInstanceOf(CensusOfMecklenburg1819::class, $census_dates[0]);
+        $this->assertInstanceOf(CensusOfMecklenburg1867::class, $census_dates[1]);
+        $this->assertInstanceOf(CensusOfMecklenburg1867NL::class, $census_dates[2]);
+        $this->assertInstanceOf(CensusOfMecklenburg1900::class, $census_dates[3]);
+        $this->assertInstanceOf(CensusOfMecklenburg1919::class, $census_dates[4]);
     }
 }

--- a/tests/app/Census/CensusOfMecklenburgTest.php
+++ b/tests/app/Census/CensusOfMecklenburgTest.php
@@ -37,7 +37,7 @@ class CensusOfMecklenburgTest extends TestCase
     {
         $census = new CensusOfMecklenburg();
 
-        $this->assertSame('Deutschland', $census->censusPlace());
+        $this->assertSame('Mecklenburg', $census->censusPlace());
     }
 
     /**

--- a/tests/app/Census/CensusTest.php
+++ b/tests/app/Census/CensusTest.php
@@ -40,7 +40,7 @@ class CensusTest extends TestCase
         $this->assertInstanceOf(CensusOfEngland::class, $censuses[1]);
         $this->assertInstanceOf(CensusOfScotland::class, $censuses[2]);
         $this->assertInstanceOf(CensusOfWales::class, $censuses[3]);
-        $this->assertInstanceOf(CensusOfDeutschland::class, $censuses[4]);
+        $this->assertInstanceOf(CensusOfMecklenburg::class, $censuses[4]);
         $this->assertInstanceOf(CensusOfFrance::class, $censuses[5]);
         $this->assertInstanceOf(CensusOfCzechRepublic::class, $censuses[6]);
         $this->assertInstanceOf(CensusOfSlovakia::class, $censuses[7]);


### PR DESCRIPTION
Since there have been different censuses in Germany and its predecessor states, those listed here should be clearly assigned. I hope that I have changed all relevant files.