### PR TITLE
Roots filter not working in family datatable

### DIFF
--- a/resources/views/lists/families-table.phtml
+++ b/resources/views/lists/families-table.phtml
@@ -396,7 +396,7 @@ $marriageAgeData = [
 
                 <!-- Filter by roots/leaves -->
                 <td hidden>
-                    <?php if (!$husb->childFamilies() && !$wife->childFamilies()) : ?>
+                    <?php if ($husb->childFamilies()->isEmpty() && $wife->childFamilies()->isEmpty()) : ?>
                         R
                     <?php elseif (!$husb->isDead() && !$wife->isDead() && $family->numberOfChildren() === 0) : ?>
                         L


### PR DESCRIPTION
The logic for the "roots" filter is not working properly, as it is checking a null on `->childFamilies()` which always returns a `Collection`. We want to check if the collection is empty.