### PR TITLE
Bootstrap5: use new accordion native component

### DIFF
--- a/resources/css/_base.css
+++ b/resources/css/_base.css
@@ -83,6 +83,17 @@ a:hover {
     display: none;
 }
 
+/* Accordions */
+.accordion-button,
+.accordion-button:not(.collapsed) {
+    background-color: rgba(0,0,0,.03);
+    color: currentcolor;
+}
+
+.accordion-button:after {
+    display: none;
+}
+
 /* Link styling */
 a, .btn-link, .nav-link {
     color: var(--link-color);

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -1042,3 +1042,13 @@ a > .wt-icon-arrow-up:hover {
 .col-form-label {
     font-weight: bold;
 }
+
+/* Accordions */
+.accordion .wt-icon-expand,
+.accordion .wt-icon-collapse {
+    display: none;
+}
+
+.accordion-button:after {
+    display: block;
+}

--- a/resources/views/admin/trees.phtml
+++ b/resources/views/admin/trees.phtml
@@ -49,21 +49,21 @@ use Illuminate\Database\Capsule\Manager as DB;
     </div>
 <?php endif ?>
 
-<div id="accordion" role="tablist" aria-multiselectable="true">
+<div id="accordion" aria-multiselectable="true">
     <?php foreach ($all_trees as $managed_tree) : ?>
         <?php if (Auth::isManager($managed_tree)) : ?>
-            <div class="card">
-                <div class="card-header" role="tab" id="card-tree-header-<?= $managed_tree->id() ?>">
-                    <h2 class="mb-0">
-                        <?= view('icons/tree') ?>
-                        <a data-bs-toggle="collapse" data-bs-parent="#accordion" href="#card-tree-content-<?= $managed_tree->id() ?>" <?= $managed_tree === $tree || $managed_tree->getPreference('imported') === '0' ? 'aria-expanded="true"' : '' ?> aria-controls="card-tree-content-<?= $managed_tree->id() ?>">
+            <div class="accordion-item">
+                <div class="accordion-header" id="card-tree-header-<?= $managed_tree->id() ?>">
+                    <button class="accordion-button <?= $managed_tree == $tree || $managed_tree->getPreference('imported') === '0' ? ' ' : ' collapsed' ?>" type="button" data-bs-toggle="collapse" data-bs-target="#card-tree-content-<?= $managed_tree->id() ?>" aria-expanded="<?= $managed_tree === $tree || $managed_tree->getPreference('imported') === '0' ? 'true' : 'false' ?>" aria-controls="card-tree-content-<?= $managed_tree->id() ?>">
+                        <h2>
+                            <?= view('icons/tree') ?>
                             <?= e($managed_tree->name()) ?> — <?= e($managed_tree->title()) ?>
-                        </a>
-                    </h2>
+                        </h2>
+                    </button>
                 </div>
 
-                <div id="card-tree-content-<?= $managed_tree->id() ?>" class="collapse<?= $managed_tree == $tree || $managed_tree->getPreference('imported') === '0' ? ' show' : '' ?>" role="tabpanel" aria-labelledby="panel-tree-header-<?= $managed_tree->id() ?>">
-                    <div class="card-body">
+                <div id="card-tree-content-<?= $managed_tree->id() ?>" class="accordion-collapse collapse<?= $managed_tree == $tree || $managed_tree->getPreference('imported') === '0' ? ' show' : '' ?>" aria-labelledby="panel-tree-header-<?= $managed_tree->id() ?>">
+                    <div class="accordion-body">
                         <?php $importing = DB::table('gedcom_chunk')->where('gedcom_id', '=', $managed_tree->id())->where('imported', '=', 0)->exists() ?>
                         <?php if ($importing) : ?>
                             <div id="import<?= $managed_tree->id() ?>" class="col-12">

--- a/resources/views/individual-name.phtml
+++ b/resources/views/individual-name.phtml
@@ -34,9 +34,9 @@ if ($fact->isPendingDeletion()) {
 }
 
 ?>
-<div class="card <?= $container_class ?>">
-    <div class="card-header" role="tab" id="name-header-<?= $fact->id() ?>">
-        <a data-bs-toggle="collapse" href="#name-content-<?= $fact->id() ?>" aria-expanded="false" aria-controls="name-content-<?= $fact->id() ?>">
+<div class="accordion-item <?= $container_class ?>">
+    <div class="accordion-header" id="name-header-<?= $fact->id() ?>">
+        <button class="accordion-button collapsed gap-1" type="button" data-bs-toggle="collapse" data-bs-target="#name-content-<?= $fact->id() ?>" aria-expanded="false" aria-controls="name-content-<?= $fact->id() ?>">
             <?= view('icons/expand') ?>
             <?= view('icons/collapse') ?>
             <span class="label"><?= I18N::translate('Name') ?></span>
@@ -45,52 +45,54 @@ if ($fact->isPendingDeletion()) {
                 —
                 <?= Registry::elementFactory()->make($fact->tag() . ':TYPE')->value($fact->attribute('TYPE'), $tree) ?>
             <?php endif ?>
-        </a>
+        </button>
     </div>
 
-    <div id="name-content-<?= $fact->id() ?>" class="card-body collapse" data-bs-parent="#individual-names" aria-labelledby="name-header-<?= $fact->id() ?>">
-        <dl class="row mb-0">
-            <dt class="col-md-4 col-lg-3"><?= I18N::translate('Name') ?></dt>
-            <dd class="col-md-8 col-lg-9"><bdi><?= e($fact->value()) ?></bdi></dd>
-
-            <?php preg_match_all('/\n2 (\w+) (.+)/', $fact->gedcom(), $matches, PREG_SET_ORDER) ?>
-            <?php foreach ($matches as $key => $match) : ?>
-                <?php [, $tag, $value] = $match ?>
-                <?php $element = Registry::elementFactory()->make($fact->tag() . ':' . $tag) ?>
-                <?php if ($tag !== 'SOUR' && $tag !== 'NOTE') : ?>
-                    <dt class="col-md-4 col-lg-3">
-                        <?= $element->label() ?>
-                    </dt>
-                    <dd class="col-md-8 col-lg-9">
-                        <?= $element->value($value, $fact->record()->tree()) ?>
-                    </dd>
-                <?php endif ?>
-            <?php endforeach ?>
-        </dl>
-
-        <?= FunctionsPrintFacts::printFactSources($tree, $fact->gedcom(), 2) ?>
-        <?= FunctionsPrint::printFactNotes($tree, $fact->gedcom(), 2) ?>
-
-        <?php if ($fact->canEdit()) : ?>
-            <div class="d-flex">
-                <a class="btn btn-link ms-auto" href="<?= e(route(EditFactPage::class, ['xref' => $individual->xref(), 'fact_id' => $fact->id(), 'tree' => $individual->tree()->name()])) ?>" title="<?= I18N::translate('Edit the name') ?>">
-                    <?= view('icons/edit') ?>
-                    <span class="visually-hidden"><?= I18N::translate('Edit the name') ?></span>
-                </a>
-
+    <div id="name-content-<?= $fact->id() ?>" class="accordion-collapse collapse" data-bs-parent="#individual-names" aria-labelledby="name-header-<?= $fact->id() ?>">
+        <div class="accordion-body">
+            <dl class="row mb-0">
+                <dt class="col-md-4 col-lg-3"><?= I18N::translate('Name') ?></dt>
+                <dd class="col-md-8 col-lg-9"><bdi><?= e($fact->value()) ?></bdi></dd>
+    
+                <?php preg_match_all('/\n2 (\w+) (.+)/', $fact->gedcom(), $matches, PREG_SET_ORDER) ?>
+                <?php foreach ($matches as $key => $match) : ?>
+                    <?php [, $tag, $value] = $match ?>
+                    <?php $element = Registry::elementFactory()->make($fact->tag() . ':' . $tag) ?>
+                    <?php if ($tag !== 'SOUR' && $tag !== 'NOTE') : ?>
+                        <dt class="col-md-4 col-lg-3">
+                            <?= $element->label() ?>
+                        </dt>
+                        <dd class="col-md-8 col-lg-9">
+                            <?= $element->value($value, $fact->record()->tree()) ?>
+                        </dd>
+                    <?php endif ?>
+                <?php endforeach ?>
+            </dl>
+    
+            <?= FunctionsPrintFacts::printFactSources($tree, $fact->gedcom(), 2) ?>
+            <?= FunctionsPrint::printFactNotes($tree, $fact->gedcom(), 2) ?>
+    
+            <?php if ($fact->canEdit()) : ?>
+                <div class="d-flex">
+                    <a class="btn btn-link ms-auto" href="<?= e(route(EditFactPage::class, ['xref' => $individual->xref(), 'fact_id' => $fact->id(), 'tree' => $individual->tree()->name()])) ?>" title="<?= I18N::translate('Edit the name') ?>">
+                        <?= view('icons/edit') ?>
+                        <span class="visually-hidden"><?= I18N::translate('Edit the name') ?></span>
+                    </a>
+    
                 <a class="btn btn-link" href="#" data-wt-post-url="<?= e(route(CopyFact::class, ['tree' => $fact->record()->tree()->name(), 'xref' => $fact->record()->xref(), 'fact_id' => $fact->id()])) ?>" title="<?= I18N::translate('Copy') ?>">
-                    <?= view('icons/copy') ?>
-                    <span class="visually-hidden"><?= I18N::translate('Copy') ?></span>
-                </a>
-
-                <a class="btn btn-link" href="#"
+                        <?= view('icons/copy') ?>
+                        <span class="visually-hidden"><?= I18N::translate('Copy') ?></span>
+                    </a>
+    
+                    <a class="btn btn-link" href="#"
                    data-wt-confirm="<?= I18N::translate('Are you sure you want to delete this fact?') ?>"
                    data-wt-post-url="<?= e(route(DeleteFact::class, ['tree' => $individual->tree()->name(), 'xref' => $individual->xref(), 'fact_id' => $fact->id()])) ?>"
-                   title="<?= I18N::translate('Delete this name') ?>">
-                    <?= view('icons/delete') ?>
-                    <span class="visually-hidden"><?= I18N::translate('Delete this name') ?></span>
-                </a>
-            </div>
-        <?php endif ?>
+                       title="<?= I18N::translate('Delete this name') ?>">
+                        <?= view('icons/delete') ?>
+                        <span class="visually-hidden"><?= I18N::translate('Delete this name') ?></span>
+                    </a>
+                </div>
+            <?php endif ?>
+        </div>
     </div>
 </div>

--- a/resources/views/individual-page-sidebars.phtml
+++ b/resources/views/individual-page-sidebars.phtml
@@ -12,19 +12,16 @@ use Illuminate\Support\Collection;
 
 <div class="col-sm-4 accordion" id="sidebar">
     <?php foreach ($sidebars as $sidebar) : ?>
-        <div class="card">
-            <div class="card-header" role="tab" id="sidebar-header-<?= $sidebar->name() ?>">
-                <div class="card-title mb-0">
-                    <a data-bs-toggle="collapse" href="#sidebar-content-<?= $sidebar->name() ?>" aria-expanded="<?= $sidebar->name() === 'family_nav' ? 'true' : 'false' ?>" aria-controls="sidebar-content-<?= $sidebar->name() ?>">
-                        <?= view('icons/expand') ?>
-                        <?= view('icons/collapse') ?>
-                        <?= $sidebar->sidebarTitle($record) ?>
-                    </a>
-                </div>
+        <div class="accordion-item">
+            <div class="accordion-header" id="sidebar-header-<?= $sidebar->name() ?>">
+                <button class="accordion-button gap-1<?= $sidebar->name() === 'family_nav' ? '' : ' collapsed' ?>" type="button" data-bs-toggle="collapse" data-bs-target="#sidebar-content-<?= $sidebar->name() ?>" aria-expanded="<?= $sidebar->name() === 'family_nav' ? 'true' : 'false' ?>" aria-controls="sidebar-content-<?= $sidebar->name() ?>">
+                    <?= view('icons/expand') ?>
+                    <?= view('icons/collapse') ?>
+                    <?= $sidebar->sidebarTitle($record) ?>
+                </button>
             </div>
-
-            <div id="sidebar-content-<?= $sidebar->name() ?>" class="collapse<?= $sidebar->name() === 'family_nav' ? ' show' : '' ?>" data-bs-parent="#sidebar" aria-labelledby="sidebar-header-<?= $sidebar->name() ?>">
-                <div class="card-body">
+            <div id="sidebar-content-<?= $sidebar->name() ?>" class="accordion-collapse collapse<?= $sidebar->name() === 'family_nav' ? ' show' : '' ?>" data-bs-parent="#sidebar" aria-labelledby="sidebar-header-<?= $sidebar->name() ?>">
+                <div class="accordion-body">
                     <?= $sidebar->getSidebarContent($record) ?>
                 </div>
             </div>

--- a/resources/views/individual-sex.phtml
+++ b/resources/views/individual-sex.phtml
@@ -21,9 +21,9 @@ if ($fact->isPendingDeletion()) {
 }
 
 ?>
-<div class="card <?= $container_class ?>">
-    <div class="card-header" role="tab" id="name-header-<?= $fact->id() ?>">
-        <a data-bs-toggle="collapse" href="#name-content-<?= $fact->id() ?>" aria-expanded="false" aria-controls="name-content-<?= $fact->id() ?>">
+<div class="accordion-item <?= $container_class ?>">
+    <div class="accordion-header" id="name-header-<?= $fact->id() ?>">
+        <button class="accordion-button collapsed gap-1" type="button" data-bs-toggle="collapse" data-bs-target="#name-content-<?= $fact->id() ?>" aria-expanded="false" aria-controls="name-content-<?= $fact->id() ?>">
             <?= view('icons/expand') ?>
             <?= view('icons/collapse') ?>
             <span class="label"><?= I18N::translate('Gender') ?></span>
@@ -40,20 +40,22 @@ if ($fact->isPendingDeletion()) {
                     break;
             }
             ?>
-        </a>
+        </button>
     </div>
-    <div id="name-content-<?= $fact->id() ?>" class="card-body collapse" data-bs-parent="#individual-names" aria-labelledby="name-header-<?= $fact->id() ?>">
-        <?= FunctionsPrintFacts::printFactSources($tree, $fact->gedcom(), 2) ?>
-        <?= FunctionsPrint::printFactNotes($tree, $fact->gedcom(), 2) ?>
-
-        <?php if ($fact->canEdit()) : ?>
-            <div class="d-flex">
-                <a class="btn btn-link ms-auto" href="<?= e(route(EditFactPage::class, ['xref' => $fact->record()->xref(), 'fact_id' => $fact->id(), 'tree' => $fact->record()->tree()->name()])) ?>"
-                   title="<?= I18N::translate('Edit the gender') ?>">
-                    <?= view('icons/edit') ?>
-                    <span class="visually-hidden"><?= I18N::translate('Edit the gender') ?></span>
-                </a>
-            </div>
-        <?php endif ?>
+    <div id="name-content-<?= $fact->id() ?>" class="accordion-collapse collapse" data-bs-parent="#individual-names" aria-labelledby="name-header-<?= $fact->id() ?>">
+        <div class="accordion-body">
+            <?= FunctionsPrintFacts::printFactSources($tree, $fact->gedcom(), 2) ?>
+            <?= FunctionsPrint::printFactNotes($tree, $fact->gedcom(), 2) ?>
+    
+            <?php if ($fact->canEdit()) : ?>
+                <div class="d-flex">
+                    <a class="btn btn-link ms-auto" href="<?= e(route(EditFactPage::class, ['xref' => $fact->record()->xref(), 'fact_id' => $fact->id(), 'tree' => $fact->record()->tree()->name()])) ?>"
+                       title="<?= I18N::translate('Edit the gender') ?>">
+                        <?= view('icons/edit') ?>
+                        <span class="visually-hidden"><?= I18N::translate('Edit the gender') ?></span>
+                    </a>
+                </div>
+            <?php endif ?>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
Bootstrap 5 introduce a proper Accordion component, with specific classes (BS4 was using a combination of cards component and `data-toggle` attributes).

The PR migrate the few accordions structure to use the new component, as the old one shows some discrepancies (small gap between headers, rounded headers...)

The Accordion styling is a bit different, and have several states, but I have restored the card style, so the header does not look different.

However, the component comes as well with the dropdown arrow already added, so I have removed the collapse/expand icons in favour of the native styling. That can be reverted back if necessary.
The only aspect I am not entirely satisfied is that the arrow in the expanded state is blue. This is actually because the full text color is blue in the native BS5 styling. To change the arrow color, it is needed to add the full SVG image, and tweak the fill parameter (this is configurable in Bootstrap, but the themes are not generating their own Bootstrap stylesheet, and  only override the default stylesheet).

```css
.accordion-button:not(.collapsed):after {
    background-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='#{$accordion-icon-active-color}'><path fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/></svg>");
}
```

![image](https://user-images.githubusercontent.com/5150782/131353305-f3bcc85d-f367-4ccb-8f60-8eae95a005db.png)



