### PR TITLE
Over-ride some bootstrap code

### DIFF
--- a/resources/css/clouds.css
+++ b/resources/css/clouds.css
@@ -487,6 +487,7 @@ table {
     background: url(clouds/images/block-header-background.png);
     background-size: auto 100%;
     padding: 0.25rem 0.75rem;
+    border-bottom: 0;
 }
 
 .wt-block-header::before {


### PR DESCRIPTION
For the clouds & colors theme, blocks on the home page & my page have a small gap between the block header and the block content (most visible for some reason on the "On this day" block. 

The cause is bootstrap setting `border-bottom: 1px solid rgba(0,0,0,.125);`  on the card-header class. This PR over-rides that.