### PR TITLE
Bootstrap5: migration `form-select` and `card-deck`

### DIFF
--- a/resources/views/components/select-family.phtml
+++ b/resources/views/components/select-family.phtml
@@ -19,7 +19,7 @@ $at = $at ?? '';
 
 <select
     autocomplete="off"
-    class="form-control select2 <?= $class ?? '' ?>"
+    class="form-select select2 <?= $class ?? '' ?>"
     data-ajax--delay="<?= e(Select2Family::AJAX_DELAY) ?>"
     data-minimum-input-length="<?= e(Select2Family::MINIMUM_INPUT_LENGTH) ?>"
     data-ajax--type="POST"

--- a/resources/views/components/select-individual.phtml
+++ b/resources/views/components/select-individual.phtml
@@ -19,7 +19,7 @@ $at = $at ?? '';
 
 <select
     autocomplete="off"
-    class="form-control select2 <?= $class ?? '' ?>"
+    class="form-select select2 <?= $class ?? '' ?>"
     data-ajax--delay="<?= e(Select2Individual::AJAX_DELAY) ?>"
     data-minimum-input-length="<?= e(Select2Individual::MINIMUM_INPUT_LENGTH) ?>"
     data-ajax--type="POST"

--- a/resources/views/components/select-location.phtml
+++ b/resources/views/components/select-location.phtml
@@ -19,7 +19,7 @@ $at = $at ?? '';
 
 <select
         autocomplete="off"
-        class="form-control select2 <?= $class ?? '' ?>"
+        class="form-select select2 <?= $class ?? '' ?>"
         data-ajax--delay="<?= e(Select2Location::AJAX_DELAY) ?>"
         data-minimum-input-length="<?= e(Select2Location::MINIMUM_INPUT_LENGTH) ?>"
         data-ajax--type="POST"

--- a/resources/views/components/select-media.phtml
+++ b/resources/views/components/select-media.phtml
@@ -19,7 +19,7 @@ $at = $at ?? '';
 
 <select
     autocomplete="off"
-    class="form-control select2 <?= $class ?? '' ?>"
+    class="form-select select2 <?= $class ?? '' ?>"
     data-ajax--delay="<?= e(Select2MediaObject::AJAX_DELAY) ?>"
     data-minimum-input-length="<?= e(Select2MediaObject::MINIMUM_INPUT_LENGTH) ?>"
     data-ajax--type="POST"

--- a/resources/views/components/select-note.phtml
+++ b/resources/views/components/select-note.phtml
@@ -19,7 +19,7 @@ $at = $at ?? '';
 
 <select
     autocomplete="off"
-    class="form-control select2 <?= $class ?? '' ?>"
+    class="form-select select2 <?= $class ?? '' ?>"
     data-ajax--delay="<?= e(Select2Note::AJAX_DELAY) ?>"
     data-minimum-input-length="<?= e(Select2Note::MINIMUM_INPUT_LENGTH) ?>"
     data-ajax--type="POST"

--- a/resources/views/components/select-number.phtml
+++ b/resources/views/components/select-number.phtml
@@ -13,7 +13,7 @@ use Fisharebest\Webtrees\I18N;
 ?>
 
 <select
-    class="form-control <?= $class ?? '' ?>"
+    class="form-select <?= $class ?? '' ?>"
     name="<?= e($name) ?>"
     id="<?= e($id ?? $name) ?>"
 >

--- a/resources/views/components/select-place.phtml
+++ b/resources/views/components/select-place.phtml
@@ -16,7 +16,7 @@ use Fisharebest\Webtrees\Tree;
 
 <select
     autocomplete="off"
-    class="form-control select2 <?= $class ?? '' ?>"
+    class="form-select select2 <?= $class ?? '' ?>"
     data-ajax--delay="<?= e(Select2Place::AJAX_DELAY) ?>"
     data-minimum-input-length="<?= e(Select2Place::MINIMUM_INPUT_LENGTH) ?>"
     data-ajax--type="POST"

--- a/resources/views/components/select-repository.phtml
+++ b/resources/views/components/select-repository.phtml
@@ -19,7 +19,7 @@ $at = $at ?? '';
 
 <select
     autocomplete="off"
-    class="form-control select2 <?= $class ?? '' ?>"
+    class="form-select select2 <?= $class ?? '' ?>"
     data-ajax--delay="<?= e(Select2Repository::AJAX_DELAY) ?>"
     data-minimum-input-length="<?= e(Select2Repository::MINIMUM_INPUT_LENGTH) ?>"
     data-ajax--type="POST"

--- a/resources/views/components/select-source.phtml
+++ b/resources/views/components/select-source.phtml
@@ -19,7 +19,7 @@ $at = $at ?? '';
 
 <select
     autocomplete="off"
-    class="form-control select2 <?= $class ?? '' ?>"
+    class="form-select select2 <?= $class ?? '' ?>"
     data-ajax--delay="<?= e(Select2Source::AJAX_DELAY) ?>"
     data-minimum-input-length="<?= e(Select2Source::MINIMUM_INPUT_LENGTH) ?>"
     data-ajax--type="POST"

--- a/resources/views/components/select-submission.phtml
+++ b/resources/views/components/select-submission.phtml
@@ -19,7 +19,7 @@ $at = $at ?? '';
 
 <select
     autocomplete="off"
-    class="form-control select2 <?= $class ?? '' ?>"
+    class="form-select select2 <?= $class ?? '' ?>"
     data-ajax--delay="<?= e(Select2Submission::AJAX_DELAY) ?>"
     data-minimum-input-length="<?= e(Select2Submission::MINIMUM_INPUT_LENGTH) ?>"
     data-ajax--type="POST"

--- a/resources/views/components/select-submitter.phtml
+++ b/resources/views/components/select-submitter.phtml
@@ -19,7 +19,7 @@ $at = $at ?? '';
 
 <select
     autocomplete="off"
-    class="form-control select2 <?= $class ?? '' ?>"
+    class="form-select select2 <?= $class ?? '' ?>"
     data-ajax--delay="<?= e(Select2Submitter::AJAX_DELAY) ?>"
     data-minimum-input-length="<?= e(Select2Submitter::MINIMUM_INPUT_LENGTH) ?>"
     data-ajax--type="POST"

--- a/resources/views/components/select.phtml
+++ b/resources/views/components/select.phtml
@@ -12,7 +12,7 @@
 ?>
 
 <select
-    class="form-control <?= $class ?? '' ?>"
+    class="form-select <?= $class ?? '' ?>"
     name="<?= e($name) ?>"
     id="<?= e($id ?? $name) ?>"
     <?= is_array($selected) ? 'multiple' : '' ?>

--- a/resources/views/edit-blocks-page.phtml
+++ b/resources/views/edit-blocks-page.phtml
@@ -25,19 +25,23 @@ use Illuminate\Support\Collection;
 
 <form method="post" action="<?= e($url_save) ?>" id="edit-blocks">
     <?= csrf_field() ?>
-    <div class="card-deck" id="current-blocks">
-        <div class="card">
-            <div class="card-body" id="main-blocks">
-                <?php foreach ($main_blocks as $block_id => $block) : ?>
-                    <?= view('edit-blocks-block', ['block_id' => $block_id, 'block' => $block]) ?>
-                <?php endforeach ?>
+    <div class="row row-cols-1 row-cols-sm-2 g-3" id="current-blocks">
+        <div class="col">
+            <div class="card h-100">
+                <div class="card-body" id="main-blocks">
+                    <?php foreach ($main_blocks as $block_id => $block) : ?>
+                        <?= view('edit-blocks-block', ['block_id' => $block_id, 'block' => $block]) ?>
+                    <?php endforeach ?>
+                </div>
             </div>
         </div>
-        <div class="card">
-            <div class="card-body" id="side-blocks">
-                <?php foreach ($side_blocks as $block_id => $block) : ?>
-                    <?= view('edit-blocks-block', ['block_id' => $block_id, 'block' => $block]) ?>
-                <?php endforeach ?>
+        <div class="col">
+            <div class="card h-100">
+                <div class="card-body" id="side-blocks">
+                    <?php foreach ($side_blocks as $block_id => $block) : ?>
+                        <?= view('edit-blocks-block', ['block_id' => $block_id, 'block' => $block]) ?>
+                    <?php endforeach ?>
+                </div>
             </div>
         </div>
     </div>

