### PR TITLE
Remove self reference import in _pages-family.css

### DIFF
--- a/resources/css/_pages-family.css
+++ b/resources/css/_pages-family.css
@@ -13,8 +13,6 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-@import "_pages-family.css";
-
 .wt-family-members .wt-chart-box {
     width: 22.5vw;
 }


### PR DESCRIPTION
The file `_pages-family.css` references itself in an import (probably from a copy of the `_pages.css` file).
It seems that the `postcss-import` module silently ignores that loop, allowing the build to succeed, but I was having issue on my own theme when trying to import some of the native webtrees css file into my theme without that module.