### PR TITLE
shift resetControl to webtrees.js

### DIFF
--- a/resources/js/webtrees.js
+++ b/resources/js/webtrees.js
@@ -622,12 +622,36 @@
    * Create a LeafletJS map from a list of providers/layers.
    * @param {string} id
    * @param {object} config
+   * @param {requestCallback} resetActions
    * @returns Map
    */
-  webtrees.buildLeafletJsMap = function (id, config) {
+  webtrees.buildLeafletJsMap = function (id, config, resetActions) {
     const zoomControl = new L.control.zoom({
       zoomInTitle: config.i18n.zoomIn,
       zoomoutTitle: config.i18n.zoomOut,
+    });
+
+    const resetControl = L.Control.extend({
+      options: {
+        position: 'topleft',
+      },
+      onAdd: function (map) {
+        let container = L.DomUtil.create('div', 'leaflet-bar leaflet-control leaflet-control-custom');
+        container.onclick = function () {
+
+          return resetActions();
+        };
+        let reset = config.i18n.reset;
+        let anchor = L.DomUtil.create('a', 'leaflet-control-reset', container);
+        anchor.setAttribute('aria-label', reset);
+        anchor.href = '#';
+        anchor.title = reset;
+        anchor.role = 'button';
+        let image = L.DomUtil.create('i', 'fas fa-redo', anchor);
+        image.alt = reset;
+
+        return container;
+      },
     });
 
     let defaultLayer = null;
@@ -656,6 +680,7 @@
       zoomControl: false,
     })
       .addControl(zoomControl)
+      .addControl(new resetControl())
       .addLayer(defaultLayer)
       .addControl(L.control.layers.tree(config.mapProviders, null, {
         closedSymbol: config.icons.expand,

--- a/resources/views/admin/location-edit.phtml
+++ b/resources/views/admin/location-edit.phtml
@@ -111,31 +111,17 @@ use Fisharebest\Webtrees\View;
                 $('#new_place_long').val(Number(coords.lng).toFixed(5));
             });
 
-        //reset map to initial state
-        let resetControl = L.Control.extend({
-            options: {
-                position: 'topleft'
-            },
-            onAdd: function (map) {
-                let container = L.DomUtil.create('div', 'leaflet-bar leaflet-control leaflet-control-custom');
-                container.onclick = function () {
-                    map.fitBounds(<?= json_encode($map_bounds, JSON_THROW_ON_ERROR) ?>, {padding: [50, 30]});
-                    marker.setLatLng(<?= json_encode([$location->latitude(), $location->longitude()], JSON_THROW_ON_ERROR) ?>);
-                    $('form').trigger('reset');
-                    return false;
-                };
-                let reset = config.i18n.reset;
-                let anchor = L.DomUtil.create('a', 'leaflet-control-reset', container);
-                anchor.setAttribute('aria-label', reset);
-                anchor.href = '#';
-                anchor.title = reset;
-                anchor.role = 'button';
-                let image = L.DomUtil.create('i', 'fas fa-redo', anchor);
-                image.alt = reset;
+        /**
+         * Passed to resetControl to
+         * perform necessary reset actions on map
+         */
+        let resetFunction = function () {
+          map.fitBounds(<?= json_encode($map_bounds, JSON_THROW_ON_ERROR) ?>, {padding: [50, 30]});
+          marker.setLatLng(<?= json_encode([$location->latitude(), $location->longitude()], JSON_THROW_ON_ERROR) ?>);
+          $('form').trigger('reset');
 
-                return container;
-            }
-        });
+          return false;
+        }
 
         // Geocoder (place lookup)
         let geocoder = new L.Control.geocoder({
@@ -176,8 +162,7 @@ use Fisharebest\Webtrees\View;
             });
         });
 
-      const map = webtrees.buildLeafletJsMap('osm-map', config)
-            .addControl(new resetControl())
+      const map = webtrees.buildLeafletJsMap('osm-map', config, resetFunction)
             .addControl(geocoder)
             .addLayer(marker)
             .fitBounds(<?= json_encode($map_bounds, JSON_THROW_ON_ERROR) ?>, {padding: [50, 30]})

--- a/resources/views/modules/pedigree-map/chart.phtml
+++ b/resources/views/modules/pedigree-map/chart.phtml
@@ -47,37 +47,22 @@ use Fisharebest\Webtrees\View;
       showCoverageOnHover: false,
     });
 
