### PR TITLE
Lifespan chart: exclude unknown dates from min/max year calculation

### DIFF
--- a/app/Module/LifespansChartModule.php
+++ b/app/Module/LifespansChartModule.php
@@ -297,7 +297,8 @@ class LifespansChartModule extends AbstractModule implements ModuleChartInterfac
     protected function maxYear(array $individuals): int
     {
         $jd = array_reduce($individuals, static function ($carry, Individual $item) {
-            return max($carry, $item->getEstimatedDeathDate()->maximumJulianDay());
+            $estimated_death = $item->getEstimatedDeathDate();
+            return $estimated_death->isOK() ? max($carry, $estimated_death->maximumJulianDay()) : $carry;
         }, 0);
 
         $year = $this->jdToYear($jd);
@@ -316,7 +317,8 @@ class LifespansChartModule extends AbstractModule implements ModuleChartInterfac
     protected function minYear(array $individuals): int
     {
         $jd = array_reduce($individuals, static function ($carry, Individual $item) {
-            return min($carry, $item->getEstimatedBirthDate()->minimumJulianDay());
+            $estimated_birth = $item->getEstimatedBirthDate();
+            return $estimated_birth->isOK() ? min($carry, $estimated_birth->minimumJulianDay()) : $carry;
         }, PHP_INT_MAX);
 
         return $this->jdToYear($jd);


### PR DESCRIPTION
Adding individuals without any date (and no way to estimate them) sets the start of the lifespan chart to year 0, which can end up in an awkward display in most family genealogies where the bulk of individuals are usually between the 16th to 21st century.

This is due to `Individual::getEstimatedBirthDate` always returning a date (that would we `Date('')` when it cannot estimate it), and the `LifespansChartModule::minYear` is not excluding those default dates from its decreasing calculation of the minimum date, therefore it will return 0 (as `(new Date(''))->minimumJulianDay() == 0`). In my opinion, the empty dates should not be taken into account.

### Steps to reproduce

- Create a lifespan chart with individuals with known dates. The chart should be nicely bounded between the earliest known decade and the latest one (or today)
- Add to that chart an individual without known birth and death date (and no way to estimate from parent/spouse)
- The lifespan chart now starts at year 0, with typically a huge gap with the earliest known decade. The individual's box is nearly not visible, as it has no span

I actually noticed it when creating a lifespan chart for all individuals in a given place, and some of them were isolated individuals without any date.

### Comments

- One consequence of the PR is that the individuals without estimated dates (so no lifespans) do not appear anymore on the chart (because they are aligned with year 0 - which does not appear any more), but I do not think this is an issue, as the chart is precisely to display lifespans.
- I applied the same change to the `LifespansChartModule::maxYear` for consistency sake, but this is probably least problematic, because it is likely another date will be greater than year 0. Arguably, we could show probably the same symmetric behaviour for the max year for genealogies with BCE dates (I have not tested)