### PR TITLE
French Relationships: fix placeholder in genitive form

### DIFF
--- a/app/Module/LanguageFrench.php
+++ b/app/Module/LanguageFrench.php
@@ -32,13 +32,13 @@ class LanguageFrench extends AbstractModule implements ModuleLanguageInterface
 
     protected const SYMMETRIC_COUSINS = [
         1 => [
-            'F' => ['cousine germaine', '$s de la cousine germaine'],
-            'M' => ['cousin germain', '$s du cousin germain'],
+            'F' => ['cousine germaine', '%s de la cousine germaine'],
+            'M' => ['cousin germain', '%s du cousin germain'],
             'U' => ['cousin germain', '%s du cousin germain' ]
         ],
         2 => [
-            'F' => ['cousine issue de germain', '$s de la cousine issue de germain'],
-            'M' => ['cousin issu de germain', '$s du cousin issu de germain'],
+            'F' => ['cousine issue de germain', '%s de la cousine issue de germain'],
+            'M' => ['cousin issu de germain', '%s du cousin issu de germain'],
             'U' => ['cousin issu de germain', '%s du cousin issu de germain' ]
         ]
     ];
@@ -241,12 +241,12 @@ class LanguageFrench extends AbstractModule implements ModuleLanguageInterface
             Relationship::fixed('beau-frère/belle-sœur', '%s du beau-frère/belle-sœur')->sibling()->spouse(),
             // Grandparents and above
             //"Trisaïeux" are an exception to the dynamic rule
-            Relationship::fixed('trisaïeule maternelle', '% de la trisaïeule maternelle')->mother()->parent()->parent()->mother(),
-            Relationship::fixed('trisaïeul maternel', '% du trisaïeul maternel')->mother()->parent()->parent()->father(),
-            Relationship::fixed('trisaïeule paternelle', '% de la trisaïeule paternelle')->father()->parent()->parent()->mother(),
-            Relationship::fixed('trisaïeul paternel', '% du trisaïeul paternel')->father()->parent()->parent()->father(),
-            Relationship::fixed('trisaïeule', '% de la trisaïeule')->parent()->parent()->parent()->mother(),
-            Relationship::fixed('trisaïeul', '% du trisaïeul')->parent()->parent()->parent()->father(),
+            Relationship::fixed('trisaïeule maternelle', '%s de la trisaïeule maternelle')->mother()->parent()->parent()->mother(),
+            Relationship::fixed('trisaïeul maternel', '%s du trisaïeul maternel')->mother()->parent()->parent()->father(),
+            Relationship::fixed('trisaïeule paternelle', '%s de la trisaïeule paternelle')->father()->parent()->parent()->mother(),
+            Relationship::fixed('trisaïeul paternel', '%s du trisaïeul paternel')->father()->parent()->parent()->father(),
+            Relationship::fixed('trisaïeule', '%s de la trisaïeule')->parent()->parent()->parent()->mother(),
+            Relationship::fixed('trisaïeul', '%s du trisaïeul')->parent()->parent()->parent()->father(),
             Relationship::dynamic(fn (int $n) => $firstCompound($n, 'grand-mère maternelle', 'de la '))->mother()->ancestor()->female(),
             Relationship::dynamic(fn (int $n) => $firstCompound($n, 'grand-père maternel', 'du '))->mother()->ancestor()->male(),
             Relationship::dynamic(fn (int $n) => $firstCompound($n, 'grand-parent maternel', 'du '))->mother()->ancestor(),

--- a/tests/feature/RelationshipNamesTest.php
+++ b/tests/feature/RelationshipNamesTest.php
@@ -321,6 +321,7 @@ class RelationshipNamesTest extends TestCase
             self::assertRelationship('épouse de l’arrière-petit-neveu', [$i24m, $f10, $i21f, $f9, $i18m, $f8, $i17f, $f7, $i11m, $f4m, $i12f], $fr);
             self::assertRelationship('conjoint de la petite-nièce', [$i24m, $f10, $i21f, $f9, $i18m, $f8, $i17f, $f7, $i16m], $fr);
             self::assertRelationship('conjointe du neveu', [$i24m, $f10, $i21f, $f9, $i18m, $f8, $i19f], $fr);
+            self::assertRelationships('cousine germaine du conjoint', 'conjointe du cousin germain', [$i19f, $f8, $i18m, $f9, $i21f, $f10, $i24m, $f11m, $i26f], $fr);
         }
 
         ///////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I have just noticed I had left invalid placeholders in some genitive forms (probably typo then too many copy/paste...), that the tests were not covering.

This should now be fixed, and an additional test covering one of those genitive forms (the other faulty ones are more difficult to test using the reference tree)