### PR TITLE
GitHub: create issue templates

### DIFF
--- a/.github/workflows/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/workflows/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,115 @@
+---
+name: 🐛 Bug report
+about: Help us improving by reporting a bug
+labels: bug
+assignees: ''
+---
+
+<!--
+Thanks for reporting issues back to Webtrees!
+
+Note: This is the **issue tracker of Webtrees**, please do **NOT** use this to get answers to your questions or get help for fixing your installation. This is a place to report bugs to developers, after your server has been debugged. You can find help debugging your system on our home user forums: https://www.webtrees.net/index.php/en/forum See also https://webtrees.net/faq/.
+
+Webtrees is an open source project maintained by Greg Roach. Most of our volunteers are home users and thus primarily care about issues that affect home users.
+
+Guidelines for submitting issues:
+
+1. Please **search** the existing issues first, it's likely that your issue was already reported or even fixed:
+   - Go to https://github.com/fisharebest/webtrees and type any word in the top search/command bar. You probably see something like "*We couldn’t find any repositories matching ...*" then click `Issues` in the left navigation.
+   - You can also filter by appending e. g. `state:open` to the search string. More info on search syntax within github: https://help.github.com/articles/searching-issues
+2. **SECURITY**: Report any potential security bug to Greg Roach at greg@subaqua.co.uk instead of filing an issue in our bug tracker.
+   -->
+
+<!--- Please keep this note for other contributors -->
+
+## 1) How to use GitHub
+
+* Please use the 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to show that you are affected by the same issue.
+* Please don't comment if you have no relevant information to add. It's just extra noise for everyone subscribed to this issue.
+* Subscribe to receive notifications on status change and new comments. 
+
+
+## 2) Describe the bug
+*A clear and concise description of the bug.*
+
+### Steps to reproduce
+```
+
+1. 
+2. 
+3. 
+
+```
+### Expected behavior
+```
+
+A clear and concise description of what you expected to happen.
+
+```
+### Actual behaviour
+```
+
+A clear and concise description of what happens instead.
+
+```
+
+### Screenshots
+*If applicable, add any screenshots here to help explain your problem.*
+
+### Server configuration
+```
+
+- Host: 
+- Operating system: 
+- Web server: 
+- Database: 
+- PHP version: 
+
+```
+
+### Webtrees configuration
+```
+
+- Webtrees version: 
+- Updated from an older Webtrees or fresh install: 
+- Where did you install Webstrees from: 
+
+```
+
+### Client configuration
+```
+
+- Device: 
+- Operating system: 
+- Browser: 
+
+```
+
+## 3) Additional context
+```
+
+Add any other context about the problem here.
+
+```
+
+## 4) Logs
+*Reports without logs might be closed as unqualified reports!*
+
+### Web server error log
+
+```
+
+Insert your webserver error log (not the access log) here.
+
+```
+
+### Browser log
+
+```
+
+Insert your browser log here, this could for example include:
+a) The javascript console log
+b) The network log
+c) ...
+
+```

--- a/.github/workflows/ISSUE_TEMPLATE/config.yml
+++ b/.github/workflows/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Support and Questions
+    url: "https://www.webtrees.net/index.php/en/forum"
+    about: "If you have trouble with setting up Webtrees, please use the forum instead of opening an issue here."

--- a/.github/workflows/ISSUE_TEMPLATE/development_help.md
+++ b/.github/workflows/ISSUE_TEMPLATE/development_help.md
@@ -1,0 +1,31 @@
+---
+name: 🚧 Development
+about: Ask for help with development 
+labels: question
+---
+
+<!--
+Note: This is the **issue tracker of Webtrees**, please do NOT use this to get answers to your questions or get help for fixing your installation. This is a place to report bugs to developers, after your server has been debugged. You can find help debugging your system on our home user forums: https://www.webtrees.net/index.php/en/forum See also https://webtrees.net/faq/.
+
+Webtrees is an open source project maintained by Greg Roach. Most of our volunteers are home users and thus primarily care about issues that affect home users.
+
+Guidelines for submitting issues:
+1. Please **search** the existing issues first, it's likely that your issue was already reported or even fixed:
+   - Go to https://github.com/fisharebest/webtrees and type any word in the top search/command bar. You probably see something like "*We couldn’t find any repositories matching ...*" then click `Issues` in the left navigation.
+   - You can also filter by appending e. g. `state:open` to the search string. More info on search syntax within github: https://help.github.com/articles/searching-issues
+2. **SECURITY**: Report any potential security bug to Greg Roach at greg@subaqua.co.uk instead of filing an issue in our bug tracker.
+-->
+
+
+<!--- Please keep this note for other contributors -->
+
+## How to use GitHub
+
+* Please use the 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to show that you are interested into the same feature.
+* Please don't comment if you have no relevant information to add. It's just extra noise for everyone subscribed to this issue.
+* Subscribe to receive notifications on status change and new comments. 
+
+## Please describe your development goal
+* Is your question related to a existing feature? Or is it a new feature?
+* What are you struggling with?
+* What are your development skills?

--- a/.github/workflows/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/workflows/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,57 @@
+---
+name: 🚀 Feature request
+about: Suggest an idea for this project
+labels: enhancement
+assignees: ''
+---
+
+<!--
+Thanks for reporting issues back to Webtrees!
+
+Note: This is the **issue tracker of Webtrees**, please do NOT use this to get answers to your questions or get help for fixing your installation. This is a place to report bugs to developers, after your server has been debugged. You can find help debugging your system on our home user forums: https://www.webtrees.net/index.php/en/forum See also https://webtrees.net/faq/.
+
+Webtrees is an open source project maintained by Greg Roach. Most of our volunteers are home users and thus primarily care about issues that affect home users.
+
+Guidelines for submitting issues:
+1. Please **search** the existing issues first, it's likely that your issue was already reported or even fixed:
+   - Go to https://github.com/fisharebest/webtrees and type any word in the top search/command bar. You probably see something like "*We couldn’t find any repositories matching ...*" then click `Issues` in the left navigation.
+   - You can also filter by appending e. g. `state:open` to the search string. More info on search syntax within github: https://help.github.com/articles/searching-issues
+2. **SECURITY**: Report any potential security bug to Greg Roach at greg@subaqua.co.uk instead of filing an issue in our bug tracker.
+-->
+
+
+<!--- Please keep this note for other contributors -->
+
+## 1) How to use GitHub
+
+* Please use the 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to show that you are interested into the same feature.
+* Please don't comment if you have no relevant information to add. It's just extra noise for everyone subscribed to this issue.
+* Subscribe to receive notifications on status change and new comments. 
+
+
+## 2) Describe your feature request
+
+### Is your feature request related to a problem? Please describe.
+```
+
+A clear and concise description of what the problem is.
+
+```
+
+
+### Describe the solution you'd like.
+```
+
+A clear and concise description of what you want to happen.
+
+```
+
+### Describe alternatives you've considered.
+```
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+```
+
+### Additional context.
+*Add any other context or screenshots about the feature request here.*


### PR DESCRIPTION
should help to labeling and structure if issues.

**Suggestions:**

- add a standard assignee to `bug_report `and `feature_request`
- for `bug-report` automated label is `bug` (as in possible bug); consider using secondary label `need more info`, `cannot reproduce`, `confirmed bug` and `won't fix`
- for `feature request` automated label is `enhancement`; consider using secondary label `need more info`, `good first issue`, `idea accepted` and `rejected`
- consider labeling with `semantic milestones`