### PR TITLE
Map coordinate fixes

### DIFF
--- a/app/Fact.php
+++ b/app/Fact.php
@@ -273,9 +273,9 @@ class Fact
     /**
      * Get the PLAC:MAP:LATI for the fact.
      *
-     * @return float
+     * @return float|null
      */
-    public function latitude(): float
+    public function latitude()
     {
         if (preg_match('/\n4 LATI (.+)/', $this->gedcom, $match)) {
             $gedcom_service = new GedcomService();
@@ -283,15 +283,15 @@ class Fact
             return $gedcom_service->readLatitude($match[1]);
         }
 
-        return 0.0;
+        return null;
     }
 
     /**
      * Get the PLAC:MAP:LONG for the fact.
      *
-     * @return float
+     * @return float|null
      */
-    public function longitude(): float
+    public function longitude()
     {
         if (preg_match('/\n4 LONG (.+)/', $this->gedcom, $match)) {
             $gedcom_service = new GedcomService();
@@ -299,7 +299,7 @@ class Fact
             return $gedcom_service->readLongitude($match[1]);
         }
 
-        return 0.0;
+        return null;
     }
 
     /**

--- a/app/Functions/FunctionsImport.php
+++ b/app/Functions/FunctionsImport.php
@@ -491,7 +491,7 @@ class FunctionsImport
 
         $location = new PlaceLocation($place_name);
 
-        if ($location->latitude() === 0.0 && $location->longitude() === 0.0) {
+        if ($location->latitude() === null || $location->longitude() === null) {
             DB::table('placelocation')
                 ->where('pl_id', '=', $location->id())
                 ->update([
@@ -528,7 +528,7 @@ class FunctionsImport
 
         $location = new PlaceLocation($place_name);
 
-        if ($location->latitude() === 0.0 && $location->longitude() === 0.0) {
+        if ($location->latitude() === null || $location->longitude() === null) {
             DB::table('placelocation')
                 ->where('pl_id', '=', $location->id())
                 ->update([

--- a/app/Module/PedigreeMapModule.php
+++ b/app/Module/PedigreeMapModule.php
@@ -31,6 +31,7 @@ use Fisharebest\Webtrees\Individual;
 use Fisharebest\Webtrees\PlaceLocation;
 use Fisharebest\Webtrees\Menu;
 use Fisharebest\Webtrees\Services\ChartService;
+use Fisharebest\Webtrees\Services\GedcomService;
 use Fisharebest\Webtrees\Tree;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -268,12 +269,12 @@ class PedigreeMapModule extends AbstractModule implements ModuleChartInterface, 
             $longitude = $fact->longitude();
 
             // Use the co-ordinates from the location otherwise.
-            if ($latitude === 0.0 && $longitude === 0.0) {
+            if ($latitude === null || $longitude === null) {
                 $latitude  = $location->latitude();
                 $longitude = $location->longitude();
             }
 
-            if ($latitude !== 0.0 || $longitude !== 0.0) {
+            if ($latitude !== null && $longitude !== null) {
                 $polyline           = null;
                 $sosa_points[$sosa] = [$latitude, $longitude];
                 $sosa_child         = intdiv($sosa, 2);

--- a/app/Module/PlaceHierarchyListModule.php
+++ b/app/Module/PlaceHierarchyListModule.php
@@ -25,6 +25,7 @@ use Fisharebest\Webtrees\Contracts\UserInterface;
 use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\Place;
 use Fisharebest\Webtrees\PlaceLocation;
+use Fisharebest\Webtrees\Services\GedcomService;
 use Fisharebest\Webtrees\Services\ModuleService;
 use Fisharebest\Webtrees\Services\SearchService;
 use Fisharebest\Webtrees\Services\UserService;
@@ -353,7 +354,7 @@ class PlaceHierarchyListModule extends AbstractModule implements ModuleListInter
                 $flag = '';
             }
 
-            if ($location->latitude() === 0.0 && $location->longitude() === 0.0) {
+            if ($location->latitude() === null || $location->longitude() === null) {
                 $sidebar_class = 'unmapped';
             } else {
                 $sidebar_class = 'mapped';

--- a/app/Module/PlacesModule.php
+++ b/app/Module/PlacesModule.php
@@ -25,6 +25,7 @@ use Fisharebest\Webtrees\Family;
 use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\Individual;
 use Fisharebest\Webtrees\PlaceLocation;
+use Fisharebest\Webtrees\Services\GedcomService;
 use Fisharebest\Webtrees\Site;
 use Illuminate\Support\Collection;
 use stdClass;
@@ -167,12 +168,12 @@ class PlacesModule extends AbstractModule implements ModuleTabInterface
             $longitude = $fact->longitude();
 
             // Use the co-ordinates from the location otherwise.
-            if ($latitude === 0.0 && $longitude === 0.0) {
+            if ($latitude === null || $longitude === null) {
                 $latitude  = $location->latitude();
                 $longitude = $location->longitude();
             }
 
-            if ($latitude !== 0.0 || $longitude !== 0.0) {
+            if ($latitude !== null && $longitude !== null) {
                 $geojson['features'][] = [
                     'type'       => 'Feature',
                     'id'         => $id,

--- a/app/Schema/Migration45.php
+++ b/app/Schema/Migration45.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2020 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Fisharebest\Webtrees\Schema;
+
+use Illuminate\Database\Capsule\Manager as DB;
+use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Schema\Blueprint;
+
+/**
+ * Upgrade the database schema from version 45 to version 46.
+ */
+class Migration45 implements MigrationInterface
+{
+    /**
+     * Upgrade to the next version
+     *
+     * @return void
+     */
+    public function upgrade(): void
+    {
+        if (!DB::schema()->hasColumn('placelocation', 'pl_latitude')) {
+            DB::schema()->table('placelocation', static function (Blueprint $table): void {
+                $table->float('pl_latitude')->nullable()->after('pl_lati');
+                $table->float('pl_longitude')->nullable()->after('pl_long');
+            });
+        }
+
+        DB::table('placelocation')
+            ->where('pl_lati', 'LIKE', 'N%')
+            ->update(['pl_latitude' => new Expression('CAST(SUBSTR(pl_lati, 2) AS FLOAT)')]);
+
+        DB::table('placelocation')
+            ->where('pl_lati', 'LIKE', 'S%')
+            ->update(['pl_latitude' => new Expression('- CAST(SUBSTR(pl_lati, 2) AS FLOAT)')]);
+
+        DB::table('placelocation')
+            ->where('pl_long', 'LIKE', 'E%')
+            ->update(['pl_longitude' => new Expression('CAST(SUBSTR(pl_long, 2) AS FLOAT)')]);
+
+        DB::table('placelocation')
+            ->where('pl_long', 'LIKE', 'W%')
+            ->update(['pl_longitude' => new Expression('- CAST(SUBSTR(pl_long, 2) AS FLOAT)')]);
+
+        DB::schema()->table('placelocation', static function (Blueprint $table): void {
+            $table->dropColumn('pl_lati');
+            $table->dropColumn('pl_long');
+            $table->dropColumn('pl_zoom');
+            $table->dropColumn('pl_icon');
+            $table->dropColumn('pl_level');
+        });
+    }
+}

