### PR TITLE
Fix imported boolean column for postgresql

### DIFF
--- a/app/Http/RequestHandlers/GedcomLoad.php
+++ b/app/Http/RequestHandlers/GedcomLoad.php
@@ -129,7 +129,7 @@ class GedcomLoad implements RequestHandlerInterface
                 $n = DB::table('gedcom_chunk')
                     ->where('gedcom_chunk_id', '=', $data->gedcom_chunk_id)
                     ->where('imported', '=', '0')
-                    ->update(['imported' => 1]);
+                    ->update(['imported' => '1']);
 
                 // Another process has already imported this data?
                 if ($n === 0) {

--- a/resources/views/admin/trees.phtml
+++ b/resources/views/admin/trees.phtml
@@ -63,7 +63,7 @@ use Illuminate\Database\Capsule\Manager as DB;
                 </div>
                 <div id="card-tree-content-<?= $managed_tree->id() ?>" class="collapse<?= $managed_tree == $tree || $managed_tree->getPreference('imported') === '0' ? ' show' : '' ?>" role="tabpanel" aria-labelledby="panel-tree-header-<?= $managed_tree->id() ?>">
                     <div class="card-body">
-                        <?php $importing = DB::table('gedcom_chunk')->where('gedcom_id', '=', $managed_tree->id())->where('imported', '=', 0)->exists() ?>
+                        <?php $importing = DB::table('gedcom_chunk')->where('gedcom_id', '=', $managed_tree->id())->where('imported', '=', '0')->exists() ?>
                         <?php if ($importing) : ?>
                             <div id="import<?= $managed_tree->id() ?>" class="col-12">
                                 <div class="progress">


### PR DESCRIPTION
When setting up webtrees with a PostgreSQL database (tested with 13.2), showing the manage trees page and importing gedcom files doesn't work.
It shows the following error:
```
SQLSTATE[42883]: Undefined function: 7 ERROR:  operator does not exist: boolean = integer
LINE 1: ...dcom_chunk" where "gedcom_id" = $1 and "imported" = $2) as "...
                                                             ^
HINT:  No operator matches the given name and argument types. You might need to add explicit type casts. (SQL: select exists(select * from "wt_gedcom_chunk" where "gedcom_id" = 1 and "imported" = 0) as "exists") …/vendor/illuminate/database/Connection.php:664
#0 …/vendor/illuminate/database/Connection.php(624): Illuminate\Database\Connection->runQueryCallback()
#1 …/vendor/illuminate/database/Connection.php(333): Illuminate\Database\Connection->run()
#2 …/vendor/illuminate/database/Query/Builder.php(2426): Illuminate\Database\Connection->select()
#3 …/resources/views/admin/trees.phtml(66): Illuminate\Database\Query\Builder->exists()
```

PostgreSQL seems to be more strict for boolean columns.
It only accepts string representations, but not a numeric representation: https://www.postgresql.org/docs/13/datatype-boolean.html
This PR replaces `0` with `'0'` for the `imported` column, as it is already done in the other places.
