### PR TITLE
Fix validator signature for array method + unit tests

### DIFF
--- a/app/Validator.php
+++ b/app/Validator.php
@@ -135,10 +135,6 @@ class Validator
                 return null;
             }
 
-            if ($value === null) {
-                return null;
-            }
-
             throw new LogicException(__METHOD__ . ' does not accept ' . gettype($value));
         };
 
@@ -152,7 +148,7 @@ class Validator
     {
         $this->rules[] = static function ($value) {
             if (is_string($value)) {
-                if (preg_match('/^' . Gedcom::REGEX_XREF . '$/', $value)) {
+                if (preg_match('/^' . Gedcom::REGEX_XREF . '$/', $value) === 1) {
                     return $value;
                 }
 
@@ -161,7 +157,7 @@ class Validator
 
             if (is_array($value)) {
                 foreach ($value as $item) {
-                    if (!preg_match('/^' . Gedcom::REGEX_XREF . '$/', $item)) {
+                    if (preg_match('/^' . Gedcom::REGEX_XREF . '$/', $item) !== 1) {
                         return null;
                     }
                 }
@@ -182,9 +178,9 @@ class Validator
     /**
      * @param string $parameter
      *
-     * @return array<string>
+     * @return array<string>|null
      */
-    public function array(string $parameter): array
+    public function array(string $parameter): ?array
     {
         $value = $this->parameters[$parameter] ?? null;
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2005,16 +2005,6 @@ parameters:
 			path: app/SurnameTradition/PatrilinealSurnameTradition.php
 
 		-
-			message: "#^Strict comparison using \\=\\=\\= between mixed and null will always evaluate to false\\.$#"
-			count: 1
-			path: app/Validator.php
-
-		-
-			message: "#^Unreachable statement \\- code above always terminates\\.$#"
-			count: 1
-			path: app/Validator.php
-
-		-
 			message: "#^Ternary operator condition is always true\\.$#"
 			count: 1
 			path: app/Webtrees.php

--- a/tests/app/ValidatorTest.php
+++ b/tests/app/ValidatorTest.php
@@ -1,0 +1,210 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2021 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Fisharebest\Webtrees;
+
+use Fisharebest\Webtrees\Http\Exceptions\HttpBadRequestException;
+use LogicException;
+
+/**
+ * Test harness for the class Validator
+ */
+class ValidatorTest extends TestCase
+{
+    /**
+     * @covers \Fisharebest\Webtrees\Validator::array
+     */
+    public function testArrayParameter(): void
+    {
+        $parameters = ['param' => ['test'], 'invalid' => 'not_array'];
+        $validator = new Validator($parameters);
+
+        self::assertSame(['test'], $validator->array('param'));
+        self::assertNull($validator->array('invalid'));
+        self::assertNull($validator->array('param2'));
+    }
+
+    /**
+     * @covers \Fisharebest\Webtrees\Validator::integer
+     */
+    public function testIntegerParameter(): void
+    {
+        $parameters = ['param' => '42', 'invalid' => 'not_int', 'integer' => 42];
+        $validator = new Validator($parameters);
+
+        self::assertSame(42, $validator->integer('param'));
+        self::assertNull($validator->integer('invalid'));
+        self::assertNull($validator->integer('integer'));
+        self::assertNull($validator->integer('param2'));
+    }
+
+    /**
+     * @covers \Fisharebest\Webtrees\Validator::string
+     */
+    public function testStringParameter(): void
+    {
+        $parameters = ['param' => 'test', 'invalid' => ['not_string']];
+        $validator = new Validator($parameters);
+
+        self::assertSame('test', $validator->string('param'));
+        self::assertNull($validator->string('invalid'));
+        self::assertNull($validator->string('param2'));
+    }
+
+    /**
+     * @covers \Fisharebest\Webtrees\Validator::requiredArray
+     */
+    public function testRequiredArrayParameter(): void
+    {
+        $parameters = ['param' => ['test'], 'invalid' => 'not_array'];
+        $validator = new Validator($parameters);
+
+        self::assertSame(['test'], $validator->requiredArray('param'));
+
+        $this->expectException(HttpBadRequestException::class);
+        $validator->requiredArray('invalid');
+    }
+
+    /**
+     * @covers \Fisharebest\Webtrees\Validator::requiredInteger
+     */
+    public function testRequiredIntegerParameter(): void
+    {
+        $parameters = ['param' => '42', 'invalid' => 'not_int'];
+        $validator = new Validator($parameters);
+
+        self::assertSame(42, $validator->requiredInteger('param'));
+
+        $this->expectException(HttpBadRequestException::class);
+        $validator->requiredInteger('invalid');
+    }
+
+    /**
+     * @covers \Fisharebest\Webtrees\Validator::requiredString
+     */
+    public function testRequiredStringParameter(): void
+    {
+        $parameters = ['param' => 'test', 'invalid' => ['not_string']];
+        $validator = new Validator($parameters);
+
+        self::assertSame('test', $validator->requiredString('param'));
+
+        $this->expectException(HttpBadRequestException::class);
+        $validator->requiredString('invalid');
+    }
+
+    /**
+     * @covers \Fisharebest\Webtrees\Validator::isBetween
+     */
+    public function testIsBetweenParameter(): void
+    {
+        $parameters = ['param' => '42', 'invalid' => '10', 'wrongtype' => 'not_integer'];
+        $validator = (new Validator($parameters))->isBetween(40, 45);
+
+        self::assertSame(42, $validator->integer('param'));
+        self::assertNull($validator->integer('invalid'));
+        self::assertNull($validator->integer('wrongtype'));
+
+        $this->expectException(LogicException::class);
+        $validator->string('wrongtype');
+    }
+
+    /**
+     * @covers \Fisharebest\Webtrees\Validator::isXref
+     */
+    public function testIsXrefParameter(): void
+    {
+        $parameters = [
+            'param' => 'X1',
+            'param2' => ['X2', 'X3'],
+            'invalid' => '@X1@',
+            'invalid2' => ['X2', '#X4!'],
+            'wrongtype' => '42'
+        ];
+        $validator = (new Validator($parameters))->isXref();
+
+        self::assertSame('X1', $validator->string('param'));
+        self::assertSame(['X2', 'X3'], $validator->array('param2'));
+        self::assertNull($validator->string('param2'));
+        self::assertNull($validator->string('invalid'));
+        self::assertNull($validator->array('invalid2'));
+
+        $this->expectException(LogicException::class);
+        $validator->integer('wrongtype');
+    }
+
+    /**
+     * @covers \Fisharebest\Webtrees\Validator::isLocalUrl
+     */
+    public function testIsLocalUrlParameter(): void
+    {
+        $parameters = [
+            'param' => 'http://example.local/wt/page',
+            'noscheme' => '//example.local/wt/page',
+            'https' => 'https://example.local/wt/page',
+            'invalid' => 'http://example.com/wt/page',
+            'wrongtype' => '42'
+        ];
+        $validator = (new Validator($parameters))->isLocalUrl('http://example.local/wt');
+
+        self::assertSame('http://example.local/wt/page', $validator->string('param'));
+        self::assertSame('//example.local/wt/page', $validator->string('noscheme'));
+        self::assertNull($validator->string('https'));
+        self::assertNull($validator->string('invalid'));
+        self::assertNull($validator->integer('param'));
+
+        $this->expectException(LogicException::class);
+        $validator->integer('wrongtype');
+    }
+
+    /**
+     * @covers \Fisharebest\Webtrees\Validator::isLocalUrl
+     */
+    public function testIsLocalUrlWithInvalidBaseUrl(): void
+    {
+        $this->expectException(LogicException::class);
+        (new Validator(['param' => 'test']))->isLocalUrl('http://:invalid.url/')->string('param');
+    }
+
+    /**
+     * @covers \Fisharebest\Webtrees\Validator::__construct
+     * @covers \Fisharebest\Webtrees\Validator::parsedBody
+     */
+    public function testParsedBody(): void
+    {
+        $request = self::createRequest()->withQueryParams(['param' => 'test']);
+        self::assertNull(Validator::parsedBody($request)->string('param'));
+
+        $request = self::createRequest()->withParsedBody(['param' => 'test']);
+        self::assertSame('test', Validator::parsedBody($request)->string('param'));
+    }
+
+    /**
+     * @covers \Fisharebest\Webtrees\Validator::__construct
+     * @covers \Fisharebest\Webtrees\Validator::queryParams
+     */
+    public function testQueryParams(): void
+    {
+        $request = self::createRequest()->withParsedBody(['param' => 'test']);
+        self::assertNull(Validator::queryParams($request)->string('param'));
+
+        $request = self::createRequest()->withQueryParams(['param' => 'test']);
+        self::assertSame('test', Validator::queryParams($request)->string('param'));
+    }
+}


### PR DESCRIPTION
While trying to use the new Validator class in my module, one of the code analysis tool (Psalm - phpstan was not detecting it) made me realised that `Validator::array` had an inconsistent signature with its implementation, as it does not cater for the `null` value being on of the valid output.

I added the nullability on the return type and the documentation, as well as the unit tests for that class.
