### PR TITLE
Fix: OSK script toggle stopped working

### DIFF
--- a/resources/views/modals/on-screen-keyboard.phtml
+++ b/resources/views/modals/on-screen-keyboard.phtml
@@ -10,32 +10,32 @@ use Fisharebest\Webtrees\I18N;
             <button type="button" class="btn btn-secondary wt-osk-shift-button" data-bs-toggle="button" aria-pressed="false">a &harr; A</button>
 
             <div class="btn-group" role="group">
-                <input id="wt-osk-bg-script-ltn" type="radio" class="btn-check wt-osk-script-button" checked data-wt-osk-script="latn">
+                <input id="wt-osk-bg-script-ltn" type="radio" class="btn-check wt-osk-script-button" checked data-wt-osk-script="latn" name="osk-script">
                 <label for="wt-osk-bg-script-ltn" class="btn btn-secondary m-0" dir="ltr">
                         Abcd
                 </label>
 
-                <input id="wt-osk-bg-script-cyrl" type="radio" class="btn-check wt-osk-script-button" data-wt-osk-script="cyrl">
+                <input id="wt-osk-bg-script-cyrl" type="radio" class="btn-check wt-osk-script-button" data-wt-osk-script="cyrl" name="osk-script">
                 <label for="wt-osk-bg-script-cyrl" class="btn btn-secondary m-0" dir="ltr">
                         &Acy;&bcy;&gcy;&dcy;
                 </label>
 
-                <input id="wt-osk-bg-script-grek" type="radio" class="btn-check wt-osk-script-button" data-wt-osk-script="grek">
+                <input id="wt-osk-bg-script-grek" type="radio" class="btn-check wt-osk-script-button" data-wt-osk-script="grek" name="osk-script">
                 <label for="wt-osk-bg-script-grek" class="btn btn-secondary m-0" dir="ltr">
                         &Alpha;&beta;&gamma;&delta;
                 </label>
 
-                <input id="wt-osk-bg-script-viet" type="radio" class="btn-check wt-osk-script-button" data-wt-osk-script="viet">
+                <input id="wt-osk-bg-script-viet" type="radio" class="btn-check wt-osk-script-button" data-wt-osk-script="viet" name="osk-script">
                 <label for="wt-osk-bg-script-viet" class="btn btn-secondary m-0" dir="ltr">
                         Ặềổự
                 </label>
 
-                <input id="wt-osk-bg-script-arab" type="radio" class="btn-check wt-osk-script-button" data-wt-osk-script="arab">
+                <input id="wt-osk-bg-script-arab" type="radio" class="btn-check wt-osk-script-button" data-wt-osk-script="arab" name="osk-script">
                 <label for="wt-osk-bg-script-arab" class="btn btn-secondary m-0" dir="rtl">
                         &#x627;&#x628;&#x629;&#x62a;
                 </label>
 
-                <input id="wt-osk-bg-script-hebr" type="radio" class="btn-check wt-osk-script-button" data-wt-osk-script="hebr">
+                <input id="wt-osk-bg-script-hebr" type="radio" class="btn-check wt-osk-script-button" data-wt-osk-script="hebr" name="osk-script">
                 <label for="wt-osk-bg-script-hebr" class="btn btn-secondary m-0" dir="rtl">
                         &#x5d0;&#x5d1;&#x5d2;&#x5d3;
                 </label>


### PR DESCRIPTION
I am not sure if there was a reason behind, but the `name` attribute was removed from the `input` list of scripts in the on-screen-keyboard, in commit d4786c66.
However, this attribute is used by bootstrap to toggle between the buttons. Without it, you can switch the button on, but the others are not unchecked, and you cannot use it anymore after.

This PR reinstates the `name` attribute.