--- a/resources/views/lists/families-table.phtml
+++ b/resources/views/lists/families-table.phtml
@@ -431,106 +431,94 @@ $marriageAgeData = [
 </div>
 
 <div id="family-charts-<?= e($table_id) ?>" style="display: none;">
-    <div class="mb-3">
-        <div class="card-deck">
-            <div class="col-lg-12 col-md-12 mb-3">
-                <div class="card m-0">
-                    <div class="card-header">
-                        <?= I18N::translate('Decade of birth') ?>
-                    </div><div class="card-body">
-                        <?php
-                        foreach ($birt_by_decade as $century => $values) {
-                            if (($values['M'] + $values['F']) > 0) {
-                                $birthData[] = [
-                                    [
-                                        'v' => 'Date(' . $century . ', 0, 1)',
-                                        'f' => $century,
-                                    ],
-                                    $values['M'],
-                                    $values['F'],
-                                ];
-                            }
-                        }
-                        ?>
-                        <?= view('lists/chart-by-decade', ['data' => $birthData, 'title' => I18N::translate('Decade of birth')]) ?>
-                    </div>
-                </div>
+    <div class="d-grid gap-3 my-3">
+        <div class="card">
+            <div class="card-header">
+                <?= I18N::translate('Decade of birth') ?>
+            </div><div class="card-body">
+                <?php
+                foreach ($birt_by_decade as $century => $values) {
+                    if (($values['M'] + $values['F']) > 0) {
+                        $birthData[] = [
+                            [
+                                'v' => 'Date(' . $century . ', 0, 1)',
+                                'f' => $century,
+                            ],
+                            $values['M'],
+                            $values['F'],
+                        ];
+                    }
+                }
+                ?>
+                <?= view('lists/chart-by-decade', ['data' => $birthData, 'title' => I18N::translate('Decade of birth')]) ?>
             </div>
         </div>
-        <div class="card-deck">
-            <div class="col-lg-12 col-md-12 mb-3">
-                <div class="card m-0">
-                    <div class="card-header">
-                        <?= I18N::translate('Decade of marriage') ?>
-                    </div><div class="card-body">
-                        <?php
-                        foreach ($marr_by_decade as $century => $values) {
-                            if (($values['M'] + $values['F']) > 0) {
-                                $marriageData[] = [
-                                    [
-                                        'v' => 'Date(' . $century . ', 0, 1)',
-                                        'f' => $century,
-                                    ],
-                                    $values['M'],
-                                    $values['F'],
-                                ];
-                            }
-                        }
-                        ?>
-                        <?= view('lists/chart-by-decade', ['data' => $marriageData, 'title' => I18N::translate('Decade of marriage')]) ?>
-                    </div>
-                </div>
+        <div class="card">
+            <div class="card-header">
+                <?= I18N::translate('Decade of marriage') ?>
+            </div><div class="card-body">
+                <?php
+                foreach ($marr_by_decade as $century => $values) {
+                    if (($values['M'] + $values['F']) > 0) {
+                        $marriageData[] = [
+                            [
+                                'v' => 'Date(' . $century . ', 0, 1)',
+                                'f' => $century,
+                            ],
+                            $values['M'],
+                            $values['F'],
+                        ];
+                    }
+                }
+                ?>
+                <?= view('lists/chart-by-decade', ['data' => $marriageData, 'title' => I18N::translate('Decade of marriage')]) ?>
             </div>
         </div>
-        <div class="card-deck">
-            <div class="col-lg-12 col-md-12 mb-3">
-                <div class="card m-0">
-                    <div class="card-header">
-                        <?= I18N::translate('Age in year of marriage') ?>
-                    </div>
-                    <div class="card-body">
-                        <?php
-                            $totalAge = 0;
-                            $totalSum = 0;
-                            $max      = 0;
+        <div class="card">
+            <div class="card-header">
+                <?= I18N::translate('Age in year of marriage') ?>
+            </div>
+            <div class="card-body">
+                <?php
+                    $totalAge = 0;
+                    $totalSum = 0;
+                    $max      = 0;
 
-                        foreach ($marr_by_age as $age => $values) {
-                            if (($values['M'] + $values['F']) > 0) {
-                                if (($values['M'] + $values['F']) > $max) {
-                                    $max = $values['M'] + $values['F'];
-                                }
-
-                                $totalAge += $age * ($values['M'] + $values['F']);
-                                $totalSum += $values['M'] + $values['F'];
-
-                                $marriageAgeData[] = [
-                                    $age,
-                                    $values['M'],
-                                    $values['F'],
-                                    null,
-                                ];
-                            }
+                foreach ($marr_by_age as $age => $values) {
+                    if (($values['M'] + $values['F']) > 0) {
+                        if (($values['M'] + $values['F']) > $max) {
+                            $max = $values['M'] + $values['F'];
                         }
 
-                        if ($totalSum > 0) {
-                            $marriageAgeData[] = [
-                                round($totalAge / $totalSum, 1),
-                                null,
-                                null,
-                                0,
-                            ];
+                        $totalAge += $age * ($values['M'] + $values['F']);
+                        $totalSum += $values['M'] + $values['F'];
 
-                            $marriageAgeData[] = [
-                                round($totalAge / $totalSum, 1),
-                                null,
-                                null,
-                                $max,
-                            ];
-                        }
-                        ?>
-                        <?= view('lists/chart-by-age', ['data' => $marriageAgeData, 'title' => I18N::translate('Age in year of marriage')]) ?>
-                    </div>
-                </div>
+                        $marriageAgeData[] = [
+                            $age,
+                            $values['M'],
+                            $values['F'],
+                            null,
+                        ];
+                    }
+                }
+
+                if ($totalSum > 0) {
+                    $marriageAgeData[] = [
+                        round($totalAge / $totalSum, 1),
+                        null,
+                        null,
+                        0,
+                    ];
+
+                    $marriageAgeData[] = [
+                        round($totalAge / $totalSum, 1),
+                        null,
+                        null,
+                        $max,
+                    ];
+                }
+                ?>
+                <?= view('lists/chart-by-age', ['data' => $marriageAgeData, 'title' => I18N::translate('Age in year of marriage')]) ?>
             </div>
         </div>
     </div>

--- a/resources/views/lists/individuals-table.phtml
+++ b/resources/views/lists/individuals-table.phtml
@@ -438,108 +438,96 @@ $deathAgeData = [
 </div>
 
 <div id="individual-charts-<?= e($table_id) ?>" style="display: none;">
-    <div class="mb-3">
-        <div class="card-deck">
-            <div class="col-lg-12 col-md-12 mb-3">
-                <div class="card m-0">
-                    <div class="card-header">
-                        <?= I18N::translate('Decade of birth') ?>
-                    </div>
-                    <div class="card-body">
-                        <?php
-                        foreach ($birt_by_decade as $century => $values) {
-                            if (($values['M'] + $values['F']) > 0) {
-                                $birthData[] = [
-                                    [
-                                        'v' => 'Date(' . $century . ', 0, 1)',
-                                        'f' => $century,
-                                    ],
-                                    $values['M'],
-                                    $values['F'],
-                                ];
-                            }
-                        }
-                        ?>
-                        <?= view('lists/chart-by-decade', ['data' => $birthData, 'title' => I18N::translate('Decade of birth')]) ?>
-                    </div>
-                </div>
+    <div class="d-grid gap-3 my-3">
+        <div class="card">
+            <div class="card-header">
+                <?= I18N::translate('Decade of birth') ?>
+            </div>
+            <div class="card-body">
+                <?php
+                foreach ($birt_by_decade as $century => $values) {
+                    if (($values['M'] + $values['F']) > 0) {
+                        $birthData[] = [
+                            [
+                                'v' => 'Date(' . $century . ', 0, 1)',
+                                'f' => $century,
+                            ],
+                            $values['M'],
+                            $values['F'],
+                        ];
+                    }
+                }
+                ?>
+                <?= view('lists/chart-by-decade', ['data' => $birthData, 'title' => I18N::translate('Decade of birth')]) ?>
             </div>
         </div>
-        <div class="card-deck">
-            <div class="col-lg-12 col-md-12 mb-3">
-                <div class="card m-0">
-                    <div class="card-header">
-                        <?= I18N::translate('Decade of death') ?>
-                    </div>
-                    <div class="card-body">
-                        <?php
-                        foreach ($deat_by_decade as $century => $values) {
-                            if (($values['M'] + $values['F']) > 0) {
-                                $deathData[] = [
-                                    [
-                                        'v' => 'Date(' . $century . ', 0, 1)',
-                                        'f' => $century,
-                                    ],
-                                    $values['M'],
-                                    $values['F'],
-                                ];
-                            }
-                        }
-                        ?>
-                        <?= view('lists/chart-by-decade', ['data' => $deathData, 'title' => I18N::translate('Decade of death')]) ?>
-                    </div>
-                </div>
+        <div class="card">
+            <div class="card-header">
+                <?= I18N::translate('Decade of death') ?>
+            </div>
+            <div class="card-body">
+                <?php
+                foreach ($deat_by_decade as $century => $values) {
+                    if (($values['M'] + $values['F']) > 0) {
+                        $deathData[] = [
+                            [
+                                'v' => 'Date(' . $century . ', 0, 1)',
+                                'f' => $century,
+                            ],
+                            $values['M'],
+                            $values['F'],
+                        ];
+                    }
+                }
+                ?>
+                <?= view('lists/chart-by-decade', ['data' => $deathData, 'title' => I18N::translate('Decade of death')]) ?>
             </div>
         </div>
-        <div class="card-deck">
-            <div class="col-lg-12 col-md-12 mb-3">
-                <div class="card m-0">
-                    <div class="card-header">
-                        <?= I18N::translate('Age related to death year') ?>
-                    </div>
-                    <div class="card-body">
-                        <?php
-                            $totalAge = 0;
-                            $totalSum = 0;
-                            $max      = 0;
+        <div class="card">
+            <div class="card-header">
+                <?= I18N::translate('Age related to death year') ?>
+            </div>
+            <div class="card-body">
+                <?php
+                    $totalAge = 0;
+                    $totalSum = 0;
+                    $max      = 0;
 
-                        foreach ($deat_by_age as $age => $values) {
-                            if (($values['M'] + $values['F']) > 0) {
-                                if (($values['M'] + $values['F']) > $max) {
-                                    $max = $values['M'] + $values['F'];
-                                }
-
-                                $totalAge += $age * ($values['M'] + $values['F']);
-                                $totalSum += $values['M'] + $values['F'];
-
-                                $deathAgeData[] = [
-                                    $age,
-                                    $values['M'],
-                                    $values['F'],
-                                    null,
-                                ];
-                            }
+                foreach ($deat_by_age as $age => $values) {
+                    if (($values['M'] + $values['F']) > 0) {
+                        if (($values['M'] + $values['F']) > $max) {
+                            $max = $values['M'] + $values['F'];
                         }
 
-                        if ($totalSum > 0) {
-                            $deathAgeData[] = [
-                                round($totalAge / $totalSum, 1),
-                                null,
-                                null,
-                                0,
-                            ];
+                        $totalAge += $age * ($values['M'] + $values['F']);
+                        $totalSum += $values['M'] + $values['F'];
 
-                            $deathAgeData[] = [
-                                round($totalAge / $totalSum, 1),
-                                null,
-                                null,
-                                $max,
-                            ];
-                        }
-                        ?>
-                        <?= view('lists/chart-by-age', ['data' => $deathAgeData, 'title' => I18N::translate('Age related to death year')]) ?>
-                    </div>
-                </div>
+                        $deathAgeData[] = [
+                            $age,
+                            $values['M'],
+                            $values['F'],
+                            null,
+                        ];
+                    }
+                }
+
+                if ($totalSum > 0) {
+                    $deathAgeData[] = [
+                        round($totalAge / $totalSum, 1),
+                        null,
+                        null,
+                        0,
+                    ];
+
+                    $deathAgeData[] = [
+                        round($totalAge / $totalSum, 1),
+                        null,
+                        null,
+                        $max,
+                    ];
+                }
+                ?>
+                <?= view('lists/chart-by-age', ['data' => $deathAgeData, 'title' => I18N::translate('Age related to death year')]) ?>
             </div>
         </div>
     </div>

--- a/resources/views/modules/media-list/page.phtml
+++ b/resources/views/modules/media-list/page.phtml
@@ -97,10 +97,10 @@ use League\Flysystem\FilesystemOperator;
 
         <?= view('modules/media-list/pagination', ['module' => $module, 'page' => $page, 'pages' => $pages, 'folder' => $folder, 'subdirs' => $subdirs, 'filter' => $filter, 'format' => $format, 'max' => $max, 'tree' => $tree]) ?>
 
-        <div class="card-deck row mb-4 mt-4">
+        <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-4">
             <?php foreach ($media_objects as $n => $media_object) : ?>
-                <div class="col-12 col-sm-6 col-lg-4 d-flex">
-                    <div class="card mb-4">
+                <div class="col">
+                    <div class="card h-100">
                         <div class="card-header">
                             <h4 class="card-title">
                                 <a href="<?= e($media_object->url()) ?>"><?= $media_object->fullName() ?></a>

--- a/resources/views/statistics/families/age-difference.phtml
+++ b/resources/views/statistics/families/age-difference.phtml
@@ -12,46 +12,42 @@ use Fisharebest\Webtrees\Statistics;
     <?= I18N::translate('Age difference') ?>
 </h4>
 
-<div class="mb-3">
-    <div class="card-deck">
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header">
-                    <?= I18N::translate('Age between siblings') ?>
-                </h5>
-                <?= $stats->topAgeBetweenSiblingsList() ?>
-            </div>
+<div class="row row-cols-1 row-cols-md-2 g-3 mb-3">
+    <div class="col">
+        <div class="card">
+            <h5 class="card-header">
+                <?= I18N::translate('Age between siblings') ?>
+            </h5>
+            <?= $stats->topAgeBetweenSiblingsList() ?>
         </div>
+    </div>
 
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header">
-                    <?= I18N::translate('Greatest age between siblings') ?>
-                </h5>
-                <div class="card-body">
-                    <?= $stats->topAgeBetweenSiblingsFullName() ?>
-                </div>
+    <div class="col">
+        <div class="card">
+            <h5 class="card-header">
+                <?= I18N::translate('Greatest age between siblings') ?>
+            </h5>
+            <div class="card-body">
+                <?= $stats->topAgeBetweenSiblingsFullName() ?>
             </div>
         </div>
     </div>
 
-    <div class="card-deck">
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header">
-                    <?= I18N::translate('Age between husband and wife') ?>
-                </h5>
-                <?= $stats->ageBetweenSpousesMFList() ?>
-            </div>
+    <div class="col">
+        <div class="card">
+            <h5 class="card-header">
+                <?= I18N::translate('Age between husband and wife') ?>
+            </h5>
+            <?= $stats->ageBetweenSpousesMFList() ?>
         </div>
+    </div>
 
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header">
-                    <?= I18N::translate('Age between wife and husband') ?>
-                </h5>
-                <?= $stats->ageBetweenSpousesFMList() ?>
-            </div>
+    <div class="col">
+        <div class="card">
+            <h5 class="card-header">
+                <?= I18N::translate('Age between wife and husband') ?>
+            </h5>
+            <?= $stats->ageBetweenSpousesFMList() ?>
         </div>
     </div>
 </div>

--- a/resources/views/statistics/families/birth-age.phtml
+++ b/resources/views/statistics/families/birth-age.phtml
@@ -12,87 +12,83 @@ use Fisharebest\Webtrees\Statistics;
     <?= I18N::translate('Age at birth of child') ?>
 </h4>
 
-<div class="mb-3">
-    <div class="card-deck">
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <?php $age    = $stats->youngestFatherAge('1') ?>
-                <?php $result = $stats->youngestFather() ?>
-                <h5 class="card-header">
-                    <?= I18N::translate('Youngest father') ?>
-                    <?php if ($age) :
-                        ?><?= ' - ', $age ?><?php
-                    endif; ?>
-                </h5>
-                <div class="card-body">
-                    <?php if ($result) : ?>
-                        <?= $result ?>
-                    <?php else : ?>
-                        <?= I18N::translate('This information is not available.') ?>
-                    <?php endif; ?>
-                </div>
-            </div>
-        </div>
-
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <?php $age    = $stats->youngestMotherAge('1') ?>
-                <?php $result = $stats->youngestMother() ?>
-                <h5 class="card-header">
-                    <?= I18N::translate('Youngest mother') ?>
-                    <?php if ($age) :
-                        ?><?= ' - ', $age ?><?php
-                    endif; ?>
-                </h5>
-                <div class="card-body">
-                    <?php if ($result) : ?>
-                        <?= $result ?>
-                    <?php else : ?>
-                        <?= I18N::translate('This information is not available.') ?>
-                    <?php endif; ?>
-                </div>
+<div class="row row-cols-1 row-cols-md-2 g-3 mb-3">
+    <div class="col">
+        <div class="card">
+            <?php $age    = $stats->youngestFatherAge('1') ?>
+            <?php $result = $stats->youngestFather() ?>
+            <h5 class="card-header">
+                <?= I18N::translate('Youngest father') ?>
+                <?php if ($age) :
+                    ?><?= ' - ', $age ?><?php
+                endif; ?>
+            </h5>
+            <div class="card-body">
+                <?php if ($result) : ?>
+                    <?= $result ?>
+                <?php else : ?>
+                    <?= I18N::translate('This information is not available.') ?>
+                <?php endif; ?>
             </div>
         </div>
     </div>
 
-    <div class="card-deck">
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <?php $age    = $stats->oldestFatherAge('1') ?>
-                <?php $result = $stats->oldestFather() ?>
-                <h5 class="card-header">
-                    <?= I18N::translate('Oldest father') ?>
-                    <?php if ($age) :
-                        ?><?= ' - ', $age ?><?php
-                    endif; ?>
-                </h5>
-                <div class="card-body">
-                    <?php if ($result) : ?>
-                        <?= $result ?>
-                    <?php else : ?>
-                        <?= I18N::translate('This information is not available.') ?>
-                    <?php endif; ?>
-                </div>
+    <div class="col">
+        <div class="card">
+            <?php $age    = $stats->youngestMotherAge('1') ?>
+            <?php $result = $stats->youngestMother() ?>
+            <h5 class="card-header">
+                <?= I18N::translate('Youngest mother') ?>
+                <?php if ($age) :
+                    ?><?= ' - ', $age ?><?php
+                endif; ?>
+            </h5>
+            <div class="card-body">
+                <?php if ($result) : ?>
+                    <?= $result ?>
+                <?php else : ?>
+                    <?= I18N::translate('This information is not available.') ?>
+                <?php endif; ?>
             </div>
         </div>
+    </div>
 
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <?php $age    = $stats->oldestMotherAge('1') ?>
-                <?php $result = $stats->oldestMother() ?>
-                <h5 class="card-header">
-                    <?= I18N::translate('Oldest mother') ?>
-                    <?php if ($age) :
-                        ?><?= ' - ', $age ?><?php
-                    endif; ?>
-                </h5>
-                <div class="card-body">
-                    <?php if ($result) : ?>
-                        <?= $result ?>
-                    <?php else : ?>
-                        <?= I18N::translate('This information is not available.') ?>
-                    <?php endif; ?>
-                </div>
+    <div class="col">
+        <div class="card">
+            <?php $age    = $stats->oldestFatherAge('1') ?>
+            <?php $result = $stats->oldestFather() ?>
+            <h5 class="card-header">
+                <?= I18N::translate('Oldest father') ?>
+                <?php if ($age) :
+                    ?><?= ' - ', $age ?><?php
+                endif; ?>
+            </h5>
+            <div class="card-body">
+                <?php if ($result) : ?>
+                    <?= $result ?>
+                <?php else : ?>
+                    <?= I18N::translate('This information is not available.') ?>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+
+    <div class="col">
+        <div class="card">
+            <?php $age    = $stats->oldestMotherAge('1') ?>
+            <?php $result = $stats->oldestMother() ?>
+            <h5 class="card-header">
+                <?= I18N::translate('Oldest mother') ?>
+                <?php if ($age) :
+                    ?><?= ' - ', $age ?><?php
+                endif; ?>
+            </h5>
+            <div class="card-body">
+                <?php if ($result) : ?>
+                    <?= $result ?>
+                <?php else : ?>
+                    <?= I18N::translate('This information is not available.') ?>
+                <?php endif; ?>
             </div>
         </div>
     </div>

--- a/resources/views/statistics/families/children.phtml
+++ b/resources/views/statistics/families/children.phtml
@@ -12,50 +12,46 @@ use Fisharebest\Webtrees\Statistics;
     <?= I18N::translate('Children in family') ?>
 </h4>
 
-<div class="mb-3">
-    <div class="card-deck">
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header">
-                    <?= I18N::translate('Average number of children per family') ?>
-                    <span class="badge bg-secondary rounded-pill float-end"><?= $stats->averageChildren() ?></span>
-                </h5>
-                <div class="card-body">
-                    <?= $stats->statsChildren() ?>
-                </div>
-            </div>
-        </div>
-
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header">
-                    <?= I18N::translate('Number of families without children') ?>
-                    <span class="badge bg-secondary rounded-pill float-end"><?= $stats->noChildrenFamilies() ?></span>
-                </h5>
-                <div class="card-body">
-                    <?= $stats->chartNoChildrenFamilies() ?>
-                </div>
+<div class="row row-cols-1 row-cols-md-2 g-3 mb-3">
+    <div class="col">
+        <div class="card">
+            <h5 class="card-header">
+                <?= I18N::translate('Average number of children per family') ?>
+                <span class="badge bg-secondary rounded-pill float-end"><?= $stats->averageChildren() ?></span>
+            </h5>
+            <div class="card-body">
+                <?= $stats->statsChildren() ?>
             </div>
         </div>
     </div>
 
-    <div class="card-deck">
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header">
-                    <?= I18N::translate('Largest families') ?>
-                </h5>
-                <?= $stats->topTenLargestFamilyList() ?>
+    <div class="col">
+        <div class="card">
+            <h5 class="card-header">
+                <?= I18N::translate('Number of families without children') ?>
+                <span class="badge bg-secondary rounded-pill float-end"><?= $stats->noChildrenFamilies() ?></span>
+            </h5>
+            <div class="card-body">
+                <?= $stats->chartNoChildrenFamilies() ?>
             </div>
         </div>
+    </div>
 
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header">
-                    <?= I18N::translate('Largest number of grandchildren') ?>
-                </h5>
-                <?= $stats->topTenLargestGrandFamilyList() ?>
-            </div>
+    <div class="col">
+        <div class="card">
+            <h5 class="card-header">
+                <?= I18N::translate('Largest families') ?>
+            </h5>
+            <?= $stats->topTenLargestFamilyList() ?>
+        </div>
+    </div>
+
+    <div class="col">
+        <div class="card">
+            <h5 class="card-header">
+                <?= I18N::translate('Largest number of grandchildren') ?>
+            </h5>
+            <?= $stats->topTenLargestGrandFamilyList() ?>
         </div>
     </div>
 </div>

--- a/resources/views/statistics/families/marriage-age.phtml
+++ b/resources/views/statistics/families/marriage-age.phtml
@@ -12,10 +12,10 @@ use Fisharebest\Webtrees\Statistics;
     <?= I18N::translate('Age in year of marriage') ?>
 </h4>
 
-<div class="mb-3">
-    <div class="card-deck">
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
+<div class="d-grid gap-3 mb-3">
+    <div class="row row-cols-1 row-cols-md-2 g-3">
+        <div class="col">
+            <div class="card">
                 <?php $age    = $stats->youngestMarriageMaleAge('1') ?>
                 <?php $result = $stats->youngestMarriageMale() ?>
                 <h5 class="card-header">
@@ -33,9 +33,8 @@ use Fisharebest\Webtrees\Statistics;
                 </div>
             </div>
         </div>
-
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
+        <div class="col">
+            <div class="card">
                 <?php $age    = $stats->youngestMarriageFemaleAge('1') ?>
                 <?php $result = $stats->youngestMarriageFemale() ?>
                 <h5 class="card-header">
@@ -53,11 +52,9 @@ use Fisharebest\Webtrees\Statistics;
                 </div>
             </div>
         </div>
-    </div>
-
-    <div class="card-deck">
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
+        
+        <div class="col">
+            <div class="card">
                 <?php $age    = $stats->oldestMarriageMaleAge('1') ?>
                 <?php $result = $stats->oldestMarriageMale() ?>
                 <h5 class="card-header">
@@ -75,9 +72,9 @@ use Fisharebest\Webtrees\Statistics;
                 </div>
             </div>
         </div>
-
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
+    
+        <div class="col">
+            <div class="card">
                 <?php $age    = $stats->oldestMarriageFemaleAge('1') ?>
                 <?php $result = $stats->oldestMarriageFemale() ?>
                 <h5 class="card-header">
@@ -96,14 +93,10 @@ use Fisharebest\Webtrees\Statistics;
             </div>
         </div>
     </div>
-
-    <div class="card-deck">
-        <div class="col-lg-12 col-md-12 mb-3">
-            <div class="card m-0">
-                <div class="card-body">
-                    <?= $stats->statsMarrAge() ?>
-                </div>
-            </div>
+    
+    <div class="card m-0">
+        <div class="card-body">
+            <?= $stats->statsMarrAge() ?>
         </div>
     </div>
 </div>

--- a/resources/views/statistics/families/marriage-length.phtml
+++ b/resources/views/statistics/families/marriage-length.phtml
@@ -12,45 +12,43 @@ use Fisharebest\Webtrees\Statistics;
     <?= I18N::translate('Length of marriage') ?>
 </h4>
 
-<div class="mb-3">
-    <div class="card-deck">
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <?php $age    = $stats->topAgeOfMarriage() ?>
-                <?php $result = $stats->topAgeOfMarriageFamily() ?>
-                <h5 class="card-header">
-                    <?= I18N::translate('Longest marriage') ?>
-                    <?php if ($age) :
-                        ?><?= ' - ', $age ?><?php
-                    endif; ?>
-                </h5>
-                <div class="card-body">
-                    <?php if ($result) : ?>
-                        <?= $result ?>
-                    <?php else : ?>
-                        <?= I18N::translate('This information is not available.') ?>
-                    <?php endif; ?>
-                </div>
+<div class="row row-cols-1 row-cols-md-2 g-3 mb-3">
+    <div class="col">
+        <div class="card">
+            <?php $age    = $stats->topAgeOfMarriage() ?>
+            <?php $result = $stats->topAgeOfMarriageFamily() ?>
+            <h5 class="card-header">
+                <?= I18N::translate('Longest marriage') ?>
+                <?php if ($age) :
+                    ?><?= ' - ', $age ?><?php
+                endif; ?>
+            </h5>
+            <div class="card-body">
+                <?php if ($result) : ?>
+                    <?= $result ?>
+                <?php else : ?>
+                    <?= I18N::translate('This information is not available.') ?>
+                <?php endif; ?>
             </div>
         </div>
+    </div>
 
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <?php $age    = $stats->minAgeOfMarriage() ?>
-                <?php $result = $stats->minAgeOfMarriageFamily() ?>
-                <h5 class="card-header">
-                    <?= I18N::translate('Shortest marriage') ?>
-                    <?php if ($age) :
-                        ?><?= ' - ', $age ?><?php
-                    endif; ?>
-                </h5>
-                <div class="card-body">
-                    <?php if ($result) : ?>
-                        <?= $result ?>
-                    <?php else : ?>
-                        <?= I18N::translate('This information is not available.') ?>
-                    <?php endif; ?>
-                </div>
+    <div class="col">
+        <div class="card">
+            <?php $age    = $stats->minAgeOfMarriage() ?>
+            <?php $result = $stats->minAgeOfMarriageFamily() ?>
+            <h5 class="card-header">
+                <?= I18N::translate('Shortest marriage') ?>
+                <?php if ($age) :
+                    ?><?= ' - ', $age ?><?php
+                endif; ?>
+            </h5>
+            <div class="card-body">
+                <?php if ($result) : ?>
+                    <?= $result ?>
+                <?php else : ?>
+                    <?= I18N::translate('This information is not available.') ?>
+                <?php endif; ?>
             </div>
         </div>
     </div>

--- a/resources/views/statistics/families/total-records.phtml
+++ b/resources/views/statistics/families/total-records.phtml
@@ -14,34 +14,28 @@ use Fisharebest\Webtrees\Statistics;
     <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalFamilies() ?></span>
 </h4>
 
-<div class="mb-3">
-    <div class="row">
-        <div class="col-12 col-lg-6">
-            <div class="card-deck">
-                <div class="mb-3 col-12">
-                    <div class="card m-0">
-                        <h5 class="card-header border-bottom-0">
-                            <?= I18N::translate('Total marriages') ?>
-                            <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalMarriages() ?></span>
-                        </h5>
-                    </div>
-                </div>
+<div class="row mb-3 row-cols-1 row-cols-lg-2 g-3">
+    <div class="col">
+        <div class="d-grid gap-3">
+            <div class="card">
+                <h5 class="card-header border-bottom-0">
+                    <?= I18N::translate('Total marriages') ?>
+                    <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalMarriages() ?></span>
+                </h5>
+            </div>
 
-                <div class="mb-3 col-12">
-                    <div class="card m-0">
-                        <h5 class="card-header">
-                            <?= I18N::translate('Marriages by century') ?>
-                        </h5>
-                        <div class="card-body">
-                            <?= $stats->statsMarr() ?>
-                        </div>
-                    </div>
+            <div class="card">
+                <h5 class="card-header">
+                    <?= I18N::translate('Marriages by century') ?>
+                </h5>
+                <div class="card-body">
+                    <?= $stats->statsMarr() ?>
                 </div>
             </div>
 
-            <div class="card-deck">
-                <div class="mb-3 col-lg-12 col-md-6">
-                    <div class="card m-0">
+            <div class="row row-cols-1 row-cols-md-2 row-cols-lg-1 g-3">
+                <div class="col">
+                    <div class="card">
                         <h5 class="card-header">
                             <?= I18N::translate('Earliest marriage') ?>
                         </h5>
@@ -51,8 +45,8 @@ use Fisharebest\Webtrees\Statistics;
                     </div>
                 </div>
 
-                <div class="mb-3 col-lg-12 col-md-6">
-                    <div class="card m-0">
+                <div class="col">
+                    <div class="card">
                         <h5 class="card-header">
                             <?= I18N::translate('Latest marriage') ?>
                         </h5>
@@ -63,33 +57,29 @@ use Fisharebest\Webtrees\Statistics;
                 </div>
             </div>
         </div>
+    </div>
 
-        <div class="col-12 col-lg-6">
-            <div class="card-deck">
-                <div class="mb-3 col-12">
-                    <div class="card m-0">
-                        <h5 class="card-header border-bottom-0">
-                            <?= I18N::translate('Total divorces') ?>
-                            <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalDivorces() ?></span>
-                        </h5>
-                    </div>
-                </div>
+    <div class="col">
+        <div class="d-grid gap-3">
+            <div class="card m-0">
+                <h5 class="card-header border-bottom-0">
+                    <?= I18N::translate('Total divorces') ?>
+                    <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalDivorces() ?></span>
+                </h5>
+            </div>
 
-                <div class="mb-3 col-12">
-                    <div class="card m-0">
-                        <h5 class="card-header">
-                            <?= I18N::translate('Divorces by century') ?>
-                        </h5>
-                        <div class="card-body">
-                            <?= $stats->statsDiv() ?>
-                        </div>
-                    </div>
+            <div class="card m-0">
+                <h5 class="card-header">
+                    <?= I18N::translate('Divorces by century') ?>
+                </h5>
+                <div class="card-body">
+                    <?= $stats->statsDiv() ?>
                 </div>
             </div>
 
-            <div class="card-deck">
-                <div class="mb-3 col-lg-12 col-md-6">
-                    <div class="card m-0">
+            <div class="row row-cols-1 row-cols-md-2 row-cols-lg-1 g-3">
+                <div class="col">
+                    <div class="card">
                         <h5 class="card-header">
                             <?= I18N::translate('Earliest divorce') ?>
                         </h5>
@@ -98,9 +88,9 @@ use Fisharebest\Webtrees\Statistics;
                         </div>
                     </div>
                 </div>
-
-                <div class="mb-3 col-lg-12 col-md-6">
-                    <div class="card m-0">
+    
+                <div class="col">
+                    <div class="card">
                         <h5 class="card-header">
                             <?= I18N::translate('Latest divorce') ?>
                         </h5>

--- a/resources/views/statistics/individuals/greatest-age.phtml
+++ b/resources/views/statistics/individuals/greatest-age.phtml
@@ -12,24 +12,22 @@ use Fisharebest\Webtrees\Statistics;
     <?= I18N::translate('Greatest age at death') ?>
 </h4>
 
-<div class="mb-3">
-    <div class="card-deck">
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header">
-                    <?= I18N::translate('Males') ?>
-                </h5>
-                <?= $stats->topTenOldestMaleList() ?>
-            </div>
+<div class="row row-cols-1 row-cols-md-2 mb-3 g-3">
+    <div class="col">
+        <div class="card">
+            <h5 class="card-header">
+                <?= I18N::translate('Males') ?>
+            </h5>
+            <?= $stats->topTenOldestMaleList() ?>
         </div>
+    </div>
 
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header">
-                    <?= I18N::translate('Females') ?>
-                </h5>
-                <?= $stats->topTenOldestFemaleList() ?>
-            </div>
+    <div class="col">
+        <div class="card">
+            <h5 class="card-header">
+                <?= I18N::translate('Females') ?>
+            </h5>
+            <?= $stats->topTenOldestFemaleList() ?>
         </div>
     </div>
 </div>

--- a/resources/views/statistics/individuals/lifespan.phtml
+++ b/resources/views/statistics/individuals/lifespan.phtml
@@ -12,42 +12,38 @@ use Fisharebest\Webtrees\Statistics;
     <?= I18N::translate('Lifespan') ?>
 </h4>
 
-<div class="mb-3">
-    <div class="card-deck">
-        <div class="col-12 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header border-bottom-0">
-                    <?= I18N::translate('Average age at death') ?>
-                    <span class="badge bg-secondary rounded-pill float-end"><?= $stats->averageLifespan(true) ?></span>
-                </h5>
-            </div>
+<div class="row mb-3">
+    <div class="d-grid gap-3">
+        <div class="card">
+            <h5 class="card-header border-bottom-0">
+                <?= I18N::translate('Average age at death') ?>
+                <span class="badge bg-secondary rounded-pill float-end"><?= $stats->averageLifespan(true) ?></span>
+            </h5>
         </div>
-
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header border-bottom-0">
-                    <?= I18N::translate('Males') ?>
-                    <span class="badge bg-secondary rounded-pill float-end"><?= $stats->averageLifespanMale(true) ?></span>
-                </h5>
-            </div>
-        </div>
-
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header border-bottom-0">
-                    <?= I18N::translate('Females') ?>
-                    <span class="badge bg-secondary rounded-pill float-end"><?= $stats->averageLifespanFemale(true) ?></span>
-                </h5>
-            </div>
-        </div>
-    </div>
-
-    <div class="card-deck">
-        <div class="col-12 mb-3">
-            <div class="card m-0">
-                <div class="card-body">
-                    <?= $stats->statsAge() ?>
+        
+        <div class="row row-cols-1 row-cols-md-2 g-3">
+            <div class="col">
+                <div class="card">
+                    <h5 class="card-header border-bottom-0">
+                        <?= I18N::translate('Males') ?>
+                        <span class="badge bg-secondary rounded-pill float-end"><?= $stats->averageLifespanMale(true) ?></span>
+                    </h5>
                 </div>
+            </div>
+    
+            <div class="col">
+                <div class="card">
+                    <h5 class="card-header border-bottom-0">
+                        <?= I18N::translate('Females') ?>
+                        <span class="badge bg-secondary rounded-pill float-end"><?= $stats->averageLifespanFemale(true) ?></span>
+                    </h5>
+                </div>
+            </div>
+        </div>
+        
+        <div class="card m-0">
+            <div class="card-body">
+                <?= $stats->statsAge() ?>
             </div>
         </div>
     </div>

--- a/resources/views/statistics/individuals/names.phtml
+++ b/resources/views/statistics/individuals/names.phtml
@@ -12,52 +12,42 @@ use Fisharebest\Webtrees\Statistics;
     <?= I18N::translate('Names') ?>
 </h4>
 
-<div class="mb-3">
-    <div class="row">
-        <div class="col-12 col-lg-6">
-            <div class="card-deck">
-                <div class="mb-3 col-12">
-                    <div class="card m-0">
-                        <h5 class="card-header border-bottom-0">
-                            <?= I18N::translate('Total surnames') ?>
-                            <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalSurnames() ?></span>
-                        </h5>
-                    </div>
-                </div>
+<div class="row row-cols-1 row-cols-lg-2 mb-3 g-3">
+    <div class="col">
+        <div class="d-grid gap-3">
+            <div class="card">
+                <h5 class="card-header border-bottom-0">
+                    <?= I18N::translate('Total surnames') ?>
+                    <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalSurnames() ?></span>
+                </h5>
+            </div>
 
-                <div class="mb-3 col-12">
-                    <div class="card m-0">
-                        <h5 class="card-header">
-                            <?= I18N::translate('Top surnames') ?>
-                        </h5>
-                        <div class="card-body">
-                            <?= $stats->chartCommonSurnames() ?>
-                        </div>
-                    </div>
+            <div class="card">
+                <h5 class="card-header">
+                    <?= I18N::translate('Top surnames') ?>
+                </h5>
+                <div class="card-body">
+                    <?= $stats->chartCommonSurnames() ?>
                 </div>
             </div>
         </div>
+    </div>
 
-        <div class="col-12 col-lg-6">
-            <div class="card-deck">
-                <div class="mb-3 col-12">
-                    <div class="card m-0">
-                        <h5 class="card-header border-bottom-0">
-                            <?= I18N::translate('Total given names') ?>
-                            <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalGivennames() ?></span>
-                        </h5>
-                    </div>
-                </div>
+    <div class="col">
+        <div class="d-grid gap-3">
+            <div class="card">
+                <h5 class="card-header border-bottom-0">
+                    <?= I18N::translate('Total given names') ?>
+                    <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalGivennames() ?></span>
+                </h5>
+            </div>
 
-                <div class="mb-3 col-12">
-                    <div class="card m-0">
-                        <h5 class="card-header">
-                            <?= I18N::translate('Top given names') ?>
-                        </h5>
-                        <div class="card-body">
-                            <?= $stats->chartCommonGiven() ?>
-                        </div>
-                    </div>
+            <div class="card">
+                <h5 class="card-header">
+                    <?= I18N::translate('Top given names') ?>
+                </h5>
+                <div class="card-body">
+                    <?= $stats->chartCommonGiven() ?>
                 </div>
             </div>
         </div>

--- a/resources/views/statistics/individuals/oldest-living.phtml
+++ b/resources/views/statistics/individuals/oldest-living.phtml
@@ -12,24 +12,22 @@ use Fisharebest\Webtrees\Statistics;
     <?= I18N::translate('Oldest living individuals') ?>
 </h4>
 
-<div class="mb-3">
-    <div class="card-deck">
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header">
-                    <?= I18N::translate('Males') ?>
-                </h5>
-                <?= $stats->topTenOldestMaleListAlive() ?>
-            </div>
+<div class="row row-cols-1 row-cols-md-2 mb-3 g-3">
+    <div class="col">
+        <div class="card">
+            <h5 class="card-header">
+                <?= I18N::translate('Males') ?>
+            </h5>
+            <?= $stats->topTenOldestMaleListAlive() ?>
         </div>
+    </div>
 
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header">
-                    <?= I18N::translate('Females') ?>
-                </h5>
-                <?= $stats->topTenOldestFemaleListAlive() ?>
-            </div>
+    <div class="col">
+        <div class="card">
+            <h5 class="card-header">
+                <?= I18N::translate('Females') ?>
+            </h5>
+            <?= $stats->topTenOldestFemaleListAlive() ?>
         </div>
     </div>
 </div>

--- a/resources/views/statistics/individuals/total-events.phtml
+++ b/resources/views/statistics/individuals/total-events.phtml
@@ -12,34 +12,28 @@ use Fisharebest\Webtrees\Statistics;
     <?= I18N::translate('Events') ?>
 </h4>
 
-<div class="mb-3">
-    <div class="row">
-        <div class="col-12 col-lg-6">
-            <div class="card-deck">
-                <div class="mb-3 col-12">
-                    <div class="card m-0">
-                        <h5 class="card-header border-bottom-0">
-                            <?= I18N::translate('Total births') ?>
-                            <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalBirths() ?></span>
-                        </h5>
-                    </div>
-                </div>
-
-                <div class="mb-3 col-12">
-                    <div class="card m-0">
-                        <h5 class="card-header">
-                            <?= I18N::translate('Births by century') ?>
-                        </h5>
-                        <div class="card-body">
-                            <?= $stats->statsBirth() ?>
-                        </div>
-                    </div>
+<div class="row mb-3 row-cols-1 row-cols-lg-2 g-3">
+    <div class="col">
+        <div class="d-grid gap-3">
+            <div class="card">
+                <h5 class="card-header border-bottom-0">
+                    <?= I18N::translate('Total births') ?>
+                    <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalBirths() ?></span>
+                </h5>
+            </div>
+            
+            <div class="card">
+                <h5 class="card-header">
+                    <?= I18N::translate('Births by century') ?>
+                </h5>
+                <div class="card-body">
+                    <?= $stats->statsBirth() ?>
                 </div>
             </div>
-
-            <div class="card-deck">
-                <div class="mb-3 col-lg-12 col-md-6">
-                    <div class="card m-0">
+            
+            <div class="row row-cols-1 row-cols-md-2 row-cols-lg-1 g-3">
+                <div class="col">
+                    <div class="card">
                         <h5 class="card-header">
                             <?= I18N::translate('Earliest birth') ?>
                         </h5>
@@ -48,9 +42,9 @@ use Fisharebest\Webtrees\Statistics;
                         </div>
                     </div>
                 </div>
-
-                <div class="mb-3 col-lg-12 col-md-6">
-                    <div class="card m-0">
+                
+                <div class="col">
+                    <div class="card">
                         <h5 class="card-header">
                             <?= I18N::translate('Latest birth') ?>
                         </h5>
@@ -61,33 +55,29 @@ use Fisharebest\Webtrees\Statistics;
                 </div>
             </div>
         </div>
+    </div>
 
-        <div class="col-12 col-lg-6">
-            <div class="card-deck">
-                <div class="mb-3 col-12">
-                    <div class="card m-0">
-                        <h5 class="card-header border-bottom-0">
-                            <?= I18N::translate('Total deaths') ?>
-                            <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalDeaths() ?></span>
-                        </h5>
-                    </div>
-                </div>
-
-                <div class="mb-3 col-12">
-                    <div class="card m-0">
-                        <h5 class="card-header">
-                            <?= I18N::translate('Deaths by century') ?>
-                        </h5>
-                        <div class="card-body">
-                            <?= $stats->statsDeath() ?>
-                        </div>
-                    </div>
+    <div class="col">
+        <div class="d-grid gap-3">
+            <div class="card">
+                <h5 class="card-header border-bottom-0">
+                    <?= I18N::translate('Total deaths') ?>
+                    <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalDeaths() ?></span>
+                </h5>
+            </div>
+            
+            <div class="card">
+                <h5 class="card-header">
+                    <?= I18N::translate('Deaths by century') ?>
+                </h5>
+                <div class="card-body">
+                    <?= $stats->statsDeath() ?>
                 </div>
             </div>
 
-            <div class="card-deck">
-                <div class="mb-3 col-lg-12 col-md-6">
-                    <div class="card m-0">
+            <div class="row row-cols-1 row-cols-md-2 row-cols-lg-1 g-3">
+                <div class="col">
+                    <div class="card">
                         <h5 class="card-header">
                             <?= I18N::translate('Earliest death') ?>
                         </h5>
@@ -96,9 +86,9 @@ use Fisharebest\Webtrees\Statistics;
                         </div>
                     </div>
                 </div>
-
-                <div class="mb-3 col-lg-12 col-md-6">
-                    <div class="card m-0">
+    
+                <div class="col">
+                    <div class="card">
                         <h5 class="card-header">
                             <?= I18N::translate('Latest death') ?>
                         </h5>

--- a/resources/views/statistics/individuals/total-records.phtml
+++ b/resources/views/statistics/individuals/total-records.phtml
@@ -13,12 +13,12 @@ use Fisharebest\Webtrees\Statistics;
     <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalIndividuals() ?></span>
 </h4>
 
-<div class="mb-3">
-    <div class="row">
-        <div class="col-12 col-lg-6">
-            <div class="card-deck">
-                <div class="mb-3 col-12">
-                    <div class="card m-0">
+<div class="row mb-3 row-cols-1 row-cols-lg-2 g-3">
+    <div class="col">
+        <div class="d-grid gap-3">
+            <div class="row row-cols-1 row-cols-md-2 row-cols-lg-1 g-3">
+                <div class="col">
+                    <div class="card">
                         <h5 class="card-header border-bottom-0">
                             <?= I18N::translate('Total males') ?>
                             <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalSexMales() ?></span>
@@ -26,37 +26,37 @@ use Fisharebest\Webtrees\Statistics;
                     </div>
                 </div>
 
-                <div class="mb-3 col-12">
-                    <div class="card m-0">
+                <div class="col">
+                    <div class="card">
                         <h5 class="card-header border-bottom-0">
                             <?= I18N::translate('Total females') ?>
                             <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalSexFemales() ?></span>
                         </h5>
                     </div>
                 </div>
-
-                <div class="mb-3 col-12">
-                    <div class="card m-0">
-                        <div class="card-body">
-                            <?= $stats->chartSex() ?>
-                        </div>
-                    </div>
+            </div>
+            <div class="card">
+                <div class="card-body">
+                    <?= $stats->chartSex() ?>
                 </div>
             </div>
         </div>
+    </div>
 
-        <div class="col-12 col-lg-6">
-            <div class="card-deck">
-                <div class="mb-3 col-lg-12 col-md-6">
-                    <div class="card m-0">
+    <div class="col">
+        <div class="d-grid gap-3">
+            <div class="row row-cols-1 row-cols-md-2 row-cols-lg-1 g-3">
+                <div class="col">
+                    <div class="card">
                         <h5 class="card-header border-bottom-0">
                             <?= I18N::translate('Total living') ?>
                             <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalLiving() ?></span>
                         </h5>
                     </div>
                 </div>
-                <div class="mb-3 col-lg-12 col-md-6">
-                    <div class="card m-0">
+    
+                <div class="col">
+                    <div class="card">
                         <h5 class="card-header border-bottom-0">
                             <?= I18N::translate('Total dead') ?>
                             <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalDeceased() ?></span>
@@ -64,14 +64,10 @@ use Fisharebest\Webtrees\Statistics;
                     </div>
                 </div>
             </div>
-
-            <div class="card-deck">
-                <div class="mb-3 col-12">
-                    <div class="card m-0">
-                        <div class="card-body">
-                            <?= $stats->chartMortality() ?>
-                        </div>
-                    </div>
+            
+            <div class="card">
+                <div class="card-body">
+                    <?= $stats->chartMortality() ?>
                 </div>
             </div>
         </div>

--- a/resources/views/statistics/other/chart-objects.phtml
+++ b/resources/views/statistics/other/chart-objects.phtml
@@ -12,13 +12,11 @@ use Fisharebest\Webtrees\Statistics;
     <?= I18N::translate('Media objects') ?>
 </h4>
 
-<div class="mb-3">
-    <div class="card-deck">
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <div class="card-body">
-                    <?= $stats->chartMedia() ?>
-                </div>
+<div class="row row-cols-1 row-cols-lg-2 g-3 mb-3">
+    <div class="col">
+        <div class="card">
+            <div class="card-body">
+                <?= $stats->chartMedia() ?>
             </div>
         </div>
     </div>

--- a/resources/views/statistics/other/chart-sources.phtml
+++ b/resources/views/statistics/other/chart-sources.phtml
@@ -12,29 +12,27 @@ use Fisharebest\Webtrees\Statistics;
     <?= I18N::translate('Sources') ?>
 </h4>
 
-<div class="mb-3">
-    <div class="card-deck">
-        <div class="col-12 col-lg-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header">
-                    <?= I18N::translate('Individuals with sources') ?>
-                    <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalIndisWithSources() ?></span>
-                </h5>
-                <div class="card-body">
-                    <?= $stats->chartIndisWithSources() ?>
-                </div>
+<div class="row row-cols-1 row-cols-lg-2 g-3 mb-3">
+    <div class="col">
+        <div class="card">
+            <h5 class="card-header">
+                <?= I18N::translate('Individuals with sources') ?>
+                <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalIndisWithSources() ?></span>
+            </h5>
+            <div class="card-body">
+                <?= $stats->chartIndisWithSources() ?>
             </div>
         </div>
+    </div>
 
-        <div class="col-12 col-lg-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header">
-                    <?= I18N::translate('Families with sources') ?>
-                    <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalFamsWithSources() ?></span>
-                </h5>
-                <div class="card-body">
-                    <?= $stats->chartFamsWithSources() ?>
-                </div>
+    <div class="col">
+        <div class="card">
+            <h5 class="card-header">
+                <?= I18N::translate('Families with sources') ?>
+                <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalFamsWithSources() ?></span>
+            </h5>
+            <div class="card-body">
+                <?= $stats->chartFamsWithSources() ?>
             </div>
         </div>
     </div>

--- a/resources/views/statistics/other/charts/custom.phtml
+++ b/resources/views/statistics/other/charts/custom.phtml
@@ -16,17 +16,13 @@ use Fisharebest\Webtrees\I18N;
 <?php if (count($data) === 1) : ?>
     <?= I18N::translate('This information is not available.') ?>
 <?php else : ?>
-    <div class="mb-3">
-        <div class="card-deck">
-            <div class="col-12 mb-3">
-                <div class="card m-0">
-                    <div class="card-header">
-                        <?= $chart_title ?>
-                    </div>
-                    <div class="card-body">
-                        <?= view('statistics/other/charts/column', [ 'data' => $data, 'chart_options' => $chart_options, 'chart_title' => '', 'language' => $language]) ?>
-                    </div>
-                </div>
+    <div class="d-grid mb-3">
+        <div class="card">
+            <div class="card-header">
+                <?= $chart_title ?>
+            </div>
+            <div class="card-body">
+                <?= view('statistics/other/charts/column', [ 'data' => $data, 'chart_options' => $chart_options, 'chart_title' => '', 'language' => $language]) ?>
             </div>
         </div>
     </div>

--- a/resources/views/statistics/other/charts/geo.phtml
+++ b/resources/views/statistics/other/charts/geo.phtml
@@ -20,17 +20,13 @@ $name = 'callback_' . bin2hex(random_bytes(12));
 <?php if (count($data) === 1) : ?>
     <?= I18N::translate('This information is not available.') ?>
 <?php else : ?>
-    <div class="mb-3">
-        <div class="card-deck">
-            <div class="col-12 mb-3">
-                <div class="card m-0">
-                    <div class="card-header">
-                        <?= $chart_title ?>
-                    </div>
-                    <div class="card-body">
-                        <div id="<?= $id ?>" title="<?= $chart_title ?>"></div>
-                    </div>
-                </div>
+    <div class="d-grid mb-3">
+        <div class="card">
+            <div class="card-header">
+                <?= $chart_title ?>
+            </div>
+            <div class="card-body">
+                <div id="<?= $id ?>" title="<?= $chart_title ?>"></div>
             </div>
         </div>
     </div>

--- a/resources/views/statistics/other/places.phtml
+++ b/resources/views/statistics/other/places.phtml
@@ -13,49 +13,47 @@ use Fisharebest\Webtrees\Statistics;
     <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalPlaces() ?></span>
 </h4>
 
-<div class="mb-3">
-    <div class="card-deck">
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header">
-                    <?= I18N::translate('Birth places') ?>
-                </h5>
-                <?= $stats->commonBirthPlacesList() ?>
-            </div>
+<div class="row row-cols-1 row-cols-md-2 g-3 mb-3">
+    <div class="col">
+        <div class="card">
+            <h5 class="card-header">
+                <?= I18N::translate('Birth places') ?>
+            </h5>
+            <?= $stats->commonBirthPlacesList() ?>
         </div>
+    </div>
 
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header">
-                    <?= I18N::translate('Death places') ?>
-                </h5>
-                <?= $stats->commonDeathPlacesList() ?>
-            </div>
+    <div class="col">
+        <div class="card">
+            <h5 class="card-header">
+                <?= I18N::translate('Death places') ?>
+            </h5>
+            <?= $stats->commonDeathPlacesList() ?>
         </div>
+    </div>
 
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header">
-                    <?= I18N::translate('Marriage places') ?>
-                </h5>
-                <?= $stats->commonMarriagePlacesList() ?>
-            </div>
+    <div class="col">
+        <div class="card">
+            <h5 class="card-header">
+                <?= I18N::translate('Marriage places') ?>
+            </h5>
+            <?= $stats->commonMarriagePlacesList() ?>
         </div>
+    </div>
 
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header">
-                    <?= I18N::translate('Events in countries') ?>
-                </h5>
-                <?php $result = $stats->commonCountriesList(); ?>
-                <?php if ($result) : ?>
-                    <?= $result ?>
-                <?php else : ?>
-                    <div class="card-body">
-                        <?= I18N::translate('This information is not available.') ?>
-                    </div>
-                <?php endif; ?>
-            </div>
+    <div class="col">
+        <div class="card">
+            <h5 class="card-header">
+                <?= I18N::translate('Events in countries') ?>
+            </h5>
+            <?php $result = $stats->commonCountriesList(); ?>
+            <?php if ($result) : ?>
+                <?= $result ?>
+            <?php else : ?>
+                <div class="card-body">
+                    <?= I18N::translate('This information is not available.') ?>
+                </div>
+            <?php endif; ?>
         </div>
     </div>
 </div>

--- a/resources/views/statistics/other/total-events.phtml
+++ b/resources/views/statistics/other/total-events.phtml
@@ -13,37 +13,35 @@ use Fisharebest\Webtrees\Statistics;
     <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalEvents() ?></span>
 </h4>
 
-<div class="mb-3">
-    <div class="card-deck">
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <?php $type   = $stats->firstEventType() ?>
-                <?php $result = $stats->firstEvent() ?>
-                <h5 class="card-header">
-                    <?= I18N::translate('First event') ?>
-                    <?php if ($type) :
-                        ?><?= ' - ', $type ?><?php
-                    endif; ?>
-                </h5>
-                <div class="card-body">
-                    <?= $result ?>
-                </div>
+<div class="row row-cols-1 row-cols-md-2 g-3 mb-3">
+    <div class="col">
+        <div class="card">
+            <?php $type   = $stats->firstEventType() ?>
+            <?php $result = $stats->firstEvent() ?>
+            <h5 class="card-header">
+                <?= I18N::translate('First event') ?>
+                <?php if ($type) :
+                    ?><?= ' - ', $type ?><?php
+                endif; ?>
+            </h5>
+            <div class="card-body">
+                <?= $result ?>
             </div>
         </div>
+    </div>
 
-        <div class="col-12 col-md-6 mb-3">
-            <div class="card m-0">
-                <?php $type   = $stats->lastEventType() ?>
-                <?php $result = $stats->lastEvent() ?>
-                <h5 class="card-header">
-                    <?= I18N::translate('Last event') ?>
-                    <?php if ($type) :
-                        ?><?= ' - ', $type ?><?php
-                    endif; ?>
-                </h5>
-                <div class="card-body">
-                    <?= $result ?>
-                </div>
+    <div class="col">
+        <div class="card">
+            <?php $type   = $stats->lastEventType() ?>
+            <?php $result = $stats->lastEvent() ?>
+            <h5 class="card-header">
+                <?= I18N::translate('Last event') ?>
+                <?php if ($type) :
+                    ?><?= ' - ', $type ?><?php
+                endif; ?>
+            </h5>
+            <div class="card-body">
+                <?= $result ?>
             </div>
         </div>
     </div>

--- a/resources/views/statistics/other/total-records.phtml
+++ b/resources/views/statistics/other/total-records.phtml
@@ -13,42 +13,40 @@ use Fisharebest\Webtrees\Statistics;
     <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalRecords() ?></span>
 </h4>
 
-<div class="mb-3">
-    <div class="card-deck">
-        <div class="col-12 col-lg-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header border-bottom-0">
-                    <?= I18N::translate('Media objects') ?>
-                    <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalMedia() ?></span>
-                </h5>
-            </div>
+<div class="row row-cols-1 row-cols-lg-2 g-3 mb-3">
+    <div class="col">
+        <div class="card">
+            <h5 class="card-header border-bottom-0">
+                <?= I18N::translate('Media objects') ?>
+                <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalMedia() ?></span>
+            </h5>
         </div>
+    </div>
 
-        <div class="col-12 col-lg-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header border-bottom-0">
-                    <?= I18N::translate('Sources') ?>
-                    <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalSources() ?></span>
-                </h5>
-            </div>
+    <div class="col">
+        <div class="card">
+            <h5 class="card-header border-bottom-0">
+                <?= I18N::translate('Sources') ?>
+                <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalSources() ?></span>
+            </h5>
         </div>
+    </div>
 
-        <div class="col-12 col-lg-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header border-bottom-0">
-                    <?= I18N::translate('Notes') ?>
-                    <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalNotes() ?></span>
-                </h5>
-            </div>
+    <div class="col">
+        <div class="card">
+            <h5 class="card-header border-bottom-0">
+                <?= I18N::translate('Notes') ?>
+                <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalNotes() ?></span>
+            </h5>
         </div>
+    </div>
 
-        <div class="col-12 col-lg-6 mb-3">
-            <div class="card m-0">
-                <h5 class="card-header border-bottom-0">
-                    <?= I18N::translate('Repositories') ?>
-                    <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalRepositories() ?></span>
-                </h5>
-            </div>
+    <div class="col">
+        <div class="card">
+            <h5 class="card-header border-bottom-0">
+                <?= I18N::translate('Repositories') ?>
+                <span class="badge bg-secondary rounded-pill float-end"><?= $stats->totalRepositories() ?></span>
+            </h5>
         </div>
     </div>
 </div>


### PR DESCRIPTION
### Use of `form-select`
`select` elements used to be assigned the `form-control` class. This is aimed for `input` and `textarea`. It was not causing any issue in BS4, but in BS5, the following line has been added to `form-control` which is removing the dropdown caret on `select`. Use the appropriate `form-select` class instead.

```css
.form-control {
    [...]
    appearance: none; // Fix appearance for date inputs in Safari
```
![image](https://user-images.githubusercontent.com/5150782/130354764-018be628-d9c9-4948-a935-f85d72cfc78a.png)

### `card-deck` dropped

The `card-deck` class has been removed in favour of the grid system (see [documentation](https://getbootstrap.com/docs/5.0/migration/#card)).

This is not obvious everywhere, but for instance, the *Family* and *Other* tabs of the [statistics page](https://dev.webtrees.net/demo-dev/module/statistics_chart/Chart/demo) do not display correctly, as well as the [*Customise this page* page](https://dev.webtrees.net/demo-dev/tree/demo/my-page-edit).