--- a/app/Services/GedcomService.php
+++ b/app/Services/GedcomService.php
@@ -159,7 +159,7 @@ class GedcomService
     ];
 
     // LATI and LONG tags
-    private const DEGREE_FORMAT  = ' % .5f%s';
+    public const PRECISION       = 5; // 5 decimal places locate to within about 1 metre
     private const LATITUDE_NORTH = 'N';
     private const LATITUDE_SOUTH = 'S';
     private const LONGITUDE_EAST = 'E';
@@ -203,9 +203,9 @@ class GedcomService
     /**
      * @param string $text
      *
-     * @return float
+     * @return float|null
      */
-    public function readLatitude(string $text): float
+    public function readLatitude(string $text)
     {
         return $this->readDegrees($text, self::LATITUDE_NORTH, self::LATITUDE_SOUTH);
     }
@@ -213,9 +213,9 @@ class GedcomService
     /**
      * @param string $text
      *
-     * @return float
+     * @return float|null
      */
-    public function readLongitude(string $text): float
+    public function readLongitude(string $text)
     {
         return $this->readDegrees($text, self::LONGITUDE_EAST, self::LONGITUDE_WEST);
     }
@@ -225,9 +225,9 @@ class GedcomService
      * @param string $positive
      * @param string $negative
      *
