### PR TITLE
Relationships : Bug  + French improvements + Finer pedigree linkage methods

### DIFF
--- a/app/Module/LanguageEnglishUnitedStates.php
+++ b/app/Module/LanguageEnglishUnitedStates.php
@@ -142,9 +142,15 @@ class LanguageEnglishUnitedStates extends AbstractModule implements ModuleLangua
             Relationship::fixed('foster-mother', 'foster-mother’s %s')->fostering()->mother(),
             Relationship::fixed('foster-father', 'foster-father’s %s')->fostering()->father(),
             Relationship::fixed('foster-parent', 'foster-parent’s %s')->fostering()->parent(),
+            Relationship::fixed('foster-sister', 'foster-sister’s %s')->fostering()->sister(),
+            Relationship::fixed('foster-brother', 'foster-brother’s %s')->fostering()->brother(),
+            Relationship::fixed('foster-sibling', 'foster-sibling’s %s')->fostering()->sibling(),
             Relationship::fixed('foster-daughter', 'foster-daughter’s %s')->fostered()->daughter(),
             Relationship::fixed('foster-son', 'foster-son’s %s')->fostered()->son(),
             Relationship::fixed('foster-child', 'foster-child’s %s')->fostered()->child(),
+            Relationship::fixed('foster-sister', 'foster-sister’s %s')->fostered()->sister(),
+            Relationship::fixed('foster-brother', 'foster-brother’s %s')->fostered()->brother(),
+            Relationship::fixed('foster-sibling', 'foster-sibling’s %s')->fostered()->sibling(),
             // Parents
             Relationship::fixed('mother', 'mother’s %s')->mother(),
             Relationship::fixed('father', 'father’s %s')->father(),
@@ -167,9 +173,9 @@ class LanguageEnglishUnitedStates extends AbstractModule implements ModuleLangua
             Relationship::fixed('brother', 'brother’s %s')->brother(),
             Relationship::fixed('sibling', 'sibling’s %s')->sibling(),
             // Half-siblings
-            Relationship::fixed('half-sister', 'half-sister’s %s')->parent()->daughter(),
-            Relationship::fixed('half-brother', 'half-brother’s %s')->parent()->son(),
-            Relationship::fixed('half-sibling', 'half-sibling’s %s')->parent()->child(),
+            Relationship::fixed('half-sister', 'half-sister’s %s')->biological()->parent()->biologicallyBorn()->daughter(),
+            Relationship::fixed('half-brother', 'half-brother’s %s')->biological()->parent()->biologicallyBorn()->son(),
+            Relationship::fixed('half-sibling', 'half-sibling’s %s')->biological()->parent()->biologicallyBorn()->child(),
             // Stepfamily
             Relationship::fixed('stepmother', 'stepmother’s %s')->parent()->wife(),
             Relationship::fixed('stepfather', 'stepfather’s %s')->parent()->husband(),

--- a/app/Module/LanguageFrench.php
+++ b/app/Module/LanguageFrench.php
@@ -45,14 +45,14 @@ class LanguageFrench extends AbstractModule implements ModuleLanguageInterface
 
     protected const ASYMMETRIC_COUSINS = [
         1 => [
-            'F' => ['down', 'petite-', 'cousine', 'de la ', 'de la '],
-            'M' => ['down', 'petit-', 'cousin', 'du ', 'du '],
-            'U' => ['down', 'petit-', 'cousin', 'du ', 'du ']
+            'F' => ['down', 'petite-cousine', 'de la '],
+            'M' => ['down', 'petit-cousin', 'du '],
+            'U' => ['down', 'petit-cousin', 'du ']
         ],
         -1 => [
-            'F' => ['up', 'grand-', 'cousine', 'de la ', 'de la '],
-            'M' => ['up', 'grand-', 'cousin', 'du ', 'du '],
-            'U' => ['up', 'grand-', 'cousin', 'du ', 'du ']
+            'F' => ['up', 'grand-cousine', 'de la '],
+            'M' => ['up', 'grand-cousin', 'du '],
+            'U' => ['up', 'grand-cousin', 'du ']
         ],
     ];
 
