### PR TITLE
Bootstrap5: changes in toggle button groups

### DIFF
--- a/resources/views/lists/families-table.phtml
+++ b/resources/views/lists/families-table.phtml
@@ -70,11 +70,10 @@ $("#<?= e($table_id) ?>")
     /* Filter buttons in table header */
     .on("click", "input[data-filter-column]", function() {
         let checkbox = $(this);
-        let siblings = checkbox.parent().siblings();
 
         // Deselect other options
-        siblings.children().prop("checked", false).removeAttr("checked");
-        siblings.removeClass('active');
+        let siblings = checkbox.siblings("input[type='checkbox']");
+        siblings.prop("checked", false).removeAttr("checked");
 
         // Apply (or clear) this filter
         let checked = checkbox.prop("checked");
@@ -155,55 +154,63 @@ $marriageAgeData = [
             <tr>
                 <th colspan="14">
                     <div class="btn-toolbar d-flex justify-content-between mb-2">
-                        <div class="btn-group btn-group-toggle btn-group-sm" data-bs-toggle="buttons">
-                            <label class="btn btn-outline-secondary btn-sm" title="' . I18N::translate('Show individuals who are alive or couples where both partners are alive.') ?>">
-                                <input type="checkbox" data-filter-column="12" data-filter-value="N" autocomplete="off">
+                        <div class="btn-group btn-group-sm" role="group">
+                            <input id="<?= e($table_id) ?>-bg-dead-N" class="btn-check" type="checkbox" data-filter-column="12" data-filter-value="N" autocomplete="off">
+                            <label for="<?= e($table_id) ?>-bg-dead-N" class="btn btn-outline-secondary btn-sm" title="' . I18N::translate('Show individuals who are alive or couples where both partners are alive.') ?>">
                                 <?= I18N::translate('Both alive') ?>
                             </label>
-                            <label class="btn btn-outline-secondary" title="<?= I18N::translate('Show couples where only the female partner is dead.') ?>">
-                                <input type="checkbox" data-filter-column="12" data-filter-value="W" autocomplete="off">
+
+                            <input id="<?= e($table_id) ?>-bg-dead-W" class="btn-check" type="checkbox" data-filter-column="12" data-filter-value="W" autocomplete="off">
+                            <label for="<?= e($table_id) ?>-bg-dead-W" class="btn btn-outline-secondary" title="<?= I18N::translate('Show couples where only the female partner is dead.') ?>">
                                 <?= I18N::translate('Widower') ?>
                             </label>
-                            <label class="btn btn-outline-secondary" title="<?= I18N::translate('Show couples where only the male partner is dead.') ?>">
-                                <input type="checkbox" data-filter-column="12" data-filter-value="H" autocomplete="off">
+
+                            <input id="<?= e($table_id) ?>-bg-dead-H" class="btn-check" type="checkbox" data-filter-column="12" data-filter-value="H" autocomplete="off">
+                            <label for="<?= e($table_id) ?>-bg-dead-H" class="btn btn-outline-secondary" title="<?= I18N::translate('Show couples where only the male partner is dead.') ?>">
                                 <?= I18N::translate('Widow') ?>
                             </label>
-                            <label class="btn btn-outline-secondary" title="<?= I18N::translate('Show individuals who are dead or couples where both partners are dead.') ?>">
-                                <input type="checkbox" data-filter-column="12" data-filter-value="Y" autocomplete="off">
+
+                            <input id="<?= e($table_id) ?>-bg-dead-Y" class="btn-check" type="checkbox" data-filter-column="12" data-filter-value="Y" autocomplete="off">
+                            <label for="<?= e($table_id) ?>-bg-dead-Y" class="btn btn-outline-secondary" title="<?= I18N::translate('Show individuals who are dead or couples where both partners are dead.') ?>">
                                 <?= I18N::translate('Both dead') ?>
                             </label>
                         </div>
 
-                        <div class="btn-group btn-group-toggle btn-group-sm" data-bs-toggle="buttons">
-                            <label class="btn btn-outline-secondary" title="<?= I18N::translate('Show “roots” couples or individuals. These individuals may also be called “patriarchs”. They are individuals who have no parents recorded in the database.') ?>">
-                                <input type="checkbox" data-filter-column="13" data-filter-value="R" autocomplete="off">
+                        <div class="btn-group btn-group-sm" role="group">
+                            <input id="<?= e($table_id) ?>-bg-roots-R" class="btn-check" type="checkbox" data-filter-column="13" data-filter-value="R" autocomplete="off">
+                            <label for="<?= e($table_id) ?>-bg-roots-R" class="btn btn-outline-secondary" title="<?= I18N::translate('Show “roots” couples or individuals. These individuals may also be called “patriarchs”. They are individuals who have no parents recorded in the database.') ?>">
                                 <?= I18N::translate('Roots') ?>
                             </label>
-                            <label class="btn btn-outline-secondary" title="<?= I18N::translate('Show “leaves” couples or individuals. These are individuals who are alive but have no children recorded in the database.') ?>">
-                                <input type="checkbox" data-filter-column="13" data-filter-value="L" autocomplete="off">
+
+                            <input id="<?= e($table_id) ?>-bg-roots-L" class="btn-check" type="checkbox" data-filter-column="13" data-filter-value="L" autocomplete="off">
+                            <label for="<?= e($table_id) ?>-bg-roots-L" class="btn btn-outline-secondary" title="<?= I18N::translate('Show “leaves” couples or individuals. These are individuals who are alive but have no children recorded in the database.') ?>">
                                 <?= I18N::translate('Leaves') ?>
                             </label>
                         </div>
 
-                        <div class="btn-group btn-group-toggle btn-group-sm" data-bs-toggle="buttons">
-                            <label class="btn btn-outline-secondary" title="<?= I18N::translate('Show couples with an unknown marriage date.') ?>">
-                                <input type="checkbox" data-filter-column="11" data-filter-value="U" autocomplete="off">
+                        <div class="btn-group btn-group-sm" role="group">
+                            <input id="<?= e($table_id) ?>-bg-marr-U" class="btn-check" type="checkbox" data-filter-column="11" data-filter-value="U" autocomplete="off">
+                            <label for="<?= e($table_id) ?>-bg-marr-U" class="btn btn-outline-secondary" title="<?= I18N::translate('Show couples with an unknown marriage date.') ?>">
                                 <?= I18N::translate('Not married') ?>
                             </label>
-                            <label class="btn btn-outline-secondary" title="<?= I18N::translate('Show couples who married more than 100 years ago.') ?>">
-                                <input type="checkbox" data-filter-column="11" data-filter-value="YES" autocomplete="off">
+
+                            <input id="<?= e($table_id) ?>-bg-marr-YES" class="btn-check" type="checkbox" data-filter-column="11" data-filter-value="YES" autocomplete="off">
+                            <label for="<?= e($table_id) ?>-bg-marr-YES" class="btn btn-outline-secondary" title="<?= I18N::translate('Show couples who married more than 100 years ago.') ?>">
                                 <?= I18N::translate('Marriage') ?>&gt;100
                             </label>
-                            <label class="btn btn-outline-secondary" title="<?= I18N::translate('Show couples who married within the last 100 years.') ?>">
-                                <input type="checkbox" data-filter-column="11" data-filter-value="Y100" autocomplete="off">
+
+                            <input id="<?= e($table_id) ?>-bg-marr-Y100" class="btn-check" type="checkbox" data-filter-column="11" data-filter-value="Y100" autocomplete="off">
+                            <label for="<?= e($table_id) ?>-bg-marr-Y100" class="btn btn-outline-secondary" title="<?= I18N::translate('Show couples who married within the last 100 years.') ?>">
                                 <?= I18N::translate('Marriage') ?>&lt;=100
                             </label>
-                            <label class="btn btn-outline-secondary" title="<?= I18N::translate('Show divorced couples.') ?>">
-                                <input type="checkbox" data-filter-column="11" data-filter-value="D" autocomplete="off">
+
+                            <input id="<?= e($table_id) ?>-bg-marr-D" class="btn-check" type="checkbox" data-filter-column="11" data-filter-value="D" autocomplete="off">
+                            <label for="<?= e($table_id) ?>-bg-marr-D" class="btn btn-outline-secondary" title="<?= I18N::translate('Show divorced couples.') ?>">
                                 <?= I18N::translate('Divorce') ?>
                             </label>
-                            <label class="btn btn-outline-secondary" title="<?= I18N::translate('Show couples where either partner married more than once.') ?>">
-                                <input type="checkbox" data-filter-column="11" data-filter-value="M" autocomplete="off">
+
+                            <input id="<?= e($table_id) ?>-bg-marr-M" class="btn-check" type="checkbox" data-filter-column="11" data-filter-value="M" autocomplete="off">
+                            <label for="<?= e($table_id) ?>-bg-marr-M" class="btn btn-outline-secondary" title="<?= I18N::translate('Show couples where either partner married more than once.') ?>">
                                 <?= I18N::translate('Multiple marriages') ?>
                             </label>
                         </div>

--- a/resources/views/lists/individuals-table.phtml
+++ b/resources/views/lists/individuals-table.phtml
@@ -85,11 +85,10 @@ $("#<?= e($table_id) ?>")
     /* Filter buttons in table header */
     .on("click", "input[data-filter-column]", function() {
         let checkbox = $(this);
-        let siblings = checkbox.parent().siblings();
 
         // Deselect other options
-        siblings.children().prop("checked", false).removeAttr("checked");
-        siblings.removeClass('active');
+        let siblings = checkbox.siblings("input[type='checkbox']");
+        siblings.prop("checked", false).removeAttr("checked");
 
         // Apply (or clear) this filter
         let checked = checkbox.prop("checked");
@@ -170,58 +169,68 @@ $deathAgeData = [
             <tr>
                 <th colspan="16">
                     <div class="btn-toolbar d-flex justify-content-between mb-2" role="toolbar">
-                        <div class="btn-group btn-group-toggle btn-group-sm" data-bs-toggle="buttons">
-                            <label class="btn btn-outline-secondary" title="<?= I18N::translate('Show only males.') ?>">
-                                <input type="checkbox" data-filter-column="12" data-filter-value="M" autocomplete="off">
+                        <div class="btn-group btn-group-sm" role="group">
+                            <input id="<?= e($table_id) ?>-bg-sex-M" class="btn-check" type="checkbox" data-filter-column="12" data-filter-value="M" autocomplete="off">
+                            <label for="<?= e($table_id) ?>-bg-sex-M" class="btn btn-outline-secondary" title="<?= I18N::translate('Show only males.') ?>">
                                 <?= view('icons/sex', ['sex' => 'M']) ?>
                             </label>
-                            <label class="btn btn-outline-secondary" title="<?= I18N::translate('Show only females.') ?>">
-                                <input type="checkbox" data-filter-column="12" data-filter-value="F" autocomplete="off">
+
+                            <input id="<?= e($table_id) ?>-bg-sex-F" class="btn-check" type="checkbox" data-filter-column="12" data-filter-value="F" autocomplete="off">
+                            <label for="<?= e($table_id) ?>-bg-sex-F" class="btn btn-outline-secondary" title="<?= I18N::translate('Show only females.') ?>">
                                 <?= view('icons/sex', ['sex' => 'F']) ?>
                             </label>
-                            <label class="btn btn-outline-secondary" title="<?= I18N::translate('Show only individuals for whom the gender is not known.') ?>">
-                                <input type="checkbox" data-filter-column="12" data-filter-value="U" autocomplete="off">
+
+                            <input id="<?= e($table_id) ?>-bg-sex-U" class="btn-check" type="checkbox" data-filter-column="12" data-filter-value="U" autocomplete="off">
+                            <label for="<?= e($table_id) ?>-bg-sex-U" class="btn btn-outline-secondary" title="<?= I18N::translate('Show only individuals for whom the gender is not known.') ?>">
                                 <?= view('icons/sex', ['sex' => 'U']) ?>
                             </label>
                         </div>
 
-                        <div class="btn-group btn-group-toggle btn-group-sm" data-bs-toggle="buttons">
-                            <label class="btn btn-outline-secondary" title="<?= I18N::translate('Show individuals who are alive or couples where both partners are alive.') ?>">
-                                <input type="checkbox" data-filter-column="14" data-filter-value="N" autocomplete="off">
+                        <div class="btn-group btn-group-sm" role="group">
+                            <input id="<?= e($table_id) ?>-bg-dead-N" class="btn-check" type="checkbox" data-filter-column="14" data-filter-value="N" autocomplete="off">
+                            <label for="<?= e($table_id) ?>-bg-dead-N" class="btn btn-outline-secondary" title="<?= I18N::translate('Show individuals who are alive or couples where both partners are alive.') ?>">
                                 <?= I18N::translate('Alive') ?>
                             </label>
-                            <label class="btn btn-outline-secondary" title="<?= I18N::translate('Show individuals who are dead or couples where both partners are dead.') ?>">
-                                <input type="checkbox" data-filter-column="14" data-filter-value="Y" autocomplete="off">
+
+                            <input id="<?= e($table_id) ?>-bg-dead-Y" class="btn-check" type="checkbox" data-filter-column="14" data-filter-value="Y" autocomplete="off">
+                            <label for="<?= e($table_id) ?>-bg-dead-Y" class="btn btn-outline-secondary" title="<?= I18N::translate('Show individuals who are dead or couples where both partners are dead.') ?>">
                                 <?= I18N::translate('Dead') ?>
                             </label>
-                            <label class="btn btn-outline-secondary" title="<?= I18N::translate('Show individuals who died more than 100 years ago.') ?>">
-                                <input type="checkbox" data-filter-column="14" data-filter-value="YES" autocomplete="off">
+
+                            <input id="<?= e($table_id) ?>-bg-dead-YES" class="btn-check" type="checkbox" data-filter-column="14" data-filter-value="YES" autocomplete="off">
+                            <label for="<?= e($table_id) ?>-bg-dead-YES" class="btn btn-outline-secondary" title="<?= I18N::translate('Show individuals who died more than 100 years ago.') ?>">
                                 <?= I18N::translate('Death') ?>&gt;100
                             </label>
-                            <label class="btn btn-outline-secondary" title="<?= I18N::translate('Show individuals who died within the last 100 years.') ?>">
-                                <input type="checkbox" data-filter-column="14" data-filter-value="Y100" autocomplete="off">
+
+                            <input id="<?= e($table_id) ?>-bg-alive-Y100" class="btn-check" type="checkbox" data-filter-column="14" data-filter-value="Y100" autocomplete="off">
+                            <label for="<?= e($table_id) ?>-bg-alive-Y100" class="btn btn-outline-secondary" title="<?= I18N::translate('Show individuals who died within the last 100 years.') ?>">
                                 <?= I18N::translate('Death') ?>&lt;=100
                             </label>
                         </div>
 
-                        <div class="btn-group btn-group-toggle btn-group-sm" data-bs-toggle="buttons">
-                            <label class="btn btn-outline-secondary" title="<?= I18N::translate('Show individuals born more than 100 years ago.') ?>">
-                                <input type="checkbox" data-filter-column="13" data-filter-value="YES" autocomplete="off">
+                        <div class="btn-group btn-group-sm" role="group">
+                        
+                            <input id="<?= e($table_id) ?>-bg-born-YES" class="btn-check" type="checkbox" data-filter-column="13" data-filter-value="YES" autocomplete="off">
+                            <label for="<?= e($table_id) ?>-bg-born-YES" class="btn btn-outline-secondary" title="<?= I18N::translate('Show individuals born more than 100 years ago.') ?>">
+                                <input class="btn-check" type="checkbox" data-filter-column="13" data-filter-value="YES" autocomplete="off">
                                 <?= I18N::translate('Birth') ?>&gt;100
                             </label>
-                            <label class="btn btn-outline-secondary" title="<?= I18N::translate('Show individuals born within the last 100 years.') ?>">
-                                <input type="checkbox" data-filter-column="13" data-filter-value="Y100" autocomplete="off">
+
+                            <input id="<?= e($table_id) ?>-bg-born-Y100" class="btn-check" type="checkbox" data-filter-column="13" data-filter-value="Y100" autocomplete="off">
+                            <label for="<?= e($table_id) ?>-bg-born-Y100" class="btn btn-outline-secondary" title="<?= I18N::translate('Show individuals born within the last 100 years.') ?>">
                                 <?= I18N::translate('Birth') ?>&lt;=100
                             </label>
                         </div>
 
-                        <div class="btn-group btn-group-toggle btn-group-sm" data-bs-toggle="buttons">
-                            <label class="btn btn-outline-secondary" title="<?= I18N::translate('Show “roots” couples or individuals. These individuals may also be called “patriarchs”. They are individuals who have no parents recorded in the database.') ?>">
-                                <input type="checkbox" data-filter-column="15" data-filter-value="R" autocomplete="off">
+                        <div class="btn-group btn-group-sm" role="group">
+
+                            <input id="<?= e($table_id) ?>-bg-roots-R" class="btn-check" type="checkbox" data-filter-column="15" data-filter-value="R" autocomplete="off">
+                            <label for="<?= e($table_id) ?>-bg-roots-R" class="btn btn-outline-secondary" title="<?= I18N::translate('Show “roots” couples or individuals. These individuals may also be called “patriarchs”. They are individuals who have no parents recorded in the database.') ?>">
                                 <?= I18N::translate('Roots') ?>
                             </label>
-                            <label class="btn btn-outline-secondary" title="<?= I18N::translate('Show “leaves” couples or individuals. These are individuals who are alive but have no children recorded in the database.') ?>">
-                                <input type="checkbox" data-filter-column="15" data-filter-value="L" autocomplete="off">
+
+                            <input id="<?= e($table_id) ?>-bg-roots-L" class="btn-check" type="checkbox" data-filter-column="15" data-filter-value="L" autocomplete="off">
+                            <label for="<?= e($table_id) ?>-bg-roots-L" class="btn btn-outline-secondary" title="<?= I18N::translate('Show “leaves” couples or individuals. These are individuals who are alive but have no children recorded in the database.') ?>">
                                 <?= I18N::translate('Leaves') ?>
                             </label>
                         </div>

--- a/resources/views/modals/on-screen-keyboard.phtml
+++ b/resources/views/modals/on-screen-keyboard.phtml
@@ -9,43 +9,36 @@ use Fisharebest\Webtrees\I18N;
         <div class="card-title">
             <button type="button" class="btn btn-secondary wt-osk-shift-button" data-bs-toggle="button" aria-pressed="false">a &harr; A</button>
 
-            <div class="btn-group" role="group" data-bs-toggle="buttons">
-                <div class="btn btn-secondary active" dir="ltr">
-                    <label class="m-0">
-                        <input type="radio" class="wt-osk-script-button" checked data-script="latn" name="osk-script">
+            <div class="btn-group" role="group">
+                <input id="wt-osk-bg-script-ltn" type="radio" class="btn-check wt-osk-script-button" checked data-script="latn" name="osk-script">
+                <label for="wt-osk-bg-script-ltn" class="btn btn-secondary m-0" dir="ltr">
                         Abcd
-                    </label>
-                </div>
-                <div class="btn btn-secondary" dir="ltr">
-                    <label class="m-0">
-                        <input type="radio" class="wt-osk-script-button" data-script="cyrl" name="osk-script">
+                </label>
+
+                <input id="wt-osk-bg-script-cyrl" type="radio" class="btn-check wt-osk-script-button" data-script="cyrl" name="osk-script">
+                <label for="wt-osk-bg-script-cyrl" class="btn btn-secondary m-0" dir="ltr">
                         &Acy;&bcy;&gcy;&dcy;
-                    </label>
-                </div>
-                <div class="btn btn-secondary" dir="ltr">
-                    <label class="m-0">
-                        <input type="radio" class="wt-osk-script-button" data-script="grek" name="osk-script">
+                </label>
+
+                <input id="wt-osk-bg-script-grek" type="radio" class="btn-check wt-osk-script-button" data-script="grek" name="osk-script">
+                <label for="wt-osk-bg-script-grek" class="btn btn-secondary m-0" dir="ltr">
                         &Alpha;&beta;&gamma;&delta;
-                    </label>
-                </div>
-                <div class="btn btn-secondary" dir="ltr">
-                    <label class="m-0">
-                        <input type="radio" class="wt-osk-script-button" data-script="viet" name="osk-script">
+                </label>
+
+                <input id="wt-osk-bg-script-viet" type="radio" class="btn-check wt-osk-script-button" data-script="viet" name="osk-script">
+                <label for="wt-osk-bg-script-viet" class="btn btn-secondary m-0" dir="ltr">
                         Ặềổự
-                    </label>
-                </div>
-                <div class="btn btn-secondary" dir="rtl">
-                    <label class="m-0">
-                        <input type="radio" class="wt-osk-script-button" data-script="arab" name="osk-script">
+                </label>
+
+                <input id="wt-osk-bg-script-arab" type="radio" class="btn-check wt-osk-script-button" data-script="arab" name="osk-script">
+                <label for="wt-osk-bg-script-arab" class="btn btn-secondary m-0" dir="rtl">
                         &#x627;&#x628;&#x629;&#x62a;
-                    </label>
-                </div>
-                <div class="btn btn-secondary" dir="rtl">
-                    <label class="m-0">
-                        <input type="radio" class="wt-osk-script-button" data-script="hebr" name="osk-script">
+                </label>
+
+                <input id="wt-osk-bg-script-hebr" type="radio" class="btn-check wt-osk-script-button" data-script="hebr" name="osk-script">
+                <label for="wt-osk-bg-script-hebr" class="btn btn-secondary m-0" dir="rtl">
                         &#x5d0;&#x5d1;&#x5d2;&#x5d3;
-                    </label>
-                </div>
+                </label>
             </div>
 
             <button type="button" class="btn btn-secondary wt-osk-pin-button" data-bs-toggle="button" aria-pressed="false" aria-label="<?= I18N::translate('Keep open') ?>"><?= view('icons/pin') ?></button>


### PR DESCRIPTION
There has been some changed in BS5 regarding the structure and classes used in toggle buttons groups.

This results in an incorrect display of the buttons in lists

![image](https://user-images.githubusercontent.com/5150782/130279660-a734ec3c-3a78-4e1e-abe0-6a19822ce569.png)

The PR adds the appropriate `btn-check` class, and align the structure of button groups as per the the new recommendation in the BS5 documentation (`input` & `label` at the same level vs `input` nested within `label`)
