### PR TITLE
Implement tag-based cache invalidation, and apply to Gedcom Records.

### DIFF
--- a/app/Factories/AbstractGedcomRecordFactory.php
+++ b/app/Factories/AbstractGedcomRecordFactory.php
@@ -45,7 +45,7 @@ abstract class AbstractGedcomRecordFactory
                 ->where('status', '=', 'pending')
                 ->orderBy('change_id')
                 ->pluck('new_gedcom', 'xref');
-        });
+        }, null, ['pending-t-' . $tree->id()]);
     }
 
     /**

--- a/app/Factories/CacheFactory.php
+++ b/app/Factories/CacheFactory.php
@@ -23,7 +23,8 @@ use Fisharebest\Webtrees\Cache;
 use Fisharebest\Webtrees\Contracts\CacheFactoryInterface;
 use Fisharebest\Webtrees\Webtrees;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\FilesystemTagAwareAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 
 use function random_int;
 
@@ -39,10 +40,10 @@ class CacheFactory implements CacheFactoryInterface
     private const FILES_TTL = 8640000;
     private const FILES_DIR = Webtrees::DATA_DIR . 'cache/';
 
-    /** @var ArrayAdapter */
+    /** @var TagAwareAdapter */
     private $array_adapter;
 
-    /** @var FilesystemAdapter */
+    /** @var FilesystemTagAwareAdapter */
     private $filesystem_adapter;
 
     /**
@@ -50,8 +51,8 @@ class CacheFactory implements CacheFactoryInterface
      */
     public function __construct()
     {
-        $this->array_adapter      = new ArrayAdapter(0, false);
-        $this->filesystem_adapter = new FilesystemAdapter('', self::FILES_TTL, self::FILES_DIR);
+        $this->array_adapter      = new TagAwareAdapter(new ArrayAdapter(0, false));
+        $this->filesystem_adapter = new FilesystemTagAwareAdapter('', self::FILES_TTL, self::FILES_DIR);
     }
 
     /**

--- a/app/Factories/FamilyFactory.php
+++ b/app/Factories/FamilyFactory.php
@@ -68,7 +68,7 @@ class FamilyFactory extends AbstractGedcomRecordFactory implements FamilyFactory
                 ->map(Registry::individualFactory()->mapper($tree));
 
             return new Family($xref, $gedcom ?? '', $pending, $tree);
-        });
+        }, null, ['gedrec-' . $xref . '@' . $tree->id()]);
     }
 
     /**

--- a/app/Factories/GedcomRecordFactory.php
+++ b/app/Factories/GedcomRecordFactory.php
@@ -108,7 +108,7 @@ class GedcomRecordFactory extends AbstractGedcomRecordFactory implements GedcomR
                 $type = $this->extractType($gedcom ?? $pending);
 
                 return $this->newGedcomRecord($type, $xref, $gedcom ?? '', $pending, $tree);
-            });
+            }, null, ['gedrec-' . $xref . '@' . $tree->id()]);
     }
 
     /**

--- a/app/Factories/HeaderFactory.php
+++ b/app/Factories/HeaderFactory.php
@@ -59,7 +59,7 @@ class HeaderFactory extends AbstractGedcomRecordFactory implements HeaderFactory
             $xref = $this->extractXref($gedcom ?? $pending, $xref);
 
             return new Header($xref, $gedcom ?? '', $pending, $tree);
-        });
+        }, null, ['gedrec-' . $xref . '@' . $tree->id()]);
     }
 
     /**

--- a/app/Factories/IndividualFactory.php
+++ b/app/Factories/IndividualFactory.php
@@ -58,7 +58,7 @@ class IndividualFactory extends AbstractGedcomRecordFactory implements Individua
             $xref = $this->extractXref($gedcom ?? $pending, $xref);
 
             return new Individual($xref, $gedcom ?? '', $pending, $tree);
-        });
+        }, null, ['gedrec-' . $xref . '@' . $tree->id()]);
     }
 
     /**

--- a/app/Factories/LocationFactory.php
+++ b/app/Factories/LocationFactory.php
@@ -59,7 +59,7 @@ class LocationFactory extends AbstractGedcomRecordFactory implements LocationFac
             $xref = $this->extractXref($gedcom ?? $pending, $xref);
 
             return new Location($xref, $gedcom ?? '', $pending, $tree);
-        });
+        }, null, ['gedrec-' . $xref . '@' . $tree->id()]);
     }
 
     /**

--- a/app/Factories/MediaFactory.php
+++ b/app/Factories/MediaFactory.php
@@ -59,7 +59,7 @@ class MediaFactory extends AbstractGedcomRecordFactory implements MediaFactoryIn
             $xref = $this->extractXref($gedcom ?? $pending, $xref);
 
             return new Media($xref, $gedcom ?? '', $pending, $tree);
-        });
+        }, null, ['gedrec-' . $xref . '@' . $tree->id()]);
     }
 
     /**

--- a/app/Factories/NoteFactory.php
+++ b/app/Factories/NoteFactory.php
@@ -59,7 +59,7 @@ class NoteFactory extends AbstractGedcomRecordFactory implements NoteFactoryInte
             $xref = $this->extractXref($gedcom ?? $pending, $xref);
 
             return new Note($xref, $gedcom ?? '', $pending, $tree);
-        });
+        }, null, ['gedrec-' . $xref . '@' . $tree->id()]);
     }
 
     /**

--- a/app/Factories/RepositoryFactory.php
+++ b/app/Factories/RepositoryFactory.php
@@ -59,7 +59,7 @@ class RepositoryFactory extends AbstractGedcomRecordFactory implements Repositor
             $xref = $this->extractXref($gedcom ?? $pending, $xref);
 
             return new Repository($xref, $gedcom ?? '', $pending, $tree);
-        });
+        }, null, ['gedrec-' . $xref . '@' . $tree->id()]);
     }
 
     /**

--- a/app/Factories/SourceFactory.php
+++ b/app/Factories/SourceFactory.php
@@ -60,7 +60,7 @@ class SourceFactory extends AbstractGedcomRecordFactory implements SourceFactory
             $xref = $this->extractXref($gedcom ?? $pending, $xref);
 
             return new Source($xref, $gedcom ?? '', $pending, $tree);
-        });
+        }, null, ['gedrec-' . $xref . '@' . $tree->id()]);
     }
 
     /**

--- a/app/Factories/SubmissionFactory.php
+++ b/app/Factories/SubmissionFactory.php
@@ -59,7 +59,7 @@ class SubmissionFactory extends AbstractGedcomRecordFactory implements Submissio
             $xref = $this->extractXref($gedcom ?? $pending, $xref);
 
             return new Submission($xref, $gedcom ?? '', $pending, $tree);
-        });
+        }, null, ['gedrec-' . $xref . '@' . $tree->id()]);
     }
 
     /**

--- a/app/Factories/SubmitterFactory.php
+++ b/app/Factories/SubmitterFactory.php
@@ -59,7 +59,7 @@ class SubmitterFactory extends AbstractGedcomRecordFactory implements SubmitterF
             $xref = $this->extractXref($gedcom ?? $pending, $xref);
 
             return new Submitter($xref, $gedcom ?? '', $pending, $tree);
-        });
+        }, null, ['gedrec-' . $xref . '@' . $tree->id()]);
     }
 
     /**

--- a/tests/app/CacheTest.php
+++ b/tests/app/CacheTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2021 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Fisharebest\Webtrees;
+
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+use Symfony\Component\Cache\CacheItem;
+
+/**
+ * Class CacheTest.
+ */
+class CacheTest extends TestCase
+{
+    /**
+     * @var TagAwareAdapter $tagAwareAdapter
+     */
+    private $tagAwareAdapter;
+
+    /**
+     * @var Cache $cache
+     */
+    private $cache;
+
+    /**
+     * {@inheritDoc}
+     * @see \Fisharebest\Webtrees\TestCase::setUp()
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tagAwareAdapter = new TagAwareAdapter(new ArrayAdapter());
+        $this->cache = new Cache($this->tagAwareAdapter);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \Fisharebest\Webtrees\TestCase::tearDown()
+     */
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        unset($this->tagAwareAdapter);
+        unset($this->cache);
+    }
+
+    /**
+     * @covers \Fisharebest\Webtrees\Cache::safeKey
+     * @dataProvider keyProvider
+     *
+     * @param string $key
+     */
+    public function testSafeKey(string $key): void
+    {
+        $safeKey = $this->cache->safeKey($key);
+        self::assertNotEmpty($safeKey);
+        self::assertSame($safeKey, CacheItem::validateKey($safeKey));
+    }
+
+    /**
+     * Data provider with example of keys
+     *
+     * @return string[][]
+     */
+    public function keyProvider(): array
+    {
+        return [ ['test'], ['I1@3'], [str_repeat('a', 70)], [''] ];
+    }
+
+    /**
+     * @covers \Fisharebest\Webtrees\Cache::__construct
+     * @covers \Fisharebest\Webtrees\Cache::remember
+     *
+     * @return void
+     */
+    public function testRemember(): void
+    {
+        self::assertEquals(10, $this->cache->remember('test', function () {
+            return 10;
+        }));
+
+        self::assertTrue($this->tagAwareAdapter->hasItem($this->cache->safeKey('test')));
+        self::assertEquals(10, $this->cache->remember('test', function () {
+            return 15;
+        }));
+    }
+
+    /**
+     * @covers \Fisharebest\Webtrees\Cache::remember
+     *
+     * @return void
+     */
+    public function testRememberWithTTL(): void
+    {
+        self::assertEquals(10, $this->cache->remember('test', function () {
+            return 10;
+        }, 1, []));
+        self::assertTrue($this->tagAwareAdapter->hasItem($this->cache->safeKey('test')));
+
+        sleep(2);
+        self::assertFalse($this->tagAwareAdapter->hasItem($this->cache->safeKey('test')));
+    }
+
+    /**
+     * @covers \Fisharebest\Webtrees\Cache::invalidateTags
+     *
+     * @return void
+     */
+    public function testInvalidateTags(): void
+    {
+        self::assertEquals(10, $this->cache->remember('test', function () {
+            return 10;
+        }, null, ['test-tag']));
+        self::assertTrue($this->cache->invalidateTags(['test-tag']));
+        self::assertEquals(15, $this->cache->remember('test', function () {
+            return 15;
+        }));
+
+        self::assertTrue($this->cache->invalidateTags(['test-tag2']));
+    }
+
+    /**
+     * @covers \Fisharebest\Webtrees\Cache::forget
+     *
+     * @return void
+     */
+    public function testForget(): void
+    {
+        self::assertEquals(10, $this->cache->remember('test', function () {
+            return 10;
+        }));
+        $this->cache->forget('test');
+
+        self::assertFalse($this->tagAwareAdapter->hasItem($this->cache->safeKey('test')));
+    }
+}