@@ -66,69 +66,81 @@ class LanguageFrench extends AbstractModule implements ModuleLanguageInterface
 
     /**
      * Pour les traducteurs français, certaines configurations peuvent avoir plusieurs traduction françaises possibles,
-     * ou aucune. Voici les choix qui ont été faits (mais complètement ouvert à discussion):
+     * ou aucune. Voici les choix qui ont été faits (mais complètement ouverts à discussion):
      *
      * - je n'ai aucune intention de rentrer dans le débat de l'écriture inclusive, mais malheureusement un choix doit
      *   être fait: lorsque nécessaire dans les choix des articles ou accords, je m'en suis tenu à la recommandation de
      *   l'Académie Française d'utiliser la forme non marquée (et donc le masculin) pour le genre neutre.
-     * - dans le cas de frère/sœur jumeau, j'évite le problème en utiliseant le substantif `jumeau` lorsque le sexe
-     *   n'est pas connu, alors que j'utilise la structure `frère jumeau`/`sœur jum elle` lorsque le sexe est connu.
+     * - dans le cas de frères/sœurs jumeaux, j'évite le problème en utiliseant le substantif `jumeau` lorsque le sexe
+     *   n'est pas connu, alors que j'utilise la structure `frère jumeau`/`sœur jumelle` lorsque le sexe est connu.
      * - `conjoint` a été choisi pour un couple non marié (`époux`/`épouse` lorsque les conjoints sont mariés).
      *   Une alternative est `partenaire`, mais `conjoint` est le terme déjà utilisé dans les traductions françaises.
      * - la notion de `foster` (qui peut traduire plusieurs réalités différentes en français) a été traduite dans le
      *   cadre de la `famille d'accueil`. Les suggestions sont les bienvenues.
-     * - La situation des enfants dans les familles recomposées a été traduites:
-     * - `frère`/`sœur` pour les enfants dont les deux parents sont les mêmes
-     * - `demi-frère`/`demi-sœur` pour les enfants qui ont un parent en commun
-     * - `quasi-frère`/`quasi-sœur` pour les enfants qui ne partagent aucun parent en commun, mais dont les parents
-     *   sont en couple
-     * - la notion d'âge entre frères/sœurs a été traduite par `grand frère`/`petit frère`, plutôt que des variants sur
+     * - La situation des enfants dans les familles recomposées a été traduite:
+     *      - `frère`/`sœur` pour les enfants dont les deux parents sont les mêmes
+     *      - `demi-frère`/`demi-sœur` pour les enfants qui ont un parent en commun
+     *      - `quasi-frère`/`quasi-sœur` pour les enfants qui ne partagent aucun parent en commun, mais dont les parents
+     *      sont en couple
+     * - la notion d'âge entre frères/sœurs a été traduite par `grand frère`/`petit frère`, plutôt que des variantes sur
      *   `frère aîné`/`frère cadet` ou `frère plus âgé`/`frère plus jeune`
-     * - De manière arbitraire, au delà de deux `arrière-`, la forme est raccourcie par `arrière-(xN)-` avec N décrivant
-     *   le nombre de degré. Techniquement, en français, il n'existe pas de forme raccourcie, mais je ne pense pas que
-     *   ce soit une bonne idée de multiplier les `arrière-`. On pourrait utiliser les termes `quadrisaïeul` /
-     *   `quinquisaïeul`  /`sextaïeul` / `septaïeul` /... mais ils me semblent assez peu usités.
+     * - Lorsqu'il est nécessaire d'aller au-delà d'un `arrière-`{substantif} (par exemple, pour décrire le case de 
+     *   l'enfant d'un arrière-petit-enfant), la forme `{substantif} au Ne degré` est choisie, avec pour convention 
+     *   N = 1 pour le niveau du substantif racine, on utilisera donc par exemple: 
+     *      - `petit-enfant` (= petit-enfant au 1er degré)
+     *      - `arrière-petit-enfant` (= petit-enfant au 2e degré)
+     *      - `petit-enfant au 3e degré` et ainsi de suite pour les degrés supérieurs
+     * - Un exception à la règle précédente sont les grand-parents au 3e degré, qui ont la description de `trisaïeux`.
      * - Pour les cousins, c'est la description selon le droit canon qui a été choisie (principalement car elle donne
      *   une meilleure visibilité de la distance à l'ancêtre commun que la description en droit civil), donc:
-     * - l'enfant d'un oncle/tante est un `cousin germain`/`cousine germaine` (= cousins au 1er degré)
-     * - les enfants de cousins germains sont des `cousins issus de germain` (= cousins au 2e degré)
-     * - pour les enfants des cousins issus de germains, et ainsi de suite, la relation est décrite suivant le nombre
-     *   de degré séparant les cousins de l'ancêtre commun:
-     * - en cas de symétrie des chemins, ils sont dits `cousins au N-ème degré`
-     * - en cas d'asymétrie des chemins, ils sont dit  `cousins du N-ème au M-ème degré`
-     * - de plus, les notions de `grand-cousin` et `petit-cousin` ont été implémentées comme suit:
-     * - un `(arrière-)grand-cousin` est l'enfant d'un `(arrière-)grand-oncle`/`grand-tante` (= cousin du 1er au N-ème degré)
-     * - un `(arrière-)petit-cousin` est un `(arrière-)petit-neveu`/`petite-nièce` d'un parent (= cousin du Ner au 1er degré)
+     *      - l'enfant d'un oncle/tante est un `cousin germain`/`cousine germaine` (= cousins au 1er degré)
+     *      - les enfants de cousins germains sont des `cousins issus de germain` (= cousins au 2e degré)
+     *      - pour les enfants des cousins issus de germains, et ainsi de suite, la relation est décrite suivant le
+     *      nombre de degré séparant les cousins de l'ancêtre commun:
+     *      - en cas de symétrie des chemins, ils sont dits `cousins au N-ème degré`
+     *      - en cas d'asymétrie des chemins, ils sont dit  `cousins du N-ème au M-ème degré`
+     *      - de plus, les notions de `grand-cousin` et `petit-cousin` ont été implémentées comme suit:
+     *          - un `(arrière-)grand-cousin` est l'enfant d'un `(arrière-)grand-oncle`/`grand-tante`
+     *              (= cousin du 1er au N-ème degré)
+     *          - un `(arrière-)petit-cousin` est un `(arrière-)petit-neveu`/`petite-nièce` d'un parent
+     *              (= cousin du Ner au 1er degré)
      *
      * @return array<Relationship>
      */
     public function relationships(): array
     {
+        // Construct the genitive form in French
         $genitive = fn (string $s, string $genitive_link): array => [$s, '%s ' . $genitive_link . $s];
 
-        $great = fn (int $n, string $suffix, string $genitive_link): array => $genitive(
-            ($n > 2 ? 'arrière-(x' . $n . ')-' : str_repeat('arrière-', max($n, 0))) . $suffix,
-            $n === 0 ? $genitive_link : 'de l’'
-        );
-
-        $compoundgreat =
+        // Functions to coumpound the name that can be indefinitely repeated
+        $degree = fn (int $n, string $suffix, string $genitive_link) : array =>
+                $genitive("$suffix au {$n}<sup>e</sup> degré", $genitive_link);
+        
+        $great = fn (int $n, string $suffix, string $genitive_link): array => 
+                $n <= 1 ? $genitive('arrière-' . $suffix, 'de l’') : $degree($n + 1, $suffix, $genitive_link);
+        
+        $firstCompound = fn (int $n, string $suffix, string $genitive_link): array =>
+                $n <= 1 ? $genitive($suffix, $genitive_link) : $great($n - 1, $suffix, $genitive_link);
+        
+        $compound = 
             fn (int $n, string $first_level, string $suffix, string $genitive_none, string $genitive_first): array =>
-                $great($n - 1, ($n > 0 ? $first_level : '') . $suffix, $n === 0 ? $genitive_none : $genitive_first);
-
+                $n <= 1 ? $genitive($suffix, $genitive_none) : $firstCompound($n - 1, $first_level . $suffix, $genitive_first);
+        
+        // Functions to translate cousins' degree of relationship
         $symmetricCousin = fn (int $n, string $sex): array => self::SYMMETRIC_COUSINS[$n][$sex] ?? $genitive(
             $sex === 'F' ? 'cousine au ' . $n . '<sup>e</sup> degré' : 'cousin au ' . $n . '<sup>e</sup> degré',
             $sex === 'F'  ? 'de la ' : 'du '
         );
 
-        $asymmetricCousin =
-            static function (int $up, int $down, string $sex) use ($symmetricCousin, $compoundgreat, $genitive): array {
+        $cousin =
+            static function (int $up, int $down, string $sex) use ($symmetricCousin, $firstCompound, $genitive): array {
                 if ($up === $down) {
                     return $symmetricCousin($up, $sex);
                 }
                 $fixed = self::ASYMMETRIC_COUSINS[$up][$sex] ?? self::ASYMMETRIC_COUSINS[-$down][$sex] ?? null;
                 if ($fixed !== null) {
                     $fixed[0] = $fixed[0] === 'up' ? $up - 1 : $down - 1;
-                    return $compoundgreat(...$fixed);
+                    return $firstCompound(...$fixed);
                 }
                 return $genitive(
                     $sex === 'F' ?
@@ -191,20 +203,24 @@ class LanguageFrench extends AbstractModule implements ModuleLanguageInterface
             // Partners
             Relationship::fixed('ex-épouse', '%s de l’ex-épouse')->divorced()->partner()->female(),
             Relationship::fixed('ex-époux', '%s de l’ex-époux')->divorced()->partner()->male(),
+            Relationship::fixed('ex-époux', '%s de l’ex-époux')->divorced()->partner(),
+            Relationship::fixed('ex-conjointe', '%s de l’ex-conjoint')->divorced()->partner()->female(),
+            Relationship::fixed('ex-conjoint', '%s de l’ex-conjoint')->divorced()->partner()->male(),
             Relationship::fixed('ex-conjoint', '%s de l’ex-conjoint')->divorced()->partner(),
             Relationship::fixed('fiancée', '%s de la fiancée')->engaged()->partner()->female(),
             Relationship::fixed('fiancé', '%s du fiancé')->engaged()->partner()->male(),
             Relationship::fixed('épouse', '%s de l’épouse')->wife(),
             Relationship::fixed('époux', '%s de l’époux')->husband(),
             Relationship::fixed('époux', '%s de l’époux')->spouse(),
+            Relationship::fixed('conjointe', '%s du conjoint')->partner()->female(),
+            Relationship::fixed('conjoint', '%s du conjoint')->partner()->male(),
             Relationship::fixed('conjoint', '%s du conjoint')->partner(),
             // In-laws
             Relationship::fixed('belle-mère', '%s de la belle-mère')->married()->spouse()->mother(),
             Relationship::fixed('beau-père', '%s du beau-père')->married()->spouse()->father(),
             Relationship::fixed('beau-parent', '%s du beau-parent')->married()->spouse()->parent(),
-            Relationship::fixed('belle-fille', '%s de la belle-fille')->child()->wife(),
-            Relationship::fixed('beau-fils', '%s du beau-fils')->child()->husband(),
-            Relationship::fixed('beau-fils/belle-fille', '%s du beau-fils/belle-fille')->child()->married()->spouse(),
+            Relationship::fixed('bru', '%s de la bru')->child()->wife(),
+            Relationship::fixed('gendre', '%s du gendre')->child()->husband(),
             Relationship::fixed('belle-sœur', '%s de la belle-sœur')->spouse()->sister(),
             Relationship::fixed('beau-frère', '%s du beau-frère')->spouse()->brother(),
             Relationship::fixed('beau-frère/belle-sœur', '%s du beau-frère/belle-sœur')->spouse()->sibling(),
@@ -212,31 +228,38 @@ class LanguageFrench extends AbstractModule implements ModuleLanguageInterface
             Relationship::fixed('beau-frère', '%s du beau-frère')->sibling()->husband(),
             Relationship::fixed('beau-frère/belle-sœur', '%s du beau-frère/belle-sœur')->sibling()->spouse(),
             // Grandparents and above
-            Relationship::dynamic(fn (int $n) => $great($n - 1, 'grand-mère maternelle', 'de la '))->mother()->ancestor()->female(),
-            Relationship::dynamic(fn (int $n) => $great($n - 1, 'grand-père maternel', 'du '))->mother()->ancestor()->male(),
-            Relationship::dynamic(fn (int $n) => $great($n - 1, 'grand-mère paternelle', 'de la '))->father()->ancestor()->female(),
-            Relationship::dynamic(fn (int $n) => $great($n - 1, 'grand-père paternel', 'du '))->father()->ancestor()->male(),
-            Relationship::dynamic(fn (int $n) => $great($n - 2, 'grand-mère', 'de la '))->ancestor()->female(),
-            Relationship::dynamic(fn (int $n) => $great($n - 2, 'grand-père', 'du '))->ancestor()->male(),
-            Relationship::dynamic(fn (int $n) => $great($n - 2, 'grand-parent', 'du '))->ancestor(),
+            //"Trisaïeux" are an exception to the dynamic rule
+            Relationship::fixed('trisaïeule maternelle', '% de la trisaïeule maternelle')->mother()->parent()->parent()->mother(),
+            Relationship::fixed('trisaïeul maternel', '% du trisaïeul maternel')->mother()->parent()->parent()->father(),
+            Relationship::fixed('trisaïeule paternelle', '% de la trisaïeule paternelle')->father()->parent()->parent()->mother(),
+            Relationship::fixed('trisaïeul paternel', '% du trisaïeul paternel')->father()->parent()->parent()->father(),
+            Relationship::fixed('trisaïeule', '% de la trisaïeule')->parent()->parent()->parent()->mother(),
+            Relationship::fixed('trisaïeul', '% du trisaïeul')->parent()->parent()->parent()->father(),
+            Relationship::dynamic(fn (int $n) => $firstCompound($n, 'grand-mère maternelle', 'de la '))->mother()->ancestor()->female(),
+            Relationship::dynamic(fn (int $n) => $firstCompound($n, 'grand-père maternel', 'du '))->mother()->ancestor()->male(),
+            Relationship::dynamic(fn (int $n) => $firstCompound($n, 'grand-parent maternel', 'du '))->mother()->ancestor(),
+            Relationship::dynamic(fn (int $n) => $firstCompound($n, 'grand-mère paternelle', 'de la '))->father()->ancestor()->female(),
+            Relationship::dynamic(fn (int $n) => $firstCompound($n, 'grand-père paternel', 'du '))->father()->ancestor()->male(),
+            Relationship::dynamic(fn (int $n) => $firstCompound($n, 'grand-parent paternel', 'du '))->father()->ancestor(),
+            Relationship::dynamic(fn (int $n) => $firstCompound($n, 'grand-mère', 'de la '))->parent()->ancestor()->female(),
+            Relationship::dynamic(fn (int $n) => $firstCompound($n, 'grand-père', 'du '))->parent()->ancestor()->male(),
+            Relationship::dynamic(fn (int $n) => $firstCompound($n, 'grand-parent', 'du '))->parent()->ancestor(),
             // Grandchildren and below
-            Relationship::dynamic(fn (int $n) => $great($n - 2, 'petite-fille', 'de la '))->descendant()->female(),
-            Relationship::dynamic(fn (int $n) => $great($n - 2, 'petit-fils', 'du '))->descendant()->male(),
-            Relationship::dynamic(fn (int $n) => $great($n - 2, 'petit-enfant', 'du'))->descendant(),
+            Relationship::dynamic(fn (int $n) => $firstCompound($n, 'petite-fille', 'de la '))->child()->descendant()->female(),
+            Relationship::dynamic(fn (int $n) => $firstCompound($n, 'petit-fils', 'du '))->child()->descendant()->male(),
+            Relationship::dynamic(fn (int $n) => $firstCompound($n, 'petit-enfant', 'du '))->child()->descendant(),
             // Collateral relatives
-            Relationship::dynamic(fn (int $n) => $compoundgreat($n - 1, 'grand-', 'tante', 'de la ', 'de la '))->ancestor()->sister(),
-            Relationship::dynamic(fn (int $n) => $compoundgreat($n - 1, 'grand-', 'tante par alliance', 'de la ', 'de la '))->ancestor()->sibling()->wife(),
-            Relationship::dynamic(fn (int $n) => $compoundgreat($n - 1, 'grand-', 'oncle', 'de l’', 'du '))->ancestor()->brother(),
-            Relationship::dynamic(fn (int $n) => $compoundgreat($n - 1, 'grand-', 'oncle par alliance', 'de l’', 'du '))->ancestor()->sibling()->husband(),
-            Relationship::dynamic(fn (int $n) => $compoundgreat($n - 1, 'petite-', 'nièce', 'de la ', 'de la '))->sibling()->descendant()->female(),
-            Relationship::dynamic(fn (int $n) => $compoundgreat($n - 1, 'petite-', 'nièce par alliance', 'de la ', 'de la '))->married()->spouse()->sibling()->descendant()->female(),
-            Relationship::dynamic(fn (int $n) => $compoundgreat($n - 1, 'petit-', 'neveu', 'du ', 'du '))->sibling()->descendant()->male(),
-            Relationship::dynamic(fn (int $n) => $compoundgreat($n - 1, 'petit-', 'neveu par alliance', 'du ', 'du '))->married()->spouse()->sibling()->descendant()->male(),
+            Relationship::dynamic(fn (int $n) => $compound($n, 'grand-', 'tante', 'de la ', 'de la '))->ancestor()->sister(),
+            Relationship::dynamic(fn (int $n) => $compound($n, 'grand-', 'tante par alliance', 'de la ', 'de la '))->ancestor()->sibling()->wife(),
+            Relationship::dynamic(fn (int $n) => $compound($n, 'grand-', 'oncle', 'de l’', 'du '))->ancestor()->brother(),
+            Relationship::dynamic(fn (int $n) => $compound($n, 'grand-', 'oncle par alliance', 'de l’', 'du '))->ancestor()->sibling()->husband(),
+            Relationship::dynamic(fn (int $n) => $compound($n, 'petite-', 'nièce', 'de la ', 'de la '))->sibling()->descendant()->female(),
+            Relationship::dynamic(fn (int $n) => $compound($n, 'petite-', 'nièce par alliance', 'de la ', 'de la '))->married()->spouse()->sibling()->descendant()->female(),
+            Relationship::dynamic(fn (int $n) => $compound($n, 'petit-', 'neveu', 'du ', 'du '))->sibling()->descendant()->male(),
+            Relationship::dynamic(fn (int $n) => $compound($n, 'petit-', 'neveu par alliance', 'du ', 'du '))->married()->spouse()->sibling()->descendant()->male(),
             // Cousins (based on canon law)
-            Relationship::dynamic(fn (int $n) => $symmetricCousin($n, 'F'))->symmetricCousin()->female(),
-            Relationship::dynamic(fn (int $n) => $symmetricCousin($n, 'M'))->symmetricCousin()->male(),
-            Relationship::dynamic(fn (int $up, int $down) => $asymmetricCousin($up, $down, 'F'))->cousin()->female(),
-            Relationship::dynamic(fn (int $up, int $down) => $asymmetricCousin($up, $down, 'M'))->cousin()->male(),
+            Relationship::dynamic(fn (int $up, int $down) => $cousin($up, $down, 'F'))->cousin()->female(),
+            Relationship::dynamic(fn (int $up, int $down) => $cousin($up, $down, 'M'))->cousin()->male(),
 
         ];
     }

--- a/app/Module/LanguageFrench.php
+++ b/app/Module/LanguageFrench.php
@@ -84,9 +84,9 @@ class LanguageFrench extends AbstractModule implements ModuleLanguageInterface
      *      sont en couple
      * - la notion d'âge entre frères/sœurs a été traduite par `grand frère`/`petit frère`, plutôt que des variantes sur
      *   `frère aîné`/`frère cadet` ou `frère plus âgé`/`frère plus jeune`
-     * - Lorsqu'il est nécessaire d'aller au-delà d'un `arrière-`{substantif} (par exemple, pour décrire le case de 
-     *   l'enfant d'un arrière-petit-enfant), la forme `{substantif} au Ne degré` est choisie, avec pour convention 
-     *   N = 1 pour le niveau du substantif racine, on utilisera donc par exemple: 
+     * - Lorsqu'il est nécessaire d'aller au-delà d'un `arrière-`{substantif} (par exemple, pour décrire le case de
+     *   l'enfant d'un arrière-petit-enfant), la forme `{substantif} au Ne degré` est choisie, avec pour convention
+     *   N = 1 pour le niveau du substantif racine, on utilisera donc par exemple:
      *      - `petit-enfant` (= petit-enfant au 1er degré)
      *      - `arrière-petit-enfant` (= petit-enfant au 2e degré)
      *      - `petit-enfant au 3e degré` et ainsi de suite pour les degrés supérieurs
