### PR TITLE
Use Nominatim and Openrouteservice for place autocomplete

### DIFF
--- a/app/Http/RequestHandlers/AutoCompletePlace.php
+++ b/app/Http/RequestHandlers/AutoCompletePlace.php
@@ -19,8 +19,11 @@ declare(strict_types=1);
 
 namespace Fisharebest\Webtrees\Http\RequestHandlers;
 
+use Exception;
+use Fisharebest\Webtrees\Gedcom;
 use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\Place;
+use Fisharebest\Webtrees\Services\UserService;
 use Fisharebest\Webtrees\Site;
 use Fisharebest\Webtrees\Tree;
 use GuzzleHttp\Client;
@@ -28,16 +31,27 @@ use GuzzleHttp\Exception\RequestException;
 use Illuminate\Support\Collection;
 use Psr\Http\Message\ServerRequestInterface;
 
+use function array_filter;
+use function array_merge;
 use function assert;
-use function is_array;
+use function explode;
+use function implode;
 use function json_decode;
+use function json_last_error;
+use function json_last_error_msg;
 use function rawurlencode;
+
+use const JSON_ERROR_NONE;
 
 /**
  * Autocomplete handler for places
  */
 class AutoCompletePlace extends AbstractAutocompleteHandler
 {
+    // Gazetteer urls
+    private const NOMINATIM_URL = 'https://nominatim.openstreetmap.org/search';
+    private const OPENROUTE_URL = 'https://api.openrouteservice.org/geocode/autocomplete';
+
     // Options for fetching files using GuzzleHTTP
     private const GUZZLE_OPTIONS = [
         'connect_timeout' => 3,
@@ -58,33 +72,80 @@ class AutoCompletePlace extends AbstractAutocompleteHandler
                 return $place->gedcomName();
             });
 
-        $geonames = Site::getPreference('geonames');
-
-        if ($data->isEmpty() && $geonames !== '') {
-            // No place found? Use an external gazetteer
-            $url =
-                'https://secure.geonames.org/searchJSON' .
-                '?name_startsWith=' . rawurlencode($query) .
-                '&lang=' . I18N::languageTag() .
-                '&fcode=CMTY&fcode=ADM4&fcode=PPL&fcode=PPLA&fcode=PPLC' .
-                '&style=full' .
-                '&username=' . rawurlencode($geonames);
-
-            // Read from the URL
-            $client = new Client();
-            try {
-                $json   = $client->get($url, self::GUZZLE_OPTIONS)->getBody()->__toString();
-                $places = json_decode($json, true);
-                if (isset($places['geonames']) && is_array($places['geonames'])) {
-                    foreach ($places['geonames'] as $k => $place) {
-                        $data->add($place['name'] . ', ' . $place['adminName2'] . ', ' . $place['adminName1'] . ', ' . $place['countryName']);
-                    }
-                }
-            } catch (RequestException $ex) {
-                // Service down?  Quota exceeded?
-            }
+        if ((bool) Site::getPreference('use_gazetteer')) {
+            $data = $data->concat($this->searchGazetteer($query))->unique();
+            $data = $data->slice(0, static::LIMIT);
         }
 
         return new Collection($data);
+    }
+
+    /**
+     *
+     * @param string $query
+     *
+     * @return Collection<string>
+     */
+    private function searchGazetteer($query): collection
+    {
+        $key          = Site::getPreference('openroute_key');
+        $data         = new Collection();
+        $user_service = new UserService();
+
+        if ($key === '') {
+            $url = self::NOMINATIM_URL;
+            $qry = [
+                'q'               => rawurlencode($query),
+                'format'          => 'jsonv2',
+                'limit'           => static::LIMIT,
+                'accept-language' => I18N::languageTag(),
+                'featuretype'     => 'settlement',
+                'email'           => rawurlencode($user_service->administrators()->first()->email()),
+            ];
+        } else {
+            $url = self::OPENROUTE_URL;
+            $qry = [
+                'api_key' => $key,
+                'text'    => rawurlencode($query),
+                'layers'  => 'coarse',
+                'size'    => static::LIMIT,
+            ];
+        }
+
+        // Read from the URL
+        $client = new Client();
+        try {
+            $json     = $client->get($url, array_merge(self::GUZZLE_OPTIONS, ['query' => $qry]))->getBody()->__toString();
+            $results  = json_decode($json, false);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                throw new Exception(I18N::translate('Geocoder: %s', json_last_error_msg()));
+            }
+            if ($key === '') {
+                // Use Nominatim
+                foreach ($results as $result) {
+                    $data->add($result->display_name);
+                }
+            } else {
+                // Use Openroutesearch
+                $place_elements = array_filter(explode(',', Site::getPreference('openroute_layers')));
+                foreach ($results->features as $result) {
+                    $place_parts = [];
+                    foreach ($place_elements as $place_element) {
+                        if (isset($result->properties->{$place_element})) {
+                            $place_parts[] = $result->properties->{$place_element};
+                        }
+                    }
+                    // If no elements are selected in the control panel
+                    // or none of the selected elements are present in the place
+                    // then default to the label which is always present (I think)
+                    $data->add(implode(Gedcom::PLACE_SEPARATOR, $place_parts) ?: $result->properties->label);
+                }
+            }
+        } catch (Exception | RequestException $ex) {
+            // Json error? Service down?  Quota exceeded?
+            $data->add($ex->getMessage());
+        }
+
+        return $data;
     }
 }

