### PR TITLE
Toggle first line of collapsible notes

### DIFF
--- a/app/Functions/FunctionsPrint.php
+++ b/app/Functions/FunctionsPrint.php
@@ -99,32 +99,17 @@ class FunctionsPrint
             $one_line_only = !str_contains($text, "\n") && mb_strlen($text) <= 100;
         }
 
-        if ($one_line_only) {
-            return
-                '<div class="fact_NOTE">' .
-                I18N::translate(
-                    '<span class="label">%1$s:</span> <span class="field" dir="auto">%2$s</span>',
-                    $label,
-                    $first_line
-                ) .
-                '</div>';
-        }
-
         $id       = 'collapse-' . Uuid::uuid4()->toString();
         $expanded = (bool) $tree->getPreference('EXPAND_NOTES');
 
-        return
-            '<div class="fact_NOTE">' .
-            '<a href="#' . e($id) . '" role="button" data-bs-toggle="collapse" aria-controls="' . e($id) . '" aria-expanded="' . ($expanded ? 'true' : 'false') . '">' .
-            view('icons/expand') .
-            view('icons/collapse') .
-            '</a>' .
-            '<span class="label">' . $label . ':</span> ' .
-            $first_line .
-            '</div>' .
-            '<div id="' . e($id) . '" class="collapse ' . ($expanded ? 'show' : '') . '">' .
-            $html .
-            '</div>';
+        return view('note', [
+            'label'         => $label,
+            'first_line'    => $first_line,
+            'one_line_only' => $one_line_only,
+            'id'            => $id,
+            'expanded'      => $expanded,
+            'html'          => $html,
+        ]);
     }
 
     /**

--- a/resources/js/webtrees.js
+++ b/resources/js/webtrees.js
@@ -835,3 +835,16 @@ document.addEventListener('click', (event) => {
     });
   }
 });
+
+// Hide Note title link when collapsible element is expanded
+const note_toggles = document.querySelectorAll(".note_toggle");
+note_toggles.forEach((element, index) => {
+  const collapsible = document.getElementById(element.id);
+  const first_line = document.querySelector(`span[data-id="${element.id}"]`);
+  collapsible.addEventListener('hidden.bs.collapse', () => {
+    first_line.classList.remove('d-none');
+  });
+  collapsible.addEventListener('show.bs.collapse', () => {
+    first_line.classList.add('d-none');
+  });
+});

--- a/resources/views/note.phtml
+++ b/resources/views/note.phtml
@@ -1,0 +1,36 @@
+<?php
+use Fisharebest\Webtrees\I18N;
+use Fisharebest\Webtrees\View;
+?>
+
+<?php if ($one_line_only): ?>
+  <div class="fact_NOTE">
+    <span class="label">
+      <?= I18N::translate($label) ?>
+    </span>
+    <span class="field" dir="auto">
+      <?= $first_line ?>
+    </span>
+  </div>
+<?php else: ?>
+  <div class="fact_NOTE">
+    <a
+      href="#<?= e($id) ?>"
+      role="button"
+      data-bs-toggle="collapse"
+      aria-controls="<?= e($id) ?>"
+      aria-expanded="<?= ($expanded ? 'true' : 'false') ?>">
+      <?= view('icons/expand') ?>
+      <?= view('icons/collapse') ?>
+    </a>
+    <span class="label">
+      <?= $label ?>:
+    </span>
+    <span data-id="<?= e($id) ?>">
+      <?= $first_line ?>
+    </span>
+  </div>
+  <div id="<?= e($id) ?>" class="note_toggle collapse <?= ($expanded ? 'show' : '')  ?>">
+    <?= $html ?>
+  </div>
+<?php endif; ?>


### PR DESCRIPTION
Hides the first line of multi line notes when the body of the note is expanded.

To achieve this
- Shifted HTML from app\Functions\FunctionsPrint::printNoteRecord() to a view (solely to make it easier to modify)
- Added a small amount of javascript to webtrees.js. I'd ideally like to add a bit of script to the view but it needs to be wrapped in a window.onload event and each successive run of the view overwrote the previous instance and I couldn't get around it.