@@ -113,19 +113,19 @@ class LanguageFrench extends AbstractModule implements ModuleLanguageInterface
         $genitive = fn (string $s, string $genitive_link): array => [$s, '%s ' . $genitive_link . $s];
 
         // Functions to coumpound the name that can be indefinitely repeated
-        $degree = fn (int $n, string $suffix, string $genitive_link) : array =>
+        $degree = fn (int $n, string $suffix, string $genitive_link): array =>
                 $genitive("$suffix au {$n}<sup>e</sup> degré", $genitive_link);
-        
-        $great = fn (int $n, string $suffix, string $genitive_link): array => 
+
+        $great = fn (int $n, string $suffix, string $genitive_link): array =>
                 $n <= 1 ? $genitive('arrière-' . $suffix, 'de l’') : $degree($n + 1, $suffix, $genitive_link);
-        
+
         $firstCompound = fn (int $n, string $suffix, string $genitive_link): array =>
                 $n <= 1 ? $genitive($suffix, $genitive_link) : $great($n - 1, $suffix, $genitive_link);
-        
-        $compound = 
+
+        $compound =
             fn (int $n, string $first_level, string $suffix, string $genitive_none, string $genitive_first): array =>
                 $n <= 1 ? $genitive($suffix, $genitive_none) : $firstCompound($n - 1, $first_level . $suffix, $genitive_first);