--- a/app/Http/RequestHandlers/MapDataAdd.php
+++ b/app/Http/RequestHandlers/MapDataAdd.php
@@ -23,6 +23,7 @@ use Fisharebest\Webtrees\Http\ViewResponseTrait;
 use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\PlaceLocation;
 use Fisharebest\Webtrees\Services\MapDataService;
+use Fisharebest\Webtrees\Site;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -104,6 +105,7 @@ class MapDataAdd implements RequestHandlerInterface
             'map_bounds'      => $map_bounds,
             'marker_position' => $marker_position,
             'parent'          => $parent,
+            'openroute_key'   => Site::getPreference('openroute_key'),
             'provider'        => [
                 'url'     => 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
                 'options' => [

--- a/app/Http/RequestHandlers/MapDataEdit.php
+++ b/app/Http/RequestHandlers/MapDataEdit.php
@@ -23,6 +23,7 @@ use Fisharebest\Webtrees\Http\ViewResponseTrait;
 use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\PlaceLocation;
 use Fisharebest\Webtrees\Services\MapDataService;
+use Fisharebest\Webtrees\Site;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -109,6 +110,7 @@ class MapDataEdit implements RequestHandlerInterface
             'map_bounds'      => $map_bounds,
             'marker_position' => $marker_position,
             'parent'          => $location->parent(),
+            'openroute_key'   => Site::getPreference('openroute_key'),
             'provider'        => [
                 'url'     => 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
                 'options' => [

--- a/app/Http/RequestHandlers/MapProviderAction.php
+++ b/app/Http/RequestHandlers/MapProviderAction.php
@@ -39,7 +39,9 @@ class MapProviderAction implements RequestHandlerInterface
         $settings = (array) $request->getParsedBody();
 
         Site::setPreference('map-provider', $settings['provider']);
-        Site::setPreference('geonames', $settings['geonames']);
+        Site::setPreference('use_gazetteer', $settings['use_gazetteer']);
+        Site::setPreference('openroute_key', $settings['openroute_key']);
+        Site::setPreference('openroute_layers', implode(',', $settings['openroute_layers'] ?? []));
 
         return redirect(route(ControlPanel::class));
     }

--- a/app/Http/RequestHandlers/MapProviderPage.php
+++ b/app/Http/RequestHandlers/MapProviderPage.php
@@ -42,10 +42,48 @@ class MapProviderPage implements RequestHandlerInterface
     {
         $this->layout = 'layouts/administration';
 
+        $data = [
+            'neighbourhood' => [
+                'title'       => I18N::translate('Neighborhood'),
+                'description' => I18N::translate('Social communities, neighborhoods.')
+            ],
+            'localadmin'    => [
+                'title'       => I18N::translate('Local Admin'),
+                'description' => I18N::translate('Local administrative boundaries.')
+            ],
+            'locality'      => [
+                'title'       => I18N::translate('Locality'),
+                'description' => I18N::translate('Towns, hamlets, cities.')
+            ],
+            'county'        => [
+                'title'       => I18N::translate('County'),
+                'description' => I18N::translate('Official governmental area; usually bigger than a locality, almost always smaller than a region.')
+            ],
+            'region'        => [
+                'title'       => I18N::translate('Region'),
+                'description' => I18N::translate('States and provinces.')
+            ],
+            'country'       => [
+                'title'       => I18N::translate('Country'),
+                'description' => I18N::translate('Places that issue passports, nations, nation-states.')
+            ]
+        ];
+
+        $select_opts  = [];
+        $descriptions = [];
+        foreach ($data as $k => $v) {
+            $select_opts[$k]           = $v['title'];
+            $descriptions[$v['title']] = $v['description'];
+        }
+
         return $this->viewResponse('admin/map-provider', [
-            'title'    => I18N::translate('Map provider'),
-            'provider' => Site::getPreference('map-provider'),
-            'geonames' => Site::getPreference('geonames'),
+            'title'            => I18N::translate('Map provider'),
+            'provider'         => Site::getPreference('map-provider'),
+            'use_gazetteer'    => Site::getPreference('use_gazetteer'),
+            'openroute_key'    => Site::getPreference('openroute_key'),
+            'openroute_layers' => Site::getPreference('openroute_layers'),
+            'openroute_opts'   => $select_opts,
+            'openroute_desc'   => $descriptions
         ]);
     }
 }

--- a/app/Schema/Migration45.php
+++ b/app/Schema/Migration45.php
@@ -17,30 +17,25 @@
 
 declare(strict_types=1);
 
-namespace Fisharebest\Webtrees\Http\RequestHandlers;
+namespace Fisharebest\Webtrees\Schema;
 
-use Fig\Http\Message\RequestMethodInterface;
-use Fig\Http\Message\StatusCodeInterface;
-use Fisharebest\Webtrees\TestCase;
+use Illuminate\Database\Capsule\Manager as DB;
 
 /**
- * Test the MapProviderAction request handler.
- *
- * @covers \Fisharebest\Webtrees\Http\RequestHandlers\MapProviderAction
+ * Upgrade the database schema from version 45 to version 46.
  */
-class MapProviderActionTest extends TestCase
+class Migration45 implements MigrationInterface
 {
-    protected static $uses_database = true;
-
     /**
+     * Upgrade to to the next version
+     *
      * @return void
      */
-    public function testMapProviderAction(): void
+    public function upgrade(): void
     {
-        $handler  = new MapProviderAction();
-        $request  = self::createRequest(RequestMethodInterface::METHOD_POST, [], ['provider' => '', 'use_gazetteer' => '', 'openroute_key' => '']);
-        $response = $handler->handle($request);
-
-        self::assertSame(StatusCodeInterface::STATUS_FOUND, $response->getStatusCode());
+        // Cleanup
+        DB::table('site_setting')
+        ->where('setting_name', '=', 'geonames')
+        ->delete();
     }
 }

--- a/resources/views/admin/location-edit.phtml
+++ b/resources/views/admin/location-edit.phtml
@@ -93,11 +93,13 @@ use Fisharebest\Webtrees\View;
     'use strict';
 
     window.WT_OSM_ADMIN = (function () {
-        const minZoom   = 2;
-        const provider  = <?= json_encode($provider) ?>;
-        const add_place = <?= json_encode($location->id() === null) ?>;
+        const minZoom       = 2;
+        const provider      = <?= json_encode($provider) ?>;
+        const add_place     = <?= json_encode($location->id() === null) ?>;
+        const openroute_key = <?= json_encode($openroute_key) ?>;
 
         let map = null;
+
         // map components
 
         // postcss_image_inliner breaks the autodetection of image paths.
@@ -147,7 +149,17 @@ use Fisharebest\Webtrees\View;
         });
 
         // Geocoder (place lookup)
+        let geocode_provider = null;
+        if (openroute_key === '') {
+          geocode_provider = new L.Control.Geocoder.Nominatim();
+        } else {
+          geocode_provider = new L.Control.Geocoder.Openrouteservice({
+            apiKey: openroute_key,
+          });
+        }
+
         let geocoder = new L.Control.geocoder({
+            geocoder: geocode_provider,
             defaultMarkGeocode: false,
             expand: 'click',
             showResultIcons: true,

--- a/resources/views/admin/map-provider.phtml
+++ b/resources/views/admin/map-provider.phtml
@@ -33,23 +33,61 @@ use Fisharebest\Webtrees\I18N;
 
     <hr>
 
+        <div class="form-group">
+          <div class="form-row">
+            <legend class="col-form-label col-sm-3">
+                <?= /* I18N: A configuration setting */ I18N::translate('Search gazetteer') ?>
+            </legend>
+            <div class="col-sm-9">
+                <?= view('components/radios-inline', ['name' => 'use_gazetteer', 'options' => [I18N::translate('no'), I18N::translate('yes')], 'selected' => (int) $use_gazetteer]) ?>
+                <p class="small text-muted">
+                    <?= /* I18N: Help text for the “Search gazetteer” configuration setting */
+                    I18N::translate('This option controls whether or not to use a gazetteer to provide autocomplete suggestions for places. When this is enabled, the default is Nominatim the free search engine provided by OpenStreetMap, however if a key for Openrouteservice is provided then that is used instead.') ?>
+                </p>
+            </div>
+          </div>
+        </div>
+
+    <h3><?= I18N::translate('Openroute service') ?></h3>
+
+    <!-- OPENROUTE_KEY -->
     <div class="row form-group">
-        <label class="col-sm-3 col-form-label" for="geonames">
-            <?= I18N::translate('Use the GeoNames database for autocomplete on places') ?>
+        <label class="col-sm-3 col-form-label" for="openroute_key">
+            <?= I18N::translate('Key') ?>
         </label>
         <div class="col-sm-9">
             <input
             class="form-control"
             dir="ltr"
-            id="geonames"
+            id="openroute_key"
             maxlength="255"
-            name="geonames"
+            name="openroute_key"
             type="text"
-            value="<?= e($geonames) ?>"
+            value="<?= e($openroute_key) ?>"
             >
             <p class="small text-muted">
-                <?= /* I18N: Help text for the “Use GeoNames database for autocomplete on places” configuration setting */ I18N::translate('The website www.geonames.org provides a large database of place names. This can be searched when entering new places. To use this feature, you must register for a free account at www.geonames.org and provide the username.') ?>
+                <?= /* I18N: Help text for the “Use Openrouteservice for autocomplete on places” configuration setting */ I18N::translate('Openrouteservice is a free service which searches a number of sources in order to provide autocomplete suggestions for new places. To use this feature, you must register for an account at %s and obtain a key. An account allows 1000 searches per day.', '<a href="https://openrouteservice.org/dev/#/signup">openrouteservice</a>') ?>
             </p>
+        </div>
+    </div>
+
+    <!-- OPENROUTE_LAYERS -->
+    <div class="row form-group">
+        <label class="col-sm-3 col-form-label" for="openroute_layers">
+            <?= I18N::translate('Place elements') ?>
+        </label>
+        <div class="col-sm-9">
+            <?= view('components/select', ['name' => 'openroute_layers[]', 'id' => 'openroute_layers', 'selected' => explode(',', $openroute_layers), 'options' => $openroute_opts, 'class' => 'select2']) ?>
+            <p class="small text-muted">
+                <?= /* I18N: Help text for the Openroute place parts” configuration setting */ I18N::translate('Place elements used in building an entry in the place autocomplete list. If nothing is selected defaults will be used. Note: some places may not contain all elements selected.') ?>
+            </p>
+
+            <dl class="small text-muted">
+              <?php foreach($openroute_desc as $term => $description) : ?>
+                <dt><?= $term ?></dt>
+                <dd><?= $description ?></dd>
+              <?php endforeach; ?>
+            </dl>
         </div>
     </div>
 


### PR DESCRIPTION
This replaces https://github.com/fisharebest/webtrees/pull/3120. OpenCage has been abandoned in favour of Openrouteservice as the free (trial) account of OpenCage is silently deleted after 6 months of inactivity and thereafter returns a 401 Unauthorized response. Openrouteservice is completely free (but to use it a key must be acquired). It allows 1000 geocode requests per day and uses pretty much the same opensource databases as OpenCage.

Openrouteservice (https://openrouteservice.org/) is built upon the Open Source Pelias search engine (https://github.com/pelias/pelias)

If no key is provided for Openrouteservice then Nominatim is used instead.

Both place autocomplete and the Geographic data add/edit search facility have been modified to use the above mentioned tools.

NB I've provided a migration to remove the old geonames key but haven't updated webtrees.php