### PR TITLE
Format notes on display rather than by adding formatting on creation. 

### DIFF
--- a/app/Functions/FunctionsPrintFacts.php
+++ b/app/Functions/FunctionsPrintFacts.php
@@ -792,17 +792,19 @@ class FunctionsPrintFacts
                 echo '</div>';
             }
             echo '</th>';
-            if ($note instanceof Note) {
-                $text = $note->getNote();
-            } else {
+
+            if (!$note instanceof Note) {
                 $nrec = Functions::getSubRecord($level, "$level NOTE", $factrec, $j + 1);
                 $text = $match[$j][1] . Functions::getCont($level + 1, $nrec);
+                $text = preg_replace(["/\d (NOTE|CON[C,T]) ?/", "/\r?\n/"], ["", "\n1 CONT "], $text);
+                assert(is_string($text));
+                $note = Registry::noteFactory()->new('', '0 @_@ NOTE ' . $text, null, $tree);
             }
 
             $element = new SubmitterText('');
 
             echo '<td class="', $styleadd, ' wrap">';
-            echo $element->value($text, $tree);
+            echo $element->value($note->getHtml(), $tree);
             echo '</td></tr>';
         }
     }

--- a/app/Http/RequestHandlers/ManageMediaData.php
+++ b/app/Http/RequestHandlers/ManageMediaData.php
@@ -276,7 +276,7 @@ class ManageMediaData implements RequestHandlerInterface
      */
     private function mediaObjectInfo(Media $media): string
     {
-        $html = '<b><a href="' . e($media->url()) . '">' . $media->fullName() . '</a></b>' . '<br><i>' . e($media->getNote()) . '</i></br><br>';
+        $html = '<b><a href="' . e($media->url()) . '">' . $media->fullName() . '</a></b>' . $media->getNote();
 
         $linked = [];
         foreach ($media->linkedIndividuals('OBJE') as $link) {

--- a/app/Media.php
+++ b/app/Media.php
@@ -97,12 +97,12 @@ class Media extends GedcomRecord
         if ($fact instanceof Fact) {
             // Link to note object
             $note = $fact->target();
-            if ($note instanceof Note) {
-                return $note->getNote();
+            if (!$note instanceof Note) {
+                // Inline note
+                $nrec = '0 @_@ NOTE ' . preg_replace(["/\d (NOTE|CON[C,T]) ?/", "/\r?\n/"], ["", "\n1 CONT "], $fact->value());
+                $note = Registry::noteFactory()->new('', $nrec, null, $this->tree());
             }
-
-            // Inline note
-            return $fact->value();
+            return $note->getHtml();
         }
 
         return '';

--- a/app/Module/CensusAssistantModule.php
+++ b/app/Module/CensusAssistantModule.php
@@ -178,13 +178,11 @@ class CensusAssistantModule extends AbstractModule
         $text = $ca_title;
 
         if ($ca_citation !== '') {
-            // Two trailing spaces create a line-break in markdown
-            $text .= "  \n" . $ca_citation;
+            $text .= "\n" . $ca_citation;
         }
 
         if ($ca_place !== '') {
-            // Two trailing spaces create a line-break in markdown
-            $text .= "  \n" . $ca_place;
+            $text .= "\n" . $ca_place;
         }
 
         $text .= "\n\n|";

--- a/resources/views/note-page-details.phtml
+++ b/resources/views/note-page-details.phtml
@@ -33,15 +33,7 @@ use Illuminate\Support\Collection;
             <?php endif ?>
         </th>
         <td>
-            <?php if ($record->tree()->getPreference('FORMAT_TEXT') === 'markdown') : ?>
-                <div class="markdown" dir="auto">
-                    <?= Registry::markdownFactory()->markdown($record->tree())->convertToHtml($record->getNote()) ?>
-                </div>
-            <?php else : ?>
-                <div class="markdown" dir="auto" style="white-space: pre-wrap;">
-                    <?= Registry::markdownFactory()->autolink($record->tree())->convertToHtml($record->getNote()) ?>
-                </div>
-            <?php endif ?>
+          <?= $record->getHtml() ?>
         </td>
     </tr>
 

--- a/resources/views/note.phtml
+++ b/resources/views/note.phtml
@@ -1,0 +1,36 @@
+<?php
+use Fisharebest\Webtrees\I18N;
+use Fisharebest\Webtrees\View;
+?>
+
+<?php if ($one_line_only): ?>
+  <div class="fact_NOTE">
+    <span class="label">
+      <?= I18N::translate($label) ?>
+    </span>
+    <span dir="auto">
+      <?= $title ?>
+    </span>
+  </div>
+<?php else: ?>
+  <div class="fact_NOTE">
+    <a
+      href="#<?= e($id) ?>"
+      role="button"
+      data-bs-toggle="collapse"
+      aria-controls="<?= e($id) ?>"
+      aria-expanded="<?= ($expanded ? 'true' : 'false') ?>">
+      <?= view('icons/expand') ?>
+      <?= view('icons/collapse') ?>
+    </a>
+    <span class="label">
+      <?= $label ?>:
+    </span>
+    <span dir = "auto" data-id="<?= e($id) ?>">
+      <?= $title ?>
+    </span>
+  </div>
+  <div id="<?= e($id) ?>" class="collapse <?= $expanded ?>">
+      <?= $content ?>
+  </div>
+<?php endif; ?>


### PR DESCRIPTION
Solves issue https://github.com/fisharebest/webtrees/issues/4123 (I think)

To achieve this:

- Recent changes to the census assistant have been reverted (this obviates the need for retrospective changes to existing notes)
- Add a new function getHtml() to app\Note.php which returns html formatted according to the tree FORMAT_TEXT preference. **Note** this is a potentially breaking change as the FORMAT_TEXT preference is strictly applied, currently any note containing markdown table formatting is always interpreted as markdown. However it is simple to revert to the current behaviour (see the comment in app\Note.php line 71)

Because the formatting code is in the Note class, it is necessary to convert in-line notes into temporary dummy note objects so the same code can be used for all notes.

- Non-markdown formatting just nl2br's the text.
- For markdown formatting, the new function works by splitting the text into paragraphs (split on "\n" char, tables are treated as a single paragraph) and applying formatting to each paragraph independently and then joining the bits back together. This means that each text paragraph is wrapped in `<p></p>` and tables are wrapped in `<div></div>` which allows styling if needed.

**Note**: some changes have involved classes FunctionsPrint & FunctionsPrintFact that have been slated for removal in 2.1