--- a/tests/app/DefaultUserTest.php
+++ b/tests/app/DefaultUserTest.php
@@ -22,6 +22,7 @@ namespace Fisharebest\Webtrees;
 use Fisharebest\Webtrees\Contracts\CacheFactoryInterface;
 use Fisharebest\Webtrees\Contracts\UserInterface;
 use Symfony\Component\Cache\Adapter\NullAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 
 /**
  * Test the DefaultUser class
@@ -35,7 +36,7 @@ class DefaultUserTest extends TestCase
         parent::setUp();
 
         $cache_factory = self::createMock(CacheFactoryInterface::class);
-        $cache_factory->method('array')->willReturn(new Cache(new NullAdapter()));
+        $cache_factory->method('array')->willReturn(new Cache(new TagAwareAdapter(new NullAdapter())));
         Registry::cache($cache_factory);
     }
 

--- a/tests/app/Services/UserServiceTest.php
+++ b/tests/app/Services/UserServiceTest.php
@@ -23,6 +23,7 @@ use Fisharebest\Webtrees\Contracts\CacheFactoryInterface;
 use Fisharebest\Webtrees\Contracts\UserInterface;
 use Fisharebest\Webtrees\Services\UserService;
 use Symfony\Component\Cache\Adapter\NullAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 
 /**
  * Test the UserService class
@@ -36,7 +37,7 @@ class UserServiceTest extends TestCase
         parent::setUp();
 
         $cache_factory = self::createMock(CacheFactoryInterface::class);
-        $cache_factory->method('array')->willReturn(new Cache(new NullAdapter()));
+        $cache_factory->method('array')->willReturn(new Cache(new TagAwareAdapter(new NullAdapter())));
         Registry::cache($cache_factory);
     }
 

--- a/tests/app/TreeTest.php
+++ b/tests/app/TreeTest.php
@@ -27,6 +27,7 @@ use Fisharebest\Webtrees\Services\TreeService;
 use Fisharebest\Webtrees\Services\UserService;
 use InvalidArgumentException;
 use Symfony\Component\Cache\Adapter\NullAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 
 use function stream_get_contents;
 
@@ -42,7 +43,7 @@ class TreeTest extends TestCase
         parent::setUp();
 
         $cache_factory = self::createMock(CacheFactoryInterface::class);
-        $cache_factory->method('array')->willReturn(new Cache(new NullAdapter()));
+        $cache_factory->method('array')->willReturn(new Cache(new TagAwareAdapter(new NullAdapter())));
         Registry::cache($cache_factory);
     }
 

--- a/tests/app/UserTest.php
+++ b/tests/app/UserTest.php
@@ -23,6 +23,7 @@ use Fisharebest\Webtrees\Contracts\CacheFactoryInterface;
 use Fisharebest\Webtrees\Contracts\UserInterface;
 use Fisharebest\Webtrees\Services\UserService;
 use Symfony\Component\Cache\Adapter\NullAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 
 /**
  * Test the user functions
@@ -36,7 +37,7 @@ class UserTest extends TestCase
         parent::setUp();
 
         $cache_factory = self::createMock(CacheFactoryInterface::class);
-        $cache_factory->method('array')->willReturn(new Cache(new NullAdapter()));
+        $cache_factory->method('array')->willReturn(new Cache(new TagAwareAdapter(new NullAdapter())));
         Registry::cache($cache_factory);
     }
 


### PR DESCRIPTION
This is a proposal to try and address #3747. A few files changes, but there is only really a couple that contain the significant changes.
The invalidation is done through the addition of tags to the Cache object (a feature supported by the underlying Symfony cache implementation and adapters). This requires a stricter constraint on the Cache signature itself (accepting a `Symfony\Contracts\Cache\TagAwareCacheInterface` instead of `Symfony\Contracts\Cache\CacheInterface` adapter).

The object creating cache items just needs to declare a tag, that can be then invoked for invalidation by other objects updating the object. The overall architecture changes are quite limited, and that can be applied to other invalidations than GedcomRecords.

For the GedcomRecords themselves, tags are defined as `gedrec-XXX@YY` where `XXX` is the Xref of the object, and `YY` the tree ID. They are added whenever a cache item related to a GedcomRecord is created (the factories, the `canShow` method, an improvement on the `getFactsWithMedia` method of the MediaTabModule), and the methods on `GedcomRecord` updating it can then invalidate that tag.
There is an opinionated implementation choice, as only the Array adapter is invalidated by GedcomRecord, not the FileSystem one (it can be, but I thought it may not be required - I could not really decide on it).

The pending changes implementation can be controversial as well, as any change on a record invalidate the whole pending changes (as it is all-or-nothing for a tree). Your experience would be of interest on that one.

I do not see many impacts of that implementation on the existing (performances to be assessed more explicitly if you have any tool), but it can protect the system from weird loading sequences, and it provides a mechanism that can be extended to any cache usage (even allowing modules to invalidate predefined tags if necessary).

A new unit test has been added as well for the Cache class, which I could rework is the PR is not accepted.