### PR TITLE
Datatables pagination

### DIFF
--- a/resources/js/vendor.js
+++ b/resources/js/vendor.js
@@ -28,12 +28,12 @@ import {
 } from '@fortawesome/free-regular-svg-icons';
 import {
   // For resources/views/icons/*
-  faArrowDown, faArrowLeft, faArrowRight, faArrowUp, faArrowsAltV, faBan, faBars,
-  faCalendar, faCaretDown, faCaretUp, faCheck, faCodeBranch, faDownload, faExclamationTriangle, faGenderless,
-  faGripHorizontal, faGripLines, faHistory, faInfoCircle, faLanguage, faLink, faList,
-  faLock, faMagic, faMap, faMapMarkerAlt, faMars, faMedkit, faPaintBrush, faPause, faPencilAlt,
-  faPlay, faPlus, faPuzzlePiece, faQuestionCircle, faRedo, faSearch, faSearchLocation, faSearchMinus, faSearchPlus, faShareAlt,
-  faSitemap, faSortAmountDown, faStepForward, faStop, faSyncAlt, faTags, faThList, faThumbtack,
+  faArrowDown, faArrowLeft, faArrowRight, faArrowUp, faArrowsAltV, faBan, faBars, faCalendar, faCaretDown,
+  faCaretUp, faCheck, faCodeBranch, faDownload, faExclamationTriangle, faFastBackward, faFastForward,
+  faGenderless, faGripHorizontal, faGripLines, faHistory, faInfoCircle, faLanguage, faLink, faList, faLock,
+  faMagic, faMap, faMapMarkerAlt, faMars, faMedkit, faPaintBrush, faPause, faPencilAlt, faPlay, faPlus,
+  faPuzzlePiece, faQuestionCircle, faRedo, faSearch, faSearchLocation, faSearchMinus, faSearchPlus, faShareAlt,
+  faSitemap, faSortAmountDown, faStepBackward, faStepForward, faStop, faSyncAlt, faTags, faThList, faThumbtack,
   faTimes, faTransgender, faTree, faUniversity, faUnlink, faUpload, faUsers, faVenus, faWrench,
   // For the BeautifyMarker library
   faBabyCarriage, faBullseye, faHome, faIndustry, faInfinity, faStarOfDavid, faWater
@@ -130,12 +130,12 @@ library.add(
 );
 library.add(
   // For resources/views/icons/*
-  faArrowDown, faArrowLeft, faArrowRight, faArrowUp, faArrowsAltV, faBan, faBars,
-  faCalendar, faCaretDown, faCaretUp, faCheck, faCodeBranch, faDownload, faExclamationTriangle, faGenderless,
-  faGripHorizontal, faGripLines, faHistory, faInfoCircle, faLanguage, faLink, faList,
-  faLock, faMagic, faMap, faMapMarkerAlt, faMars, faMedkit, faPaintBrush, faPause, faPencilAlt,
-  faPlay, faPlus, faPuzzlePiece, faQuestionCircle, faRedo, faSearch, faSearchLocation, faSearchMinus, faSearchPlus, faShareAlt,
-  faSitemap, faSortAmountDown, faStepForward, faStop, faSyncAlt, faThList, faThumbtack,
+  faArrowDown, faArrowLeft, faArrowRight, faArrowUp, faArrowsAltV, faBan, faBars, faCalendar, faCaretDown,
+  faCaretUp, faCheck, faCodeBranch, faDownload, faExclamationTriangle, faFastBackward, faFastForward,
+  faGenderless, faGripHorizontal, faGripLines, faHistory, faInfoCircle, faLanguage, faLink, faList, faLock,
+  faMagic, faMap, faMapMarkerAlt, faMars, faMedkit, faPaintBrush, faPause, faPencilAlt, faPlay, faPlus,
+  faPuzzlePiece, faQuestionCircle, faRedo, faSearch, faSearchLocation, faSearchMinus, faSearchPlus, faShareAlt,
+  faSitemap, faSortAmountDown, faStepBackward, faStepForward, faStop, faSyncAlt, faThList, faThumbtack,
   faTimes, faTransgender, faTree, faUniversity, faUnlink, faUpload, faUsers, faVenus, faWrench,
   // For the BeautifyMarker library
   faBabyCarriage, faBullseye, faHome, faIndustry, faInfinity, faStarOfDavid, faWater

--- a/resources/views/icons/first.phtml
+++ b/resources/views/icons/first.phtml
@@ -1,0 +1,5 @@
+<?Php
+use Fisharebest\Webtrees\I18N;
+
+?>
+<span class="wt-icon-angle-double-left wt-icon-flip-rtl"><i class="fas fa-angle-double-left fa-fw wt-icon-flip-rtl" aria-hidden="true"></i></span>

--- a/resources/views/icons/last.phtml
+++ b/resources/views/icons/last.phtml
@@ -1,0 +1,5 @@
+<?Php
+use Fisharebest\Webtrees\I18N;
+
+?>
+<span class="wt-icon-angle-double-right wt-icon-flip-rtl"><i class="fas fa-angle-double-right fa-fw wt-icon-flip-rtl" aria-hidden="true"></i></span>

--- a/resources/views/icons/next.phtml
+++ b/resources/views/icons/next.phtml
@@ -1,0 +1,5 @@
+<?Php
+use Fisharebest\Webtrees\I18N;
+
+?>
+<span class="wt-icon-angle-right wt-icon-flip-rtl"><i class="fas fa-angle-right fa-fw wt-icon-flip-rtl" aria-hidden="true"></i></span>

--- a/resources/views/icons/previous.phtml
+++ b/resources/views/icons/previous.phtml
@@ -1,0 +1,5 @@
+<?Php
+use Fisharebest\Webtrees\I18N;
+
+?>
+<span class="wt-icon-angle-left wt-icon-flip-rtl"><i class="fas fa-angle-left fa-fw wt-icon-flip-rtl" aria-hidden="true"></i></span>

--- a/resources/views/lists/datatables-attributes.phtml
+++ b/resources/views/lists/datatables-attributes.phtml
@@ -1,23 +1,19 @@
 <?php
 
 use Fisharebest\Webtrees\I18N;
-
 ?>
 
 data-auto-width="false"
-data-dom="<&quot;d-flex justify-content-between&quot;pf><t><&quot;d-flex justify-content-between&quot;irl>"
+data-dom="<&quot;d-flex justify-content-between&quot;pfl><t><&quot;d-flex justify-content-between&quot;pilr>"
 data-state-save="true"
 data-length-menu="<?= e(json_encode([[10, 20, 50, 100, 500, 1000, -1], [I18N::number(10), I18N::number(20), I18N::number(50), I18N::number(100), I18N::number(500), I18N::number(1000), I18N::translate('All')]])) ?>"
+data-paging-type="full_numbers"
 data-language="<?= e(json_encode([
     'paginate'       => [
-        /* I18N: A button label, first page */
-        'first'    => I18N::translate('first'),
-        /* I18N: A button label, last page */
-        'last'     => I18N::translate('last'),
-        /* I18N: A button label, next page */
-        'next'     => I18N::translate('next'),
-        /* I18N: A button label, previous page */
-        'previous' => I18N::translate('previous'),
+        'first'    => view('icons/first'),
+        'last'     => view('icons/last'),
+        'next'     => view('icons/next'),
+        'previous' => view('icons/previous'),
     ],
     'emptyTable'     => I18N::translate('No records to display'),
     /* I18N: %s are placeholders for numbers */


### PR DESCRIPTION
I know you don't like this but...

By changing the first/last/next/previous paging text to symbols and rearranging the controls slightly, the space saved allows the provision of the pagination & display controls on both header & footer of a list without increasing the overall table size. This is useful when viewing a long table (for example the media list on the control panel)

![demo](https://user-images.githubusercontent.com/104515/106473999-5a719100-649c-11eb-94e7-eabf612e5d2a.jpg)
