### PR TITLE
Funeral = Jordfästning, not Begravning

### DIFF
--- a/resources/lang/sv/messages.po
+++ b/resources/lang/sv/messages.po
@@ -6862,7 +6862,7 @@ msgstr "Fukuoka, Japan"
 #: app/Module/CustomTagsBrothersKeeper.php:99
 #: app/Module/CustomTagsPhpGedView.php:65
 msgid "Funeral"
-msgstr "Begravning"
+msgstr "Jordfästning"
 
 #: app/Factories/ElementFactory.php:379
 msgid "GEDCOM"


### PR DESCRIPTION
Made an significant language change.
Begravning = the act of putting the person in the grave, burial.
Jordfästning = the cermony before the burial, funeral

https://blogg.vett-och-etikett.com/begravning-vad-ar-skillnaderna-mellan-jordfastning-och-begravning/