### PR TITLE
Places module - disable marker clustering on Click of sidebar entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "leaflet-control-geocoder": "2.3.0",
     "leaflet.control.layers.tree": "1.1.0",
     "leaflet.markercluster": "1.5.3",
+    "leaflet.markercluster.freezable": "1.0.0",
     "moment": "2.29.1",
     "pinch-zoom-element": "1.1.1",
     "sortablejs": "1.14.0",

--- a/resources/js/vendor.js
+++ b/resources/js/vendor.js
@@ -60,6 +60,7 @@ import 'pinch-zoom-element';
 
 import 'leaflet';
 import 'leaflet.markercluster';
+import 'leaflet.markercluster.freezable';
 import 'beautifymarker';
 import 'leaflet-control-geocoder';
 import 'leaflet.control.layers.tree';

--- a/resources/views/modules/places/tab.phtml
+++ b/resources/views/modules/places/tab.phtml
@@ -31,6 +31,9 @@ use Fisharebest\Webtrees\I18N;
       inline: "start"
     };
 
+    // 10 is a reasonable zoom level when displaying a marker (single point)
+    const popupZoomLevel = 10;
+
     // Map components
     let markers = L.markerClusterGroup({
         showCoverageOnHover: false,
@@ -101,9 +104,10 @@ use Fisharebest\Webtrees\I18N;
               item.classList.add('messagebox');
               item.scrollIntoView(scrollOptions);
             })
-            .on("popupclose", function() {
-              sidebar.childNodes.forEach(e => e.classList.remove('messagebox'));
+            .on("popupclose", function(x) {
+              sidebar.querySelector('.gchart.messagebox').classList.remove('messagebox');
               sidebar.firstElementChild.scrollIntoView(scrollOptions);
+              markers.enableClustering();
             });
           },
           onEachFeature: function(feature, layer) {
@@ -121,34 +125,34 @@ use Fisharebest\Webtrees\I18N;
     const _loadListeners = function() {
       // Activate marker popup when sidebar entry clicked
       sidebar.querySelectorAll('.gchart').forEach((element) => {
-        var eventId = parseInt(element.dataset.wtFeatureId);
+        const eventId = parseInt(element.dataset.wtFeatureId);
 
-        element.addEventListener('click', () => {
-          // first close any existing
-          map.closePopup();
-          //find the marker corresponding to the clicked event
-          let mkrLayer = markers.getLayers().filter(function (v) {
-            return v.feature !== undefined && v.feature.id === eventId;
-          });
+        element.addEventListener('mouseup', (evt) => {
+          // Only perform map action if evt was not initiated from an anchor element
+          if (evt.target.closest('a') === null) {
+            //find the marker corresponding to the clicked event
+            const mkrLayer = markers.getLayers().filter(function (v) {
+              return v.feature !== undefined && v.feature.id === eventId;
+            });
 
-          let mkr = mkrLayer.pop();
+            const mkr = mkrLayer.pop();
 
-          markers.zoomToShowLayer(mkr, function (e) {
-            mkr.openPopup();
-          });
-
-          return false;
-        });
-
-        // stop click on a person also opening the popup
-        element.querySelectorAll('a').forEach((el) => {
-          el.addEventListener('click', (e) => {
-            e.stopPropagation();
-          });
+            if (mkr instanceof L.Layer) {
+              map
+                .closePopup()
+                .flyTo(mkr.getLatLng(), popupZoomLevel, {animate: true, duration: 0.5})
+                .once('moveend', () => {
+                  markers.disableClustering();
+                  mkr.fire('click');
+                });
+            } else {
+              // Should never get here
+              console.log('Error: unable to find the selected marker');
+            }
+          }
         });
       });
     }
-
     _drawMap();
     _buildMapData();
     _loadListeners();


### PR DESCRIPTION
~~**EXPERIMENTAL - DO NOT COMMIT TO PRODUCTION**~~

I'd appreciate your opinion on this.

**I now think this is robust enough for production - provided you're happy with the concept**

It is only applied to the Places module and is built on the current code base.

It overcomes the problem where a number of facts are located at precisely the same location and consequently get clustered together (therefore the cluster bounds are a point) and clicking on one of those facts in the sidebar causes the map to zoom to the bounds of the cluster (effectively the map maxZoom level) - `markercluster.zoomToShowLayer()`) leaving you looking at a popup on a pretty much blank map (you may see a road if you're lucky)

This change introduces another module (written by the Markercluster author leaflet.markercluster.freezable - https://github.com/ghybs/Leaflet.MarkerCluster.Freezable) which allows us to disable clustering. The outcome is that on click, the clustered markers are unclustered but zooming is handles by external code.