### PR TITLE
Format markdown text on display

### DIFF
--- a/app/Elements/AbstractElement.php
+++ b/app/Elements/AbstractElement.php
@@ -346,7 +346,9 @@ abstract class AbstractElement implements ElementInterface
         $format = $tree->getPreference('FORMAT_TEXT');
 
         if ($format === 'markdown') {
-            $html = Registry::markdownFactory()->markdown($tree)->convertToHtml($canonical);
+            // Two trailing spaces create a line-break in markdown
+            $html = strtr($canonical, ["\n" => "  \n"]);
+            $html = Registry::markdownFactory()->markdown($tree)->convertToHtml($html);
 
             return '<div class="markdown" dir="auto">' . $html . '</div>';
         }

--- a/app/Functions/FunctionsPrint.php
+++ b/app/Functions/FunctionsPrint.php
@@ -22,6 +22,7 @@ namespace Fisharebest\Webtrees\Functions;
 use Fisharebest\Webtrees\Age;
 use Fisharebest\Webtrees\Auth;
 use Fisharebest\Webtrees\Date;
+use Fisharebest\Webtrees\Elements\SubmitterText;
 use Fisharebest\Webtrees\Fact;
 use Fisharebest\Webtrees\Family;
 use Fisharebest\Webtrees\Gedcom;
@@ -75,6 +76,7 @@ class FunctionsPrint
     private static function printNoteRecord(Tree $tree, string $text, int $nlevel, string $nrec): string
     {
         $text .= Functions::getCont($nlevel, $nrec);
+        $element = new SubmitterText('');
 
         if (preg_match('/^0 @(' . Gedcom::REGEX_XREF . ')@ NOTE/', $nrec, $match)) {
             // Shared note.
@@ -83,14 +85,14 @@ class FunctionsPrint
             assert($note instanceof Note);
 
             $label      = I18N::translate('Shared note');
-            $html       = Registry::markdownFactory()->markdown($tree)->convertToHtml($note->getNote());
+            $html       = $element->value($note->getNote(), $tree);
             $first_line = '<a href="' . e($note->url()) . '">' . $note->fullName() . '</a>';
 
             $one_line_only = strip_tags($note->fullName()) === strip_tags($note->getNote());
         } else {
             // Inline note.
             $label = I18N::translate('Note');
-            $html  = Registry::markdownFactory()->markdown($tree)->convertToHtml($text);
+            $html  = $element->value($text, $tree);
 
             [$first_line] = explode("\n", strip_tags($html));
             // Use same logic as note objects

--- a/app/Http/RequestHandlers/ManageMediaData.php
+++ b/app/Http/RequestHandlers/ManageMediaData.php
@@ -276,7 +276,7 @@ class ManageMediaData implements RequestHandlerInterface
      */
     private function mediaObjectInfo(Media $media): string
     {
-        $html = '<b><a href="' . e($media->url()) . '">' . $media->fullName() . '</a></b>' . '<br><i>' . e($media->getNote()) . '</i></br><br>';
+        $html = '<b><a href="' . e($media->url()) . '">' . $media->fullName() . '</a></b>' . $media->getNote();
 
         $linked = [];
         foreach ($media->linkedIndividuals('OBJE') as $link) {

--- a/app/Http/RequestHandlers/NotePage.php
+++ b/app/Http/RequestHandlers/NotePage.php
@@ -21,6 +21,7 @@ namespace Fisharebest\Webtrees\Http\RequestHandlers;
 
 use Fig\Http\Message\StatusCodeInterface;
 use Fisharebest\Webtrees\Auth;
+use Fisharebest\Webtrees\Elements\SubmitterText;
 use Fisharebest\Webtrees\Http\ViewResponseTrait;
 use Fisharebest\Webtrees\Registry;
 use Fisharebest\Webtrees\Services\ClipboardService;
@@ -86,6 +87,7 @@ class NotePage implements RequestHandlerInterface
             'record'               => $record,
             'title'                => $record->fullName(),
             'tree'                 => $tree,
+            'element'              => new SubmitterText(''),
         ]);
     }
 }

--- a/app/Media.php
+++ b/app/Media.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace Fisharebest\Webtrees;
 
+use Fisharebest\Webtrees\Elements\SubmitterText;
 use Fisharebest\Webtrees\Functions\FunctionsPrintFacts;
 use Fisharebest\Webtrees\Http\RequestHandlers\MediaPage;
 use Illuminate\Database\Capsule\Manager as DB;
@@ -93,16 +94,17 @@ class Media extends GedcomRecord
     public function getNote(): string
     {
         $fact = $this->facts(['NOTE'])->first();
+        $element = new SubmitterText('');
 
         if ($fact instanceof Fact) {
             // Link to note object
             $note = $fact->target();
             if ($note instanceof Note) {
-                return $note->getNote();
+                return $element->value($note->getnote(), $this->tree);
             }
 
             // Inline note
-            return $fact->value();
+            return $element->value($fact->value(), $this->tree);
         }
 
         return '';

--- a/app/Module/CensusAssistantModule.php
+++ b/app/Module/CensusAssistantModule.php
@@ -178,13 +178,11 @@ class CensusAssistantModule extends AbstractModule
         $text = $ca_title;
 
         if ($ca_citation !== '') {
-            // Two trailing spaces create a line-break in markdown
-            $text .= "  \n" . $ca_citation;
+            $text .= "\n" . $ca_citation;
         }
 
         if ($ca_place !== '') {
-            // Two trailing spaces create a line-break in markdown
-            $text .= "  \n" . $ca_place;
+            $text .= "\n" . $ca_place;
         }
 
         $text .= "\n\n|";

--- a/resources/views/note-page-details.phtml
+++ b/resources/views/note-page-details.phtml
@@ -33,15 +33,7 @@ use Illuminate\Support\Collection;
             <?php endif ?>
         </th>
         <td>
-            <?php if ($record->tree()->getPreference('FORMAT_TEXT') === 'markdown') : ?>
-                <div class="markdown" dir="auto">
-                    <?= Registry::markdownFactory()->markdown($record->tree())->convertToHtml($record->getNote()) ?>
-                </div>
-            <?php else : ?>
-                <div class="markdown" dir="auto" style="white-space: pre-wrap;">
-                    <?= Registry::markdownFactory()->autolink($record->tree())->convertToHtml($record->getNote()) ?>
-                </div>
-            <?php endif ?>
+          <?= $element->value($record->getNote(), $record->tree()) ?>
         </td>
     </tr>
 

--- a/resources/views/note-page.phtml
+++ b/resources/views/note-page.phtml
@@ -34,7 +34,7 @@ use Illuminate\Support\Collection;
 
 <div class="wt-page-content">
     <?= view('record-page-links', [
-        'details'              => view('note-page-details', ['clipboard_facts' => $clipboard_facts, 'record' => $record]),
+        'details'              => view('note-page-details', ['clipboard_facts' => $clipboard_facts, 'record' => $record, 'element' => $element]),
         'linked_families'      => $linked_families,
         'linked_individuals'   => $linked_individuals,
         'linked_media_objects' => $linked_media_objects,


### PR DESCRIPTION
Better (and simpler) attempt at solving issue https://github.com/fisharebest/webtrees/issues/4123

To achieve this:

- Recent changes to the census assistant have been reverted (this obviates the need for retrospective changes to existing notes)
- Added two trailing spaces to html in `abstractElement::valueFormatted()`
- Whenever some formatted text is needed used code similar to this
```
$element = new SubmitterText('');
$formatted = $element->value($text, $tree);
```