### PR TITLE
Finer control of abbreviate place names

### DIFF
--- a/app/Place.php
+++ b/app/Place.php
@@ -169,6 +169,19 @@ class Place
     }
 
     /**
+     * Extract the last parts of a place name, omitting top levels if possible.
+     *
+     * @param int $num : of parts to include - has highest priority
+     * @param int $omit : where to start counting backwards 1=top level, 2=next etc.
+     *
+     * @return Collection<string>
+     */
+    public function backParts(int $num, $omit): Collection
+    {
+        return $this->parts->slice(-($omit - 1) - $num, $num);
+    }
+
+    /**
      * Extract the country (last parts) of a place name.
      *
      * @param int $n
@@ -283,10 +296,11 @@ class Place
     public function shortName(bool $link = false): string
     {
         $SHOW_PEDIGREE_PLACES = (int) $this->tree->getPreference('SHOW_PEDIGREE_PLACES');
+        $SHOW_PEDIGREE_PLACES_SUFFIX = (int) $this->tree->getPreference('SHOW_PEDIGREE_PLACES_SUFFIX');
 
         // Abbreviate the place name, for lists
-        if ($this->tree->getPreference('SHOW_PEDIGREE_PLACES_SUFFIX')) {
-            $parts = $this->lastParts($SHOW_PEDIGREE_PLACES);
+        if ($SHOW_PEDIGREE_PLACES_SUFFIX) {
+            $parts = $this->backParts($SHOW_PEDIGREE_PLACES, $SHOW_PEDIGREE_PLACES_SUFFIX);
         } else {
             $parts = $this->firstParts($SHOW_PEDIGREE_PLACES);
         }

--- a/resources/views/admin/trees-preferences.phtml
+++ b/resources/views/admin/trees-preferences.phtml
@@ -566,7 +566,13 @@ use Illuminate\Support\Collection;
         <div class="col-sm-9">
             <?= /* I18N: The placeholders are edit controls. Show the [first/last] [1/2/3/4/5] parts of a place name */ I18N::translate(
                 'Show the %1$s %2$s parts of a place name.',
-                view('components/select', ['name' => 'SHOW_PEDIGREE_PLACES_SUFFIX', 'selected' => $tree->getPreference('SHOW_PEDIGREE_PLACES_SUFFIX'), 'options' => ['0' => I18N::translateContext('Show the [first/last] [N] parts of a place name.', 'first'), '1' => I18N::translateContext('Show the [first/last] [N] parts of a place name.', 'last')]]),
+                view('components/select', ['name' => 'SHOW_PEDIGREE_PLACES_SUFFIX', 'selected' => $tree->getPreference('SHOW_PEDIGREE_PLACES_SUFFIX'),
+                  'options' => ['0' => I18N::translateContext('Show the [first/last] [N] parts of a place name.', 'first'), 
+                                '1' => I18N::translateContext('Show the [first/last] [N] parts of a place name.', 'last'),
+                                '2' => I18N::translateContext('Show the [first/last] [N] parts of a place name.', 'last, omitting top level'),
+                                '3' => I18N::translateContext('Show the [first/last] [N] parts of a place name.', 'last, omitting top 2 levels'),
+                                '4' => I18N::translateContext('Show the [first/last] [N] parts of a place name.', 'last, omitting top 3 levels'),
+                              ]]),
                 view('components/select-number', ['name' => 'SHOW_PEDIGREE_PLACES', 'selected' => $tree->getPreference('SHOW_PEDIGREE_PLACES'), 'options' => range(1, 9)])
             ) ?>
             <div class="form-text">


### PR DESCRIPTION
Motivation: Including highest level place name when abbreviating from back is not always desirable. This *requests* which highest levels to omit while always trying to show SHOW_PEDIGREE_PLACES number of levels

Implementation: 
- add function backParts to Places
- keep lastParts as it is used for census
- expand scope of SHOW_PEDIGREE_PLACES_SUFFIX so that 1=keep top level, 2=only keep to 2nd highest level, etc.
 
Note: options text in tree preferences probably needs work