### PR TITLE
Replace EOL Swiftmailer library by Symfony Mailer

### DIFF
--- a/app/Services/EmailService.php
+++ b/app/Services/EmailService.php
@@ -25,13 +25,16 @@ use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\Log;
 use Fisharebest\Webtrees\Site;
 use Psr\Http\Message\ServerRequestInterface;
-use Swift_Mailer;
-use Swift_Message;
-use Swift_NullTransport;
-use Swift_SendmailTransport;
-use Swift_Signers_DKIMSigner;
-use Swift_SmtpTransport;
-use Swift_Transport;
+use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mailer\Transport\NullTransport;
+use Symfony\Component\Mailer\Transport\SendmailTransport;
+use Symfony\Component\Mailer\Transport\Smtp\EsmtpTransport;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Crypto\DkimOptions;
+use Symfony\Component\Mime\Crypto\DkimSigner;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Mime\Message;
 
 use function assert;
 use function checkdnsrr;
@@ -64,11 +67,10 @@ class EmailService
      */
     public function send(UserInterface $from, UserInterface $to, UserInterface $reply_to, string $subject, string $message_text, string $message_html): bool
     {
-        $message   = $this->message($from, $to, $reply_to, $subject, $message_text, $message_html);
-        $transport = $this->transport();
-        $mailer    = new Swift_Mailer($transport);
-
         try {
+            $message   = $this->message($from, $to, $reply_to, $subject, $message_text, $message_html);
+            $transport = $this->transport();
+            $mailer    = new Mailer($transport);
             $mailer->send($message);
         } catch (Exception $ex) {
             Log::addErrorLog('MailService: ' . $ex->getMessage());
@@ -89,35 +91,35 @@ class EmailService
      * @param string        $message_text
      * @param string        $message_html
      *
-     * @return Swift_Message
+     * @return Message
      */
-    protected function message(UserInterface $from, UserInterface $to, UserInterface $reply_to, string $subject, string $message_text, string $message_html): Swift_Message
+    protected function message(UserInterface $from, UserInterface $to, UserInterface $reply_to, string $subject, string $message_text, string $message_html): Message
     {
         // Mail needs MS-DOS line endings
         $message_text = str_replace("\n", "\r\n", $message_text);
         $message_html = str_replace("\n", "\r\n", $message_html);
 
-        $message = (new Swift_Message())
-            ->setSubject($subject)
-            ->setFrom($from->email(), $from->realName())
-            ->setTo($to->email(), $to->realName())
-            ->setReplyTo($reply_to->email(), $reply_to->realName())
-            ->setBody($message_html, 'text/html');
+        $message = (new Email())
+            ->subject($subject)
+            ->from(new Address($from->email(), $from->realName()))
+            ->to(new Address($to->email(), $to->realName()))
+            ->replyTo(new Address($reply_to->email(), $reply_to->realName()))
+            ->html($message_html);
 
         $dkim_domain   = Site::getPreference('DKIM_DOMAIN');
         $dkim_selector = Site::getPreference('DKIM_SELECTOR');
         $dkim_key      = Site::getPreference('DKIM_KEY');
 
         if ($dkim_domain !== '' && $dkim_selector !== '' && $dkim_key !== '') {
-            $signer = new Swift_Signers_DKIMSigner($dkim_key, $dkim_domain, $dkim_selector);
-            $signer
-                ->setHeaderCanon('relaxed')
-                ->setBodyCanon('relaxed');
+            $signer = new DkimSigner($dkim_key, $dkim_domain, $dkim_selector);
+            $options = (new DkimOptions())
+                ->headerCanon('relaxed')
+                ->bodyCanon('relaxed');
 
-            $message->attachSigner($signer);
+            return $signer->sign($message, $options->toArray());
         } else {
             // DKIM body hashes don't work with multipart/alternative content.
-            $message->addPart($message_text, 'text/plain');
+            $message->text($message_text);
         }
 
         return $message;
@@ -126,9 +128,9 @@ class EmailService
     /**
      * Create a transport mechanism for sending mail
      *
-     * @return Swift_Transport
+     * @return TransportInterface
      */
-    protected function transport(): Swift_Transport
+    protected function transport(): TransportInterface
     {
         switch (Site::getPreference('SMTP_ACTIVE')) {
             case 'sendmail':
@@ -138,7 +140,7 @@ class EmailService
 
                 $sendmail_command = $request->getAttribute('sendmail_command', '/usr/sbin/sendmail -bs');
 
-                return new Swift_SendmailTransport($sendmail_command);
+                return new SendmailTransport($sendmail_command);
 
             case 'external':
                 // SMTP
@@ -148,13 +150,9 @@ class EmailService
                 $smtp_auth = (bool) Site::getPreference('SMTP_AUTH');
                 $smtp_user = Site::getPreference('SMTP_AUTH_USER');
                 $smtp_pass = Site::getPreference('SMTP_AUTH_PASS');
-                $smtp_encr = Site::getPreference('SMTP_SSL');
+                $smtp_encr = Site::getPreference('SMTP_SSL') === 'ssl';
 
-                if ($smtp_encr === 'none') {
-                    $smtp_encr = null;
-                }
-
-                $transport = new Swift_SmtpTransport($smtp_host, $smtp_port, $smtp_encr);
+                $transport = new EsmtpTransport($smtp_host, $smtp_port, $smtp_encr);
 
                 $transport->setLocalDomain($smtp_helo);
 
@@ -168,7 +166,7 @@ class EmailService
 
             default:
                 // For testing
-                return new Swift_NullTransport();
+                return new NullTransport();
         }
     }
 
@@ -181,23 +179,19 @@ class EmailService
      */
     public function isValidEmail(string $email): bool
     {
-        $at_domain = strrchr($email, '@');
-
-        if ($at_domain === false) {
+        try {
+            $address = new Address($email);
+        } catch (Exception $ex) {
             return false;
         }
 
-        $domain = substr($at_domain, 1);
-
-        $email_valid  = filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
-        $domain_valid = filter_var($domain, FILTER_VALIDATE_DOMAIN) !== false;
-
         // Some web hosts disable checkdnsrr.
-        if ($domain_valid && function_exists('checkdnsrr')) {
-            $domain_valid = checkdnsrr($domain);
+        if (function_exists('checkdnsrr')) {
+            $domain = substr(strrchr($address->getAddress(), '@') ?: '@', 1);
+            return checkdnsrr($domain, 'MX');
         }
 
-        return $email_valid && $domain_valid;
+        return true;
     }
 
     /**
@@ -209,10 +203,10 @@ class EmailService
     {
         return [
             'none' => I18N::translate('none'),
-            /* I18N: Secure Sockets Layer - a secure communications protocol*/
-            'ssl'  => I18N::translate('ssl'),
-            /* I18N: Transport Layer Security - a secure communications protocol */
-            'tls'  => I18N::translate('tls'),
+            /* I18N: Use SMTP over SSL/TLS, or Implicit TLS - a secure communications protocol */
+            'ssl'  => I18N::translate('SSL/TLS'),
+            /* I18N: Use SMTP with STARTTLS, or Explicit TLS - a secure communications protocol */
+            'tls'  => I18N::translate('STARTTLS'),
         ];
     }
 

--- a/composer.json
+++ b/composer.json
@@ -68,9 +68,9 @@
         "psr/http-server-middleware": "1.0.1",
         "ramsey/uuid": "4.2.1",
         "sabre/vobject": "4.3.5",
-        "swiftmailer/swiftmailer": "6.2.7",
         "symfony/cache": "5.3.7",
         "symfony/expression-language": "5.3.7",
+        "symfony/mailer": "5.3.4",
         "symfony/polyfill-mbstring": "1.23.1",
         "symfony/polyfill-php80": "1.23.1",
         "tecnickcom/tcpdf": "6.4.2"

--- a/tests/app/Services/EmailServiceTest.php
+++ b/tests/app/Services/EmailServiceTest.php
@@ -17,24 +17,130 @@
 
 declare(strict_types=1);
 
-namespace Fisharebest\Webtrees;
+namespace Fisharebest\Webtrees\Services;
 
-use Fisharebest\Webtrees\Services\EmailService;
+use Fisharebest\Webtrees\Site;
+use Fisharebest\Webtrees\TestCase;
+use Fisharebest\Webtrees\Contracts\UserInterface;
 
 /**
- * Test harness for the class MailService
+ * Test harness for the class EmailService
  *
  * @covers \Fisharebest\Webtrees\Services\EmailService
  */
 class EmailServiceTest extends TestCase
 {
+    protected static bool $uses_database = true;
+
     /**
-     * Test that the class exists
-     *
-     * @return void
+     * @covers \Fisharebest\Webtrees\Services\EmailService::send
+     * @covers \Fisharebest\Webtrees\Services\EmailService::message
+     * @covers \Fisharebest\Webtrees\Services\EmailService::transport
      */
-    public function testClassExists(): void
+    public function testSend(): void
     {
-        self::assertTrue(class_exists(EmailService::class));
+        $email_service = new EmailService();
+
+        $user_from = $this->createMock(UserInterface::class);
+        $user_from->method('email')->willReturn('user.from@example.com');
+
+        $user_from = $this->createMock(UserInterface::class);
+        $user_from->method('email')->willReturn('user.from@example.com');
+
+        $user_to = $this->createMock(UserInterface::class);
+        $user_to->method('email')->willReturn('user.to@example.com');
+
+        $user_reply_to = $this->createMock(UserInterface::class);
+        $user_reply_to->method('email')->willReturn('user.replyto@example.com');
+
+        Site::setPreference('SMTP_ACTIVE', 'internal');
+
+        self::assertSame(true, $email_service->send($user_from, $user_to, $user_reply_to, 'Test No DKIM', 'Test Plain Message', '<p>Test Html Message</p>'));
+
+        Site::setPreference('DKIM_DOMAIN', 'example.com');
+        Site::setPreference('DKIM_SELECTOR', 'sel');
+        Site::setPreference('DKIM_KEY', '-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0FPqri0cb2JZfXJ/DgYSF6vUp
+wmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/3j+skZ6UtW+5u09lHNsj6tQ5
+1s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZwIDAQABAoGAFijko56+qGyN8M0RVyaRAXz++xTqHBLh
+3tx4VgMtrQ+WEgCjhoTwo23KMBAuJGSYnRmoBZM3lMfTKevIkAidPExvYCdm5dYq3XToLkkLv5L2
+pIIVOFMDG+KESnAFV7l2c+cnzRMW0+b6f8mR1CJzZuxVLL6Q02fvLi55/mbSYxECQQDeAw6fiIQX
+GukBI4eMZZt4nscy2o12KyYner3VpoeE+Np2q+Z3pvAMd/aNzQ/W9WaI+NRfcxUJrmfPwIGm63il
+AkEAxCL5HQb2bQr4ByorcMWm/hEP2MZzROV73yF41hPsRC9m66KrheO9HPTJuo3/9s5p+sqGxOlF
+L0NDt4SkosjgGwJAFklyR1uZ/wPJjj611cdBcztlPdqoxssQGnh85BzCj/u3WqBpE2vjvyyvyI5k
+X6zk7S0ljKtt2jny2+00VsBerQJBAJGC1Mg5Oydo5NwD6BiROrPxGo2bpTbu/fhrT8ebHkTz2epl
+U9VQQSQzY1oZMVX8i1m5WUTLPz2yLJIBQVdXqhMCQBGoiuSoSjafUhV7i1cEGpb88h5NBYZzWXGZ
+37sJ5QsW+sJyoNde3xH8vdXhzU7eT82D6X/scw9RZz+/6rCJ4p0=
+-----END RSA PRIVATE KEY-----');
+
+        self::assertSame(true, $email_service->send($user_from, $user_to, $user_reply_to, 'Test DKIM', 'Test Plain Message', '<p>Test Html Message</p>'));
+    }
+
+    /**
+     * Data provider for testing email validity
+     *
+     * @return array<array<bool|string>>
+     */
+    public function emailProvider(): array
+    {
+        return [
+            // Valid emails
+            ['Abc@webtrees.com', true],
+            ['ABC@webtrees.com', true],
+            ['Abc.123@webtrees.com', true],
+            ['user+mailbox/tree=family@webtrees.com', true],
+            ['!#$%&\'*+-/=?^_`.{|}~@webtrees.com', true],
+            ['"Abc@def"@webtrees.com', true],
+            ['"John\ Doe"@webtrees.com', true],
+            ['"Joe.\\Smith"@webtrees.com', true],
+            ['généalogie@webtrees.com', true],
+            // Invalid
+            ['example@invalid.example.com', false],
+            ['example', false],
+            ['example@with space', false],
+            ['example@webtrees.', false],
+            ['example@webtr\ees.com', false],
+            ['example(comment)@example.com', false],
+            ["\x80\x81\x82@\x83\x84\x85.\x86\x87\x88", false],
+            ['user  name@example.com', false],
+            ['example.@example.com', false],
+            ['example(example]example@example.co.uk', false],
+            ['a@b.c+&%$.d', false],
+            ['a.b+&%$.c@d', false],
+            ['example@généalogie', false]
+        ];
+    }
+
+    /**
+     * @dataProvider emailProvider
+     *
+     * @covers \Fisharebest\Webtrees\Services\EmailService::isValidEmail
+     *
+     * @param string $email
+     * @param bool $is_valid
+     */
+    public function testIsValidEmail(string $email, bool $is_valid): void
+    {
+        self::assertSame($is_valid, (new EmailService())->isValidEmail($email));
+    }
+
+    /**
+     * @covers \Fisharebest\Webtrees\Services\EmailService::mailSslOptions
+     */
+    public function testMailSslOptions(): void
+    {
+        $options = (new EmailService())->mailSslOptions();
+        self::assertCount(3, $options);
+        self::assertArrayHasKey('ssl', $options);
+    }
+
+    /**
+     * @covers \Fisharebest\Webtrees\Services\EmailService::mailTransportOptions
+     */
+    public function testMailTransportOptions(): void
+    {
+        $options = (new EmailService())->mailTransportOptions();
+        self::assertCount(function_exists('proc_open') ? 2 : 1, $options);
+        self::assertArrayHasKey('external', $options);
     }
 }


### PR DESCRIPTION
Following my comment in #4011, I open this PR to prepare the replacement of the Swiftmailer library by Symfony Mailer.

As advertised on the website, and based on [the announcement of its author](https://symfony.com/blog/the-end-of-swiftmailer), Swiftmailer is reaching end-of-life, with its maintenance being stopped by the end of November 2021, and the Symfony Mailer component (written by the same author) is the recommended replacement.

The PR intends to implement the replacement, whilst discussing some minor points raised during the upgrade. I will keep it as a draft until all questions/comments have been addressed.

The upgrade is rather straightforward, with very similar classes and signatures. In my first commit, I have taken the approach to keep essentially the same code, with just the few namespace/class replacement and minor adjustments.

@fisharebest, there are a couple of points I would like to pass by you:

### Email validation

During my testing, it appears that the email handling is slightly less permissive than before, so an exception can be raised if the email is not valid, as early as the constructor of the new `Address` class, and so as soon as the first line of the `send` method (not covered by the `try/catch` block. This raised some questions to me:

- Shall we extend the scope of the `try/catch` to the whole `EmailService::send` method, so that exceptions are captured during the creation of the message or the transport?
- Should we add a validation of the email before sending? This is normally done when saving the email, so maybe not necessary
- I have slightly modified the `isValidEmail` method used when saving the email, so that it uses at least the same validation as the one used when sending. This is simply by calling the constructor, as Symfony Mailer does not provide any method or utility to check the validity of the email in a consistent manner (probably something they could improve a bit).
  We could go even further and replace the validation logic by using directly the egulias/email-validator library to perform the validation (as this is the underlying library in Symfony Mailer), using MessageIDValidation & DNSCheckValidation. This provides maybe a more robust check, but the current logic is probably enough (I have done some testing using the Egulias data set, and its validator and the `isValidEmail` do not agree only in a handful of edge cases).

### SSL / TLS / STARTTLS confusion

That may be the topic where I have noticed the most sensible change.
Swiftmailer had 3 modes for email security. I had never taken a deep look at them, but they were particularly badly named in the library:
- no security (plain non-secure SMTP was used, the 'none' option in webtrees)
- 'ssl' : this is the SMTP over TLS option, where the connection is secure from its initialisation, at the transport layer. This is the 'Implicit TLS' or 'Enforced TLS' option with some providers, or port 465 with Gmail. The name SSL is completely outdated now, as hopefully everybody have switched to TLS by now, but is probably useful not to confuse with the next option
- 'tls': probably the most confusing one. This is the option where the SMTP command STARTTLS is called after a non-secure connection has been established with the server, to upgrade the connection to a secure one (over TLS). This is the 'Explicit TLS' or 'Opportunistic TLS' option with some providers, or port 587 with Gmail.

Symfony Mailer has slightly modified the approach, and it now automatically tries to issue a STARTTLS command if the server allows it, without any configuration. Only the ex-'ssl' mode now needs to be explicitly set (even there, if no configuration is given, it will try to infer the 'ssl' mode if the port is 465).

It means that the options are now reduced to a simple binary choice: Use Implicit TLS ?
- If yes, then the TLS channel is created first when connecting to the SMTP server (ex-'ssl' option)
- If no, a non-secure channel is created, the STARTTLS command is issued, and depending on the handshake result, either the connection remains non-secure, or it will be upgraded to TLS (so, the ex-'none' and 'tls' options result in the same outcome).

In the first commit, I have not modified the options for the 'Secure connection' configuration, but two of them are redundant. So what's next?

- Keep the options as they are: I would however improve the wording, i.e. 'ssl' => '*SMTP over TLS (Implicit TLS)*', 'tls' => '*SMTP with STARTTLS (Explicit TLS)*'
- Keep a dropdown, with the same preference value `SMTP_SSL`, but reduced to two options : 'none' => '*Best effort security (use STARTTLS if available)*', 'ssl' => '*SMTP over TLS (Implicit TLS)*'. No migration is strictly required, as all tests can be done against 'ssl', so 'none' and the defunct 'tls' option with produce the same result.
- Refactor the preference `SMTP_SSL`, and transform it to a binary value. In the control panel, this would become a 'yes/no' choice to '*Use Implicit TLS*'. A small migration is to be planned to change 'ssl' to '1' and 'none'/'tls' to '0'.

### DKIM

How did you manage to test it? The email providers that I have tend to overwrite any DKIM value I set, so I find it difficult to test. The classes seem quite straightforward, so assuming the previous code was working, I guess the new one will work equally...