-     * @return float
+     * @return float|null
      */
-    private function readDegrees(string $text, string $positive, string $negative): float
+    private function readDegrees(string $text, string $positive, string $negative)
     {
         $text       = trim($text);
         $hemisphere = substr($text, 0, 1);
@@ -253,7 +253,7 @@ class GedcomService
         }
 
         // Can't match anything.
-        return 0.0;
+        return null;
     }
 
     /**
@@ -285,11 +285,9 @@ class GedcomService
      */
     private function writeDegrees(float $degrees, string $positive, string $negative): string
     {
-        if ($degrees < 0.0) {
-            return sprintf(self::DEGREE_FORMAT, $degrees, $negative);
-        }
+        $tmp = round($degrees, self::PRECISION);
 
-        return sprintf(self::DEGREE_FORMAT, $degrees, $positive);
+        return ($tmp < 0 ? $negative : $positive) . (string) abs($tmp);
     }
 
     /**

--- a/resources/views/admin/location-edit.phtml
+++ b/resources/views/admin/location-edit.phtml
@@ -3,6 +3,7 @@
 use Fisharebest\Webtrees\Http\RequestHandlers\MapDataList;
 use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\PlaceLocation;
+use Fisharebest\Webtrees\Services\GedcomService;
 use Fisharebest\Webtrees\View;
 
 /**
@@ -15,6 +16,7 @@ use Fisharebest\Webtrees\View;
  * @var PlaceLocation        $parent
  * @var mixed                $provider
  * @var string               $title
+ * @val integer              $level
  */
 
 ?>
@@ -98,9 +100,9 @@ use Fisharebest\Webtrees\View;
     window.WT_OSM_ADMIN = (function () {
         const minZoom = 2;
 
-        let provider = <?= json_encode($provider) ?>;
+        const provider  = <?= json_encode($provider) ?>;
+        const add_place = <?= json_encode($location->id() === 0) ?>;
         let map = null;
-        let add_place = <?= json_encode($location->id() === 0) ?>;
 
         // map components
 
@@ -114,8 +116,8 @@ use Fisharebest\Webtrees\View;
             .on('dragend', function () {
                 let coords = marker.getLatLng();
                 map.panTo(coords);
-                $('#new_place_lati').val(Number(coords.lat).toFixed(5));
-                $('#new_place_long').val(Number(coords.lng).toFixed(5));
+                $('#new_place_lati').val(Number(coords.lat).toFixed(<?= json_encode(GedcomService::PRECISION) ?>));
+                $('#new_place_long').val(Number(coords.lng).toFixed(<?= json_encode(GedcomService::PRECISION) ?>));
                 $('#new_zoom_factor').val(Number(map.getZoom()));
             });
 
@@ -169,9 +171,11 @@ use Fisharebest\Webtrees\View;
                 if (add_place) {
                     $('#new_place_name').val(place.shift());
                 }
-                $('#new_place_lati').val(Number(coords.lat).toFixed(5));
-                $('#new_place_long').val(Number(coords.lng).toFixed(5));
+                $('#new_place_lati').val(Number(coords.lat).toFixed(<?= json_encode(GedcomService::PRECISION) ?>));
+                $('#new_place_long').val(Number(coords.lng).toFixed(<?= json_encode(GedcomService::PRECISION) ?>));
                 $('#new_zoom_factor').val(Number(map.getZoom()));
+                validate_place();
+                validate_latlng();
             });
 
         /**
@@ -190,6 +194,41 @@ use Fisharebest\Webtrees\View;
                 map.panTo([lat, lng]);
             });
         });
+
+        /**
+         *
+         * Validate the fields
+         */
+        const level        = <?= json_encode($level) ?>;
+        const place_input  = document.getElementById("new_place_name");
+        const lat_input    = document.getElementById("new_place_lati");
+        const lng_input    = document.getElementById("new_place_long");
+        const place_error  = "<?= I18N::translate('Location [0,0] cannot have a subordinate place') ?>";
+        const latlng_error = "<?= I18N::translate('Location [0,0] cannot be subordinate to another place') ?>";
+        const parent_lat   = <?= json_encode($parent->latitude()) ?>;
+        const parent_lng   = <?= json_encode($parent->longitude()) ?>;
+
+        /**
+         *
+         * Place field
+         */
+        let validate_place = function() {
+          let invalid = level > 0 && parent_lat === 0.0 && parent_lng === 0.0;
+          place_input.setCustomValidity((invalid ? place_error : ''));
+        };
+        place_input.addEventListener('input', validate_place);
+
+        /**
+         *
+         * Combined latitude & longitude fields
+         */
+        let validate_latlng = function() {
+          let invalid = level > 0 && parseFloat(lat_input.value) === 0.0 && parseFloat(lng_input.value) === 0.0;
+          lat_input.setCustomValidity((invalid ? latlng_error : ''));
+          lng_input.setCustomValidity((invalid ? latlng_error : ''));
+        };
+        lat_input.addEventListener('input', validate_latlng);
+        lng_input.addEventListener('input', validate_latlng);
 
         // Create the map with all controls and layers
         map = L.map('osm-map', {

--- a/tests/app/PlaceLocationTest.php
+++ b/tests/app/PlaceLocationTest.php
@@ -17,26 +17,22 @@
 
 declare(strict_types=1);
 
-namespace Fisharebest\Webtrees\Schema;
-
-use Illuminate\Database\Capsule\Manager as DB;
+namespace Fisharebest\Webtrees;
 
 /**
- * Upgrade the database schema from version 44 to version 45.
+ * Test harness for the class PlaceLocation
+ *
+ * @covers \Fisharebest\Webtrees\PlaceLocation
  */
-class Migration44 implements MigrationInterface
+class PlaceLocationTest extends TestCase
 {
     /**
-     * Upgrade to the next version
+     * Test that the class exists
      *
      * @return void
      */
-    public function upgrade(): void
+    public function testClassExists(): void
     {
-        DB::table('placelocation')
-            ->where('pl_lati', '=', 'N0')
-            ->where('pl_long', '=', 'E0')
-            ->where('pl_level', '>', 0)
-            ->update(['pl_lati' => null, 'pl_long' => null, 'pl_zoom' => null]);
+        self::assertTrue(class_exists(PlaceLocation::class));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/fisharebest/webtrees/issues/3638 and standardises co-ordinate formats.

- Use null to indicate an invalid coordinate rather than 0 (which is a valid coordinate)
- Use null rather than empty string for latitude & longitude when importing places from genealogy data
- Add field validation to Control Panel|Geographic Data|Add/Edit page so that location [0,0] is only valid at the global level
- Tighten up import/export routines to ensure invalid data is excluded and data written to the database has a consistent format.
- Fixed bug in `GedcomService::writeDegrees();` - Incorrect format definition
- Bump existing (but not applied) Migration44.php to Migration45.php to enable creation of new Migration44.php which removes invalid co-ordinates from database. **IMPORTANT** SCHEMA_VERSION in app/webtrees.php has not been changed so this will need to be applied separately.

NB I think application of this PR should make changes to allow Migration45 to be applied relatively simple.