-    let resetControl = L.Control.extend({
-      options: {
-        position: 'topleft',
-      },
-      onAdd: function (map) {
-        let container = L.DomUtil.create('div', 'leaflet-bar leaflet-control leaflet-control-custom');
-        container.onclick = function () {
-          map.flyToBounds(markers.getBounds(), { padding: [50, 30], maxZoom: 15 });
-          sidebar.scrollTo(sidebar.children(':first'));
+    /**
+     * Passed to resetControl to
+     * perform necessary reset actions on map
+     */
+    let resetFunction = function () {
+      map.flyToBounds(markers.getBounds(), {padding: [50, 30], maxZoom: 15 });
+      sidebar.scrollTo(sidebar.children(':first'));
 
-          return false;
-        };
-        let reset = config.i18n.reset;
-        let anchor = L.DomUtil.create('a', 'leaflet-control-reset', container);
-        anchor.setAttribute('aria-label', reset);
-        anchor.href = '#';
-        anchor.title = reset;
-        anchor.role = 'button';
-        let image = L.DomUtil.create('i', 'fas fa-redo', anchor);
-        image.alt = reset;
-
-        return container;
-      },
-    });
+      return false;
+    }
 
     /**
      * @private
      */
     let _drawMap = function () {
-      map = webtrees.buildLeafletJsMap('osm-map', config)
-        .addControl(new resetControl());
+      map = webtrees.buildLeafletJsMap('osm-map', config, resetFunction);
     };
 
     /**
@@ -149,7 +134,7 @@ use Fisharebest\Webtrees\View;
         .on('click', '.gchart', function (e) {
           // first close any existing
           map.closePopup();
-          let eventId = $(this).data('id');
+          let eventId = $(this).data('wt-feature-id');
           //find the marker corresponding to the clicked event
           let mkrLayer = markers.getLayers().filter(function (v) {
             return typeof (v.feature) !== 'undefined' && v.feature.id === eventId;

--- a/resources/views/modules/place-hierarchy/map.phtml
+++ b/resources/views/modules/place-hierarchy/map.phtml
@@ -52,37 +52,22 @@ use Fisharebest\Webtrees\View;
       showCoverageOnHover: false,
     });
 
-    let resetControl = L.Control.extend({
-      options: {
-        position: 'topleft',
-      },
+    /**
+     * Passed to resetControl to
+     * perform necessary reset actions on map
+     */
+    let resetFunction = function () {
+      map.flyToBounds(markers.getBounds(), {padding: [50, 30], maxZoom: 15 });
+      sidebar.scrollTo(sidebar.children(':first'));
 
-      onAdd: function (map) {
-        let container = L.DomUtil.create('div', 'leaflet-bar leaflet-control leaflet-control-custom');
-        container.onclick = function () {
-          map.flyToBounds(markers.getBounds(), { padding: [50, 30], maxZoom: 15 });
-          sidebar.scrollTo(sidebar.children(':first'));
-          return false;
-        };
-        let anchor = L.DomUtil.create('a', 'leaflet-control-reset', container);
-        let reset = config.i18n.reset;
-        anchor.setAttribute('aria-label', reset);
-        anchor.href = '#';
-        anchor.title = reset;
-        anchor.role = 'button';
-        let image = L.DomUtil.create('i', 'fas fa-redo', anchor);
-        image.alt = reset;
-
-        return container;
-      },
-    });
+      return false;
+    }
 
     /**
      * @private
      */
     let _drawMap = function () {
-      map = webtrees.buildLeafletJsMap('osm-map', config)
-        .addControl(new resetControl());
+      map = webtrees.buildLeafletJsMap('osm-map', config, resetFunction);
     };
 
     /**
@@ -148,7 +133,7 @@ use Fisharebest\Webtrees\View;
         .on('click', '.mapped', function (e) {
           // first close any existing
           map.closePopup();
-          let eventId = $(this).data('id');
+          let eventId = $(this).data('wt-feature-id');
           //find the marker corresponding to the clicked event
           let mkrLayer = markers.getLayers().filter(function (v) {
             return typeof (v.feature) !== 'undefined' && v.feature.id === eventId;

--- a/resources/views/modules/places/tab.phtml
+++ b/resources/views/modules/places/tab.phtml
@@ -42,38 +42,23 @@ use Fisharebest\Webtrees\I18N;
             showCoverageOnHover: false,
         });
 
-        let resetControl = L.Control.extend({
-            options: {
-                position: "topleft",
-            },
-            onAdd: function(map) {
-                let container = L.DomUtil.create("div", "leaflet-bar leaflet-control leaflet-control-custom");
-                container.onclick = function() {
-                    map.flyToBounds(markers.getBounds(), {padding: [50, 30], maxZoom: 15});
-                    sidebar.scrollTo(sidebar.children(":first"));
+        /**
+         * Passed to resetControl to
+         * perform necessary reset actions on map
+         */
+        let resetFunction = function () {
+          map.flyToBounds(markers.getBounds(), {padding: [50, 30], maxZoom: 15 });
+          sidebar.scrollTo(sidebar.children(':first'));
 
-                    return false;
-                };
-                let reset    = config.i18n.reset;
-                let anchor   = L.DomUtil.create('a', 'leaflet-control-reset', container);
-                anchor.setAttribute('aria-label', reset);
-                anchor.href  = '#';
-                anchor.title = reset;
-                anchor.role  = 'button';
-                let image    = L.DomUtil.create('i', 'fas fa-redo', anchor);
-                image.alt    = reset;
-
-                return container;
-            },
-        });
+          return false;
+        }
 
         /**
          *
          * @private
          */
         let _drawMap = function() {
-            map = webtrees.buildLeafletJsMap('osm-map', config)
-                .addControl(new resetControl());
+            map = webtrees.buildLeafletJsMap('osm-map', config, resetFunction);
         };
 
         /**
@@ -143,7 +128,7 @@ use Fisharebest\Webtrees\I18N;
             .on('click', '.gchart', function(e) {
                 // first close any existing
                 map.closePopup();
-                let eventId = $(this).data('id');
+                let eventId = $(this).data('wt-feature-id');
                 //find the marker corresponding to the clicked event
                 let mkrLayer = markers.getLayers().filter(function(v) {
                     return typeof(v.feature) !== 'undefined' && v.feature.id === eventId;


### PR DESCRIPTION
Avoid duplication of code.

resetControl existed in each map provider view, by moving to webtrees.buildLeafletJsMap() we remove that duplication although a small function (resetActions) that carries out the required reset actions for each individual view needs to be created and passed into webtrees.buildLeafletJsMap().