### PR TITLE
Census assistant - Use markdown unordered lists for plain text census elements

### DIFF
--- a/app/Functions/FunctionsPrint.php
+++ b/app/Functions/FunctionsPrint.php
@@ -122,7 +122,7 @@ class FunctionsPrint
             '<span class="label">' . $label . ':</span> ' .
             $first_line .
             '</div>' .
-            '<div id="' . e($id) . '" class="collapse ' . ($expanded ? 'show' : '') . '">' .
+            '<div id="' . e($id) . '" class="markdown collapse ' . ($expanded ? 'show' : '') . '">' .
             $html .
             '</div>';
     }

--- a/app/Note.php
+++ b/app/Note.php
@@ -97,7 +97,7 @@ class Note extends GedcomRecord
 
 
         // Take the first line
-        [$text] = explode("\n", strip_tags(trim($text)));
+        [$text] = explode("\n", trim(strip_tags($text), "+ \n\r\t\v\0"));
 
 
         if ($text !== '') {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1731,32 +1731,12 @@ parameters:
 			path: app/Module/BranchesListModule.php
 
 		-
-			message: "#^Call to an undefined method object\\:\\:censusLanguage\\(\\)\\.$#"
-			count: 1
-			path: app/Module/CensusAssistantModule.php
-
-		-
 			message: "#^Cannot call method updateFact\\(\\) on Fisharebest\\\\Webtrees\\\\Individual\\|null\\.$#"
 			count: 1
 			path: app/Module/CensusAssistantModule.php
 
 		-
-			message: "#^Parameter \\#1 \\$census of method Fisharebest\\\\Webtrees\\\\Module\\\\CensusAssistantModule\\:\\:censusTableEmptyRow\\(\\) expects Fisharebest\\\\Webtrees\\\\Census\\\\CensusInterface, object given\\.$#"
-			count: 1
-			path: app/Module/CensusAssistantModule.php
-
-		-
 			message: "#^Parameter \\#1 \\$census of method Fisharebest\\\\Webtrees\\\\Module\\\\CensusAssistantModule\\:\\:censusTableHeader\\(\\) expects Fisharebest\\\\Webtrees\\\\Census\\\\CensusInterface, object given\\.$#"
-			count: 1
-			path: app/Module/CensusAssistantModule.php
-
-		-
-			message: "#^Parameter \\#1 \\$census of method Fisharebest\\\\Webtrees\\\\Module\\\\CensusAssistantModule\\:\\:censusTableRow\\(\\) expects Fisharebest\\\\Webtrees\\\\Census\\\\CensusInterface, object given\\.$#"
-			count: 1
-			path: app/Module/CensusAssistantModule.php
-
-		-
-			message: "#^Parameter \\#1 \\$census of method Fisharebest\\\\Webtrees\\\\Module\\\\CensusAssistantModule\\:\\:createNoteText\\(\\) expects Fisharebest\\\\Webtrees\\\\Census\\\\CensusInterface, object given\\.$#"
 			count: 1
 			path: app/Module/CensusAssistantModule.php
 
@@ -4148,4 +4128,3 @@ parameters:
 			message: "#^Ternary operator condition is always true\\.$#"
 			count: 1
 			path: app/Webtrees.php
-

--- a/resources/css/_markdown.css
+++ b/resources/css/_markdown.css
@@ -44,3 +44,14 @@
     max-width: 100%;
     height: auto;
 }
+
+.markdown .table-responsive {
+    margin-top: 0.75rem;
+    margin-bottom: 0.4rem;
+}
+
+.markdown ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+}


### PR DESCRIPTION
Rather than use markdown paragraph or line breaks, convert plain text paragraphs into an unordered list that can be styled by css