-        
+
         // Functions to translate cousins' degree of relationship
         $symmetricCousin = fn (int $n, string $sex): array => self::SYMMETRIC_COUSINS[$n][$sex] ?? $genitive(
             $sex === 'F' ? 'cousine au ' . $n . '<sup>e</sup> degré' : 'cousin au ' . $n . '<sup>e</sup> degré',
@@ -155,16 +155,45 @@ class LanguageFrench extends AbstractModule implements ModuleLanguageInterface
             Relationship::fixed('mère adoptive', '%s de la mère adoptive')->adoptive()->mother(),
             Relationship::fixed('père adoptif', '%s du père adoptif')->adoptive()->father(),
             Relationship::fixed('parent adoptif', '%s du parent adoptif')->adoptive()->parent(),
+            Relationship::fixed('sœur adoptive', '%s de la sœur adoptive')->adoptive()->sister(),
+            Relationship::fixed('frère adoptif', '%s du frère adoptif')->adoptive()->brother(),
+            Relationship::fixed('frère/sœur adoptif', '%s du frère/sœur adoptif')->adoptive()->sibling(),
             Relationship::fixed('fille adoptive', '%s de la fille adoptive')->adopted()->daughter(),
             Relationship::fixed('fils adoptif', '%s du fils adoptif')->adopted()->son(),
             Relationship::fixed('enfant adoptif', '%s de l’enfant adoptif')->adopted()->child(),
+            Relationship::fixed('sœur adoptive', '%s de la sœur adoptive')->adopted()->sister(),
+            Relationship::fixed('frère adoptif', '%s du frère adoptif')->adopted()->brother(),
+            Relationship::fixed('frère/sœur adoptif', '%s du frère/sœur adoptif')->adopted()->sibling(),
             // Fostered
             Relationship::fixed('mère d’accueil', '%s de la mère d’acceuil')->fostering()->mother(),
             Relationship::fixed('père d’accueil', '%s du père d’acceuil')->fostering()->father(),
             Relationship::fixed('parent d’accueil', '%s du parent d’acceuil')->fostering()->parent(),
+            Relationship::fixed('sœur d’accueil', '%s de la sœur d’accueil')->fostering()->sister(),
+            Relationship::fixed('frère d’accueil', '%s du frère d’accueil')->fostering()->brother(),
+            Relationship::fixed('frère/sœur d’accueil', '%s du frère/sœur d’accueil')->fostering()->sibling(),
             Relationship::fixed('fille accueillie', '%s de la fille accueillie')->fostered()->daughter(),
             Relationship::fixed('fils accueilli', '%s du fils accueilli')->fostered()->son(),
             Relationship::fixed('enfant accueilli', '%s de l’enfant accueilli')->fostered()->child(),
+            Relationship::fixed('sœur accueillie', '%s de la sœur accueillie')->fostered()->sister(),
+            Relationship::fixed('frère accueilli', '%s du frère accueilli')->fostered()->brother(),
+            Relationship::fixed('frère/sœur accueilli', '%s du frère/sœur accueilli')->fostered()->sibling(),
+            // Wet-nursed (rada)
+            Relationship::fixed('mère de lait', '%s de la mère de lait')->wetNursing()->mother(),
+            Relationship::fixed('sœur de lait', '%s de la sœur de lait')->wetNursing()->sister(),
+            Relationship::fixed('sœur de lait', '%s de la sœur de lait')->wetNursing()->parent()->daughter(),
+            Relationship::fixed('frère de lait', '%s du frère de lait')->wetNursing()->brother(),
+            Relationship::fixed('frère de lait', '%s du frère de lait')->wetNursing()->parent()->brother(),
+            Relationship::fixed('frère/sœur de lait', '%s du frère/sœur de lait')->wetNursing()->sibling(),
+            Relationship::fixed('frère/sœur de lait', '%s du frère/sœur de lait')->wetNursing()->parent()->sibling(),
+            Relationship::fixed('fille de lait', '%s de la fille de lait')->wetNursed()->daughter(),
+            Relationship::fixed('fils de lait', '%s de lait')->wetNursed()->son(),
+            Relationship::fixed('enfant de lait', '%s de lait')->wetNursed()->child(),
+            Relationship::fixed('sœur de lait', '%s de la sœur de lait')->wetNursed()->sister(),
+            Relationship::fixed('sœur de lait', '%s de la sœur de lait')->parent()->wetNursed()->daughter(),
+            Relationship::fixed('frère de lait', '%s de lait')->wetNursed()->brother(),
+            Relationship::fixed('frère de lait', '%s de lait')->parent()->wetNursed()->son(),
+            Relationship::fixed('frère/sœur de lait', '%s du frère/sœur de lait')->wetNursed()->sibling(),
+            Relationship::fixed('frère/sœur de lait', '%s du frère/sœur de lait')->parent()->wetNursed()->child(),
             // Parents
             Relationship::fixed('mère', '%s de la mère')->mother(),
             Relationship::fixed('père', '%s du père')->father(),
@@ -187,15 +216,15 @@ class LanguageFrench extends AbstractModule implements ModuleLanguageInterface
             Relationship::fixed('frère', '%s du frère')->brother(),
             Relationship::fixed('frère/sœur', '%s du frère/sœur')->sibling(),
             // Half-family
-            Relationship::fixed('demi-sœur', '%s de la demi-sœur')->parent()->daughter(),
-            Relationship::fixed('demi-frère', '%s du demi-frère')->parent()->son(),
-            Relationship::fixed('demi-frère/sœur', '%s du demi-frère/sœur')->parent()->child(),
+            Relationship::fixed('demi-sœur', '%s de la demi-sœur')->biological()->parent()->biologicallyBorn()->daughter(),
+            Relationship::fixed('demi-frère', '%s du demi-frère')->biological()->parent()->biologicallyBorn()->son(),
+            Relationship::fixed('demi-frère/sœur', '%s du demi-frère/sœur')->biological()->parent()->biologicallyBorn()->child(),
             // Stepfamily
             Relationship::fixed('belle-mère', '%s de la belle-mère')->parent()->wife(),
             Relationship::fixed('beau-père', '%s du beau-père')->parent()->husband(),
             Relationship::fixed('beau-parent', '%s du beau-parent')->parent()->married()->spouse(),
             Relationship::fixed('belle-fille', '%s de la belle-fille')->married()->spouse()->daughter(),
-            Relationship::fixed('beau-fils', '%s du beau-fils')->married()->spouse()->son(),
+            Relationship::fixed('gendre', '%s du beau-fils')->married()->spouse()->son(),
             Relationship::fixed('beau-fils/fille', '%s du beau-fils/fille')->married()->spouse()->child(),
             Relationship::fixed('quasi-sœur', '%s de la quasi-sœur')->parent()->spouse()->daughter(),
             Relationship::fixed('quasi-frère', '%s du quasi-frère')->parent()->spouse()->son(),

--- a/app/Relationship.php
+++ b/app/Relationship.php
@@ -126,11 +126,7 @@ class Relationship
      */
     public function adopted(): Relationship
     {
-        $this->matchers[] = fn (array $nodes): bool => count($nodes) > 2 && $nodes[2]
-                ->facts(['FAMC'], false, Auth::PRIV_HIDE)
-                ->contains(fn (Fact $fact): bool => $fact->value() === '@' . $nodes[1]->xref() . '@' && $fact->attribute('PEDI') === 'adopted');
-
-        return $this;
+        return $this->linkedByType('adopted');
     }
 
     /**
@@ -138,9 +134,56 @@ class Relationship
      */
     public function adoptive(): Relationship
     {
-        $this->matchers[] = fn (array $nodes): bool => $nodes[0]
-            ->facts(['FAMC'], false, Auth::PRIV_HIDE)
-            ->contains(fn (Fact $fact): bool => $fact->value() === '@' . $nodes[1]->xref() . '@' && $fact->attribute('PEDI') === 'adopted');
+        return $this->linkingByType('adopted');
+    }
+
+    /**
+     * @return Relationship
+     */
+    public function biologicallyBorn(): Relationship
+    {
+        return $this->linkedByType('birth', true);
+    }
+
+    /**
+     * @return Relationship
+     */
+    public function biological(): Relationship
+    {
+        return $this->linkingByType('birth', true);
+    }
+
+    /**
+     * Matches a pedigree linkage type based on the target node's child family status.
+     *
+     * @param string $pedigree_type
+     * @param bool $is_default
+     * @return Relationship
+     */
+    protected function linkedByType(string $pedigree_type, bool $is_default = false): Relationship
+    {
+        $this->matchers[] = fn (array $nodes): bool => count($nodes) > 2 && $nodes[2]
+                ->facts(['FAMC'], false, Auth::PRIV_HIDE)
+                ->map(fn (Fact $fact): array => [$fact->value(), $fact->attribute('PEDI')])
+                ->contains(fn (array $fact): bool => $fact[0] === '@' . $nodes[1]->xref() . '@'
+                    && ($fact[1] === $pedigree_type || ($fact[1] === '' && $is_default)));
+
+        return $this;
+    }
+
+    /**
+     * Matches a pedigree linkage type based on the initial node's child family status.
+     *
+     * @param string $pedigree_type
+     * @return Relationship
+     */
+    protected function linkingByType(string $pedigree_type, bool $is_default = false): Relationship
+    {
+        $this->matchers[] = fn (array $nodes): bool => count($nodes) > 1 && $nodes[0]
+                ->facts(['FAMC'], false, Auth::PRIV_HIDE)
+                ->map(fn (Fact $fact): array => [$fact->value(), $fact->attribute('PEDI')])
+                ->contains(fn (array $fact): bool => $fact[0] === '@' . $nodes[1]->xref() . '@'
+                    && ($fact[1] === $pedigree_type || ($fact[1] === '' && $is_default)));
 
         return $this;
     }
@@ -346,11 +389,7 @@ class Relationship
      */
     public function fostered(): Relationship
     {
-        $this->matchers[] = fn (array $nodes): bool => count($nodes) > 2 && $nodes[2]
-                ->facts(['FAMC'], false, Auth::PRIV_HIDE)
-                ->contains(fn (Fact $fact): bool => $fact->value() === '@' . $nodes[1]->xref() . '@' && $fact->attribute('PEDI') === 'foster');
-
-        return $this;
+        return $this->linkedByType('foster');
     }
 
     /**
@@ -358,11 +397,7 @@ class Relationship
      */
     public function fostering(): Relationship
     {
-        $this->matchers[] = fn (array $nodes): bool => $nodes[0]
-            ->facts(['FAMC'], false, Auth::PRIV_HIDE)
-            ->contains(fn (Fact $fact): bool => $fact->value() === '@' . $nodes[1]->xref() . '@' && $fact->attribute('PEDI') === 'foster');
-
-        return $this;
+        return $this->linkingByType('foster');
     }
 
     /**
@@ -515,6 +550,22 @@ class Relationship
         };
 
         return $this;
+    }
+
+    /**
+     * @return Relationship
+     */
+    public function wetNursed(): Relationship
+    {
+        return $this->linkedByType('rada');
+    }
+
+    /**
+     * @return Relationship
+     */
+    public function wetNursing(): Relationship
+    {
+        return $this->linkingByType('rada');
     }
 
     /**

--- a/app/Services/RelationshipService.php
+++ b/app/Services/RelationshipService.php
@@ -223,7 +223,7 @@ class RelationshipService
         // Reduce the genitive-nominative chain to a single string.
         return array_reduce($relationships, static function (array $carry, array $item): array {
             return [sprintf($carry[1], $item[0]), sprintf($carry[1], $item[1])];
-        }, [1 => '%s'])[0];
+        }, [0 => '', 1 => '%s'])[0];
     }
 
     /**

--- a/tests/feature/RelationshipNamesTest.php
+++ b/tests/feature/RelationshipNamesTest.php
@@ -279,37 +279,29 @@ class RelationshipNamesTest extends TestCase
             self::assertRelationships('grand frère', 'petite sœur', [$i4f, $f1m, $i3m], $fr);
             self::assertRelationships('petit frère/sœur', 'grand frère', [$i3m, $f1m, $i5u], $fr);
             self::assertRelationships('frère', 'sœur', [$i8f, $f2d, $i7ma], $fr);
-            self::assertRelationship('sœur', [$i7ma, $f2d, $i8f], $fr);
             self::assertRelationship('frère/sœur', [$i7ma, $f2d, $i9u], $fr);
-            self::assertRelationship('mère adoptive', [$i7ma, $f2d, $i2f], $fr);
-            self::assertRelationship('père adoptif', [$i7ma, $f2d, $i6m], $fr);
-            self::assertRelationship('fils adoptif', [$i6m, $f2d, $i7ma], $fr);
-            self::assertRelationship('beau-père', [$i8f, $f2d, $i2f, $f1m, $i1m], $fr);
-            self::assertRelationship('belle-fille', [$i1m, $f1m, $i2f, $f2d, $i8f], $fr);
-            self::assertRelationship('demi-frère', [$i8f, $f2d, $i2f, $f1m, $i3m], $fr);
+            self::assertRelationships('mère adoptive', 'fils adoptif', [$i7ma, $f2d, $i2f], $fr);
+            self::assertRelationships('père adoptif', 'fils adoptif', [$i7ma, $f2d, $i6m], $fr);
+            self::assertRelationships('beau-père', 'belle-fille', [$i8f, $f2d, $i2f, $f1m, $i1m], $fr);
+            self::assertRelationships('demi-frère', 'demi-sœur', [$i8f, $f2d, $i2f, $f1m, $i3m], $fr);
             self::assertRelationship('quasi-sœur', [$i8f, $f2d, $i6m, $f13m, $i31m, $f14d, $i33f], $fr);
-            self::assertRelationship('beau-père', [$i8f, $f2d, $i6m, $f13m, $i31m], $fr);
-            self::assertRelationship('belle-mère', [$i2f, $f1m, $i1m, $f4m, $i12f], $fr);
-            self::assertRelationship('belle-fille', [$i12f, $f4m, $i1m, $f1m, $i2f], $fr);
-            // Dynamic relationships
+            self::assertRelationships('beau-père', 'gendre', [$i1m, $f1m, $i2f, $f5m, $i13m], $fr);
+            self::assertRelationships('belle-mère', 'bru', [$i2f, $f1m, $i1m, $f4m, $i12f], $fr);
             self::assertRelationships('grand-père paternel', 'petit-fils', [$i3m, $f1m, $i1m, $f4m, $i11m], $fr);
             self::assertRelationships('grand-mère paternelle', 'petite-fille', [$i4f, $f1m, $i1m, $f4m, $i12f], $fr);
             self::assertRelationships('grand-père maternel', 'petit-fils', [$i3m, $f1m, $i2f, $f5m, $i13m], $fr);
             self::assertRelationships('grand-mère maternelle', 'petite-fille', [$i4f, $f1m, $i2f, $f5m, $i14f], $fr);
             self::assertRelationships('arrière-grand-père paternel', 'arrière-petit-fils', [$i3m, $f1m, $i1m, $f4m, $i11m, $f7, $i16m], $fr);
             self::assertRelationships('arrière-grand-mère paternelle', 'arrière-petite-fille', [$i4f, $f1m, $i1m, $f4m, $i11m, $f7, $i17f], $fr);
-            self::assertRelationships('arrière-arrière-grand-père paternel', 'arrière-arrière-petit-fils', [$i3m, $f1m, $i1m, $f4m, $i11m, $f7, $i17f, $f8, $i18m], $fr);
-            self::assertRelationships('arrière-arrière-grand-mère paternelle', 'arrière-arrière-petite-fille', [$i4f, $f1m, $i1m, $f4m, $i11m, $f7, $i17f, $f8, $i19f], $fr);
-            self::assertRelationships('arrière-(x3)-grand-père paternel', 'arrière-(x3)-petit-fils', [$i3m, $f1m, $i1m, $f4m, $i11m, $f7, $i17f, $f8, $i18m, $f9, $i20m], $fr);
-            self::assertRelationships('arrière-(x3)-grand-mère paternelle', 'arrière-(x3)-petite-fille', [$i4f, $f1m, $i1m, $f4m, $i11m, $f7, $i17f, $f8, $i18m, $f9, $i21f], $fr);
-            self::assertRelationships('arrière-(x4)-grand-père paternel', 'arrière-(x4)-petit-fils', [$i3m, $f1m, $i1m, $f4m, $i11m, $f7, $i17f, $f8, $i18m, $f9, $i21f, $f10, $i22m], $fr);
-            self::assertRelationships('arrière-(x4)-grand-mère paternelle', 'arrière-(x4)-petite-fille', [$i4f, $f1m, $i1m, $f4m, $i11m, $f7, $i17f, $f8, $i18m, $f9, $i21f, $f10, $i23f], $fr);
+            self::assertRelationships('trisaïeul paternel', 'petit-fils au 3<sup>e</sup> degré', [$i3m, $f1m, $i1m, $f4m, $i11m, $f7, $i17f, $f8, $i18m], $fr);
+            self::assertRelationships('trisaïeule paternelle', 'petite-fille au 3<sup>e</sup> degré', [$i4f, $f1m, $i1m, $f4m, $i11m, $f7, $i17f, $f8, $i19f], $fr);
+            self::assertRelationships('grand-père paternel au 4<sup>e</sup> degré', 'petit-fils au 4<sup>e</sup> degré', [$i3m, $f1m, $i1m, $f4m, $i11m, $f7, $i17f, $f8, $i18m, $f9, $i20m], $fr);
+            self::assertRelationships('grand-mère paternelle au 4<sup>e</sup> degré', 'petite-fille au 4<sup>e</sup> degré', [$i4f, $f1m, $i1m, $f4m, $i11m, $f7, $i17f, $f8, $i18m, $f9, $i21f], $fr);
             self::assertRelationships('oncle', 'neveu', [$i18m, $f9, $i21f, $f10, $i24m], $fr);
-            self::assertRelationships('grand-oncle', 'petit-neveu', [$i30m, $f8, $i18m, $f9, $i21f, $f10, $i24m], $fr);
+            self::assertRelationships('grand-oncle', 'petite-nièce', [$i17f, $f8, $i18m, $f9, $i21f, $f10, $i24m], $fr);
             self::assertRelationships('arrière-grand-oncle', 'arrière-petit-neveu', [$i11m, $f7, $i17f, $f8, $i18m, $f9, $i21f, $f10, $i24m], $fr);
-            self::assertRelationships('neveu', 'oncle', [$i24m, $f10, $i21f, $f9, $i18m], $fr);
-            self::assertRelationships('petite-nièce', 'grand-oncle', [$i24m, $f10, $i21f, $f9, $i18m, $f8, $i17f], $fr);
-            self::assertRelationships('arrière-petit-neveu', 'arrière-grand-oncle', [$i24m, $f10, $i21f, $f9, $i18m, $f8, $i17f, $f7, $i11m], $fr);
+            self::assertRelationships('grand-oncle au 3<sup>e</sup> degré', 'petit-neveu au 3<sup>e</sup> degré', [$i1m, $f4m, $i11m, $f7, $i17f, $f8, $i18m, $f9, $i21f, $f10, $i24m], $fr);
+            self::assertRelationships('grand-oncle au 4<sup>e</sup> degré', 'petite-nièce au 4<sup>e</sup> degré', [$i4f, $f1m, $i1m, $f4m, $i11m, $f7, $i17f, $f8, $i18m, $f9, $i21f, $f10, $i24m], $fr);
             self::assertRelationships('cousine germaine', 'cousin germain', [$i18m, $f9, $i21f, $f10, $i24m, $f11m, $i26f], $fr);
             self::assertRelationships('cousin issu de germain', 'cousin issu de germain', [$i30m, $f8, $i18m, $f9, $i21f, $f10, $i24m, $f11m, $i26f, $f12, $i29m], $fr);
             self::assertRelationships('cousine au 3<sup>e</sup> degré', 'cousin au 3<sup>e</sup> degré', [$i11m, $f7, $i17f, $f8, $i18m, $f9, $i21f, $f10, $i24m, $f11m, $i26f, $f12, $i29m, $f15, $i34f], $fr);
@@ -319,6 +311,10 @@ class RelationshipNamesTest extends TestCase
             self::assertRelationships('cousine du 3<sup>e</sup> au 2<sup>e</sup> degré', 'cousine du 2<sup>e</sup> au 3<sup>e</sup> degré', [$i17f, $f8, $i18m, $f9, $i21f, $f10, $i24m, $f11m, $i26f, $f12, $i29m, $f15, $i34f], $fr);
             // Compound relationships
             self::assertRelationships('ex-époux de l’épouse', 'époux de l’ex-épouse', [$i1m, $f1m, $i2f, $f2d, $i6m], $fr);
+            self::assertRelationship('fiancée du petit-neveu au 4<sup>e</sup> degré', [$i24m, $f10, $i21f, $f9, $i18m, $f8, $i17f, $f7, $i11m, $f4m, $i1m, $f1m, $i3m, $f3e, $i10f], $fr);
+            self::assertRelationship('épouse de l’arrière-petit-neveu', [$i24m, $f10, $i21f, $f9, $i18m, $f8, $i17f, $f7, $i11m, $f4m, $i12f], $fr);
+            self::assertRelationship('conjoint de la petite-nièce', [$i24m, $f10, $i21f, $f9, $i18m, $f8, $i17f, $f7, $i16m], $fr);
+            self::assertRelationship('conjointe du neveu', [$i24m, $f10, $i21f, $f9, $i18m, $f8, $i19f], $fr);
         }
 
         ///////////////////////////////////////////////////////////////////////

--- a/tests/feature/RelationshipNamesTest.php
+++ b/tests/feature/RelationshipNamesTest.php
@@ -64,13 +64,13 @@ class RelationshipNamesTest extends TestCase
         //          |                 |                                                             |
         //         i38f i12f===f4m===i11m  i13m===f5m===i14f                                       i34f===f16
         //                      |                  |                                                       |
-        //                     i1m===f1m==========i2f===f2d===i6m=====f13m===i31m===f14d===i32f           i35m===f17
-        //                            |                  |                           |                            |
-        //                        +---+---+          +---+---+                       |                            |
-        //                        |   |   |          |   |   |                       |                            |
-        //          i10f===f3e===i3m i4f i5u       i7ma i8f i9u===f6===i15u         i33f                         i36f
+        //                     i1m===f1m==========i2f===f2d===i6m=====f13m===i31m===f14d===i32f===f18     i35m===f17
+        //                            |                  |                           |             |               |
+        //                        +---+---+          +---+---+                 +-----+             |               |
+        //                        |   |   |          |   |   |                 |     |             |               |
+        //          i10f===f3e===i3m i4f i5u       i7ma i8f i9u===f6===i15u   i33f  i39mo         i40mr           i36f
         //
-        // Individual suffixes - m(ale), f(emale), u(nknown), a(dopted)
+        // Individual suffixes - m(ale), f(emale), u(nknown), a(dopted), o(foster), r(ada)
         // Family suffixes - m(arried), d(ivorced), e(ngaged)
         //
         $tree = $this->createMock(Tree::class);
@@ -119,6 +119,8 @@ class RelationshipNamesTest extends TestCase
         $i36f = new Individual('i36f', "0 @i36f@ INDI\n1 SEX F\n1 FAMC @f17@", null, $tree);
         $i37f = new Individual('i37f', "0 @i37f@ INDI\n1 SEX F\n1 FAMC @f8@", null, $tree);
         $i38f = new Individual('i38f', "0 @i38f@ INDI\n1 SEX F\n1 FAMC @f7@", null, $tree);
+        $i39mo = new Individual('i39mo', "0 @i39o@ INDI\n1 SEX M\n1 FAMC @f14d@\n2 PEDI foster", null, $tree);
+        $i40mr = new Individual('i40mr', "0 @i38f@ INDI\n1 SEX M\n1 FAMC @f18@\n2 PEDI rada", null, $tree);
 
         $individual_factory->method('make')->will($this->returnValueMap([
             'i1m'  => $i1m,
@@ -159,6 +161,8 @@ class RelationshipNamesTest extends TestCase
             'i36f' => $i36f,
             'i37f' => $i37f,
             'i38f' => $i38f,
+            'i39mo' => $i39mo,
+            'i40mr' => $i40mr
         ]));
 
         $f1m  = new Family('f1m', "0 @f1m@ FAM\n1 MARR Y\n1 HUSB @i1m@\n1 WIFE @i2f@\n1 CHIL @i3m@\n1 CHIL @i4f@\n1 CHIL @i5u@", null, $tree);
@@ -174,10 +178,11 @@ class RelationshipNamesTest extends TestCase
         $f11m = new Family('f11m', "0 @f11m@ FAM\n1 MARR Y\n1 HUSB @i24m@\n1 WIFE @i25f@\n1 CHIL @i26f@", null, $tree);
         $f12  = new Family('f12', "0 @f12@ FAM\n1 HUSB @i27m@\n1 WIFE @i26f@\n1 CHIL @i28u@\n1 CHIL @i29m@", null, $tree);
         $f13m = new Family('f13m', "0 @f13m@ FAM\n1 MARR Y\n1 HUSB @i6m@\n1 WIFE @i31m@", null, $tree);
-        $f14d = new Family('f14d', "0 @f14d@ FAM\n1 DIV Y\n1 HUSB @i31m@\n1 WIFE @i32f@\n1 CHIL @i33f@\n", null, $tree);
-        $f15  = new Family('f15', "0 @f15@ FAM\n1 HUSB @i29m@\n1 CHIL @i34f@\n", null, $tree);
-        $f16  = new Family('f16', "0 @f16@ FAM\n1 WIFE @i34f@\n1 CHIL @i35m@\n", null, $tree);
-        $f17  = new Family('f17', "0 @f17@ FAM\n1 HUSB @i35m@\n1 CHIL @i36f@\n", null, $tree);
+        $f14d = new Family('f14d', "0 @f14d@ FAM\n1 DIV Y\n1 HUSB @i31m@\n1 WIFE @i32f@\n1 CHIL @i33f@\n1 CHIL @i39mo@", null, $tree);
+        $f15  = new Family('f15', "0 @f15@ FAM\n1 HUSB @i29m@\n1 CHIL @i34f@", null, $tree);
+        $f16  = new Family('f16', "0 @f16@ FAM\n1 WIFE @i34f@\n1 CHIL @i35m@", null, $tree);
+        $f17  = new Family('f17', "0 @f17@ FAM\n1 HUSB @i35m@\n1 CHIL @i36f@", null, $tree);
+        $f18  = new Family('f18', "0 @f18@ FAM\n1 WIFE @i32f@\n1 CHIL @i40mr@", null, $tree);
 
         $family_factory->method('make')->will($this->returnValueMap([
             'f1m'  => $f1m,
@@ -197,6 +202,7 @@ class RelationshipNamesTest extends TestCase
             'f15'  => $f15,
             'f16'  => $f16,
             'f17'  => $f17,
+            'f18'  => $f18,
         ]));
 
         ///////////////////////////////////////////////////////////////////////
@@ -220,6 +226,9 @@ class RelationshipNamesTest extends TestCase
             self::assertRelationships('brother', 'sister', [$i8f, $f2d, $i7ma], $en);
             self::assertRelationships('sibling', 'brother', [$i7ma, $f2d, $i9u], $en);
             self::assertRelationships('adoptive-mother', 'adopted-son', [$i7ma, $f2d, $i2f], $en);
+            self::assertRelationships('foster-mother', 'foster-son', [$i39mo, $f14d, $i32f], $en);
+            self::assertRelationships('foster-father', 'foster-son', [$i39mo, $f14d, $i31m], $en);
+            self::assertRelationships('foster-sister', 'foster-brother', [$i39mo, $f14d, $i33f], $en);
             self::assertRelationships('stepfather', 'stepchild', [$i9u, $f2d, $i2f, $f1m, $i1m], $en);
             self::assertRelationships('stepdaughter', 'stepmother', [$i2f, $f1m, $i2f, $f2d, $i8f], $en);
             self::assertRelationships('stepsister', 'stepsibling', [$i9u, $f2d, $i6m, $f13m, $i31m, $f14d, $i33f], $en);
@@ -278,12 +287,18 @@ class RelationshipNamesTest extends TestCase
             self::assertRelationships('enfant', 'père', [$i1m, $f1m, $i5u], $fr);
             self::assertRelationships('grand frère', 'petite sœur', [$i4f, $f1m, $i3m], $fr);
             self::assertRelationships('petit frère/sœur', 'grand frère', [$i3m, $f1m, $i5u], $fr);
-            self::assertRelationships('frère', 'sœur', [$i8f, $f2d, $i7ma], $fr);
-            self::assertRelationship('frère/sœur', [$i7ma, $f2d, $i9u], $fr);
+            self::assertRelationships('frère', 'sœur', [$i38f, $f7, $i11m], $fr);
+            self::assertRelationships('frère/sœur', 'sœur', [$i8f, $f2d, $i9u], $fr);
             self::assertRelationships('mère adoptive', 'fils adoptif', [$i7ma, $f2d, $i2f], $fr);
             self::assertRelationships('père adoptif', 'fils adoptif', [$i7ma, $f2d, $i6m], $fr);
+            self::assertRelationships('sœur adoptive', 'frère adoptif', [$i7ma, $f2d, $i8f], $fr);
+            self::assertRelationships('mère d’accueil', 'fils accueilli', [$i39mo, $f14d, $i32f], $fr);
+            self::assertRelationships('père d’accueil', 'fils accueilli', [$i39mo, $f14d, $i31m], $fr);
+            self::assertRelationships('sœur d’accueil', 'frère accueilli', [$i39mo, $f14d, $i33f], $fr);
+            self::assertRelationships('mère de lait', 'fils de lait', [$i40mr, $f18, $i32f], $fr);
+            self::assertRelationships('sœur de lait', 'frère de lait', [$i40mr, $f18, $i32f, $f14d, $i33f], $fr);
             self::assertRelationships('beau-père', 'belle-fille', [$i8f, $f2d, $i2f, $f1m, $i1m], $fr);
-            self::assertRelationships('demi-frère', 'demi-sœur', [$i8f, $f2d, $i2f, $f1m, $i3m], $fr);
+            self::assertRelationships('demi-frère', 'demi-frère/sœur', [$i9u, $f2d, $i2f, $f1m, $i3m], $fr);
             self::assertRelationship('quasi-sœur', [$i8f, $f2d, $i6m, $f13m, $i31m, $f14d, $i33f], $fr);
             self::assertRelationships('beau-père', 'gendre', [$i1m, $f1m, $i2f, $f5m, $i13m], $fr);
             self::assertRelationships('belle-mère', 'bru', [$i2f, $f1m, $i1m, $f4m, $i12f], $fr);


### PR DESCRIPTION
I know I should not really put several commits in a PR, but there are the result of the same work, just wanted to functionally separate them.

First, the French translation has been modified based on the first feedbacks on the forum.

A small bug was in `nameFromPath` when no relationships are found: `array_reduce` would then return the initial array, which did not have a 0 index.

Finally, I have added a couple of methods linked to the pedigree linkage types: now it is possible to define more precisely based on the different values of `\Fisharebest\Webtrees\Elements\PedigreeLinkageType` (with the exception of 'sealing' which is an obscure concept to me). This for instance allows to define more precisely half-brother where (in French at least) a blood-link is required. 'birth' is assumed though when no PEDI value exist.
I had some difficulties finding a good name for the `birth` linkage methods though, as the term I could think of (biological, natural,...) would be the same thing in both directions, so do not offer the dichotomy as adoptive/adopted, fostering/fostered. Feel free to modify.