### PR TITLE
Update Mime.php

### DIFF
--- a/app/Mime.php
+++ b/app/Mime.php
@@ -52,7 +52,7 @@ class Mime
         'pdf'  => 'application/pdf',
         'png'  => 'image/png',
         'rar'  => 'application/x-rar-compressed',
-        'svg'  => 'image/svg',
+        'svg'  => 'image/svg+xml',
         'swf'  => 'application/x-shockwave-flash',
         'tif'  => 'image/tiff',
         'tiff' => 'image/tiff',


### PR DESCRIPTION
Fixed mime type of SVG images => see https://www.w3.org/TR/SVG11/intro.html#MIMEType

With this fix SVG images could be used within asset URLs.