### PR TITLE
shift resetControl to webtrees.js

### DIFF
--- a/resources/js/webtrees.js
+++ b/resources/js/webtrees.js
@@ -622,12 +622,36 @@
    * Create a LeafletJS map from a list of providers/layers.
    * @param {string} id
    * @param {object} config
+   * @param {requestCallback} resetActions
    * @returns Map
    */
-  webtrees.buildLeafletJsMap = function (id, config) {
+  webtrees.buildLeafletJsMap = function (id, config, resetActions) {
     const zoomControl = new L.control.zoom({
       zoomInTitle: config.i18n.zoomIn,
       zoomoutTitle: config.i18n.zoomOut,
+    });
+
+    const resetControl = L.Control.extend({
+      options: {
+        position: 'topleft',
+      },
+      onAdd: function (map) {
+        let container = L.DomUtil.create('div', 'leaflet-bar leaflet-control leaflet-control-custom');
+        container.onclick = function () {
+
+          return resetActions();
+        };
+        let reset = config.i18n.reset;
+        let anchor = L.DomUtil.create('a', 'leaflet-control-reset', container);
+        anchor.setAttribute('aria-label', reset);
+        anchor.href = '#';
+        anchor.title = reset;
+        anchor.role = 'button';
+        let image = L.DomUtil.create('i', 'fas fa-redo', anchor);
+        image.alt = reset;
+
+        return container;
+      },
     });
 
     let defaultLayer = null;
@@ -656,6 +680,7 @@
       zoomControl: false,
     })
       .addControl(zoomControl)
+      .addControl(new resetControl())
       .addLayer(defaultLayer)
       .addControl(L.control.layers.tree(config.mapProviders, null, {
         closedSymbol: config.icons.expand,

--- a/resources/views/admin/location-edit.phtml
+++ b/resources/views/admin/location-edit.phtml
@@ -101,32 +101,17 @@ use Fisharebest\Webtrees\View;
       new_place_long.value = Number(coords.lng).toFixed(5);
     });
 
-    //reset map to initial state
-    let resetControl = L.Control.extend({
-      options: {
-          position: 'topleft'
-      },
-      onAdd: function (map) {
-        let container = L.DomUtil.create('div', 'leaflet-bar leaflet-control leaflet-control-custom');
-        container.onclick = function () {
-          map.fitBounds(<?= json_encode($map_bounds, JSON_THROW_ON_ERROR) ?>, {padding: [50, 30]});
-          marker.setLatLng(<?= json_encode([$location->latitude(), $location->longitude()], JSON_THROW_ON_ERROR) ?>);
-          document.querySelector('form').reset();
+    /**
+     * Passed to resetControl to
+     * perform necessary reset actions on map
+     */
+     let resetActions = function () {
+      map.fitBounds(<?= json_encode($map_bounds, JSON_THROW_ON_ERROR) ?>, {padding: [50, 30]});
+      marker.setLatLng(<?= json_encode([$location->latitude(), $location->longitude()], JSON_THROW_ON_ERROR) ?>);
+      document.querySelector('form').reset();
 
-          return false;
-        };
-        let reset = config.i18n.reset;
-        let anchor = L.DomUtil.create('a', 'leaflet-control-reset', container);
-        anchor.setAttribute('aria-label', reset);
-        anchor.href = '#';
-        anchor.title = reset;
-        anchor.role = 'button';
-        let image = L.DomUtil.create('i', 'fas fa-redo', anchor);
-        image.alt = reset;
-
-        return container;
-      }
-    });
+      return false;
+    }
 
     // Geocoder (place lookup)
     let geocoder = new L.Control.geocoder({
@@ -151,8 +136,7 @@ use Fisharebest\Webtrees\View;
       new_place_long.value = Number(coords.lng).toFixed(5);
     });
 
-    const map = webtrees.buildLeafletJsMap('wt-map', config)
-      .addControl(new resetControl())
+    const map = webtrees.buildLeafletJsMap('wt-map', config, resetActions)
       .addControl(geocoder)
       .addLayer(marker)
       .fitBounds(<?= json_encode($map_bounds, JSON_THROW_ON_ERROR) ?>, {padding: [50, 30]})

--- a/resources/views/modules/pedigree-map/chart.phtml
+++ b/resources/views/modules/pedigree-map/chart.phtml
@@ -37,38 +37,23 @@ use Fisharebest\Webtrees\View;
       showCoverageOnHover: false,
     });
 
-    let resetControl = L.Control.extend({
-      options: {
-        position: 'topleft',
-      },
-      onAdd: function (map) {
-        let container = L.DomUtil.create('div', 'leaflet-bar leaflet-control leaflet-control-custom');
-        container.onclick = function () {
-          map.flyToBounds(markers.getBounds(), { padding: [50, 30], maxZoom: 15 });
-          sidebar.firstElementChild.scrollIntoView(scrollOptions);
+    /**
+     * Passed to resetControl to
+     * perform necessary reset actions on map
+     */
+     let resetActions = function () {
+      map.flyToBounds(markers.getBounds(), {padding: [50, 30], maxZoom: 15 });
+      sidebar.firstElementChild.scrollIntoView(scrollOptions);
 
-          return false;
-        };
-        let reset = config.i18n.reset;
-        let anchor = L.DomUtil.create('a', 'leaflet-control-reset', container);
-        anchor.setAttribute('aria-label', reset);
-        anchor.href = '#';
-        anchor.title = reset;
-        anchor.role = 'button';
-        let image = L.DomUtil.create('i', 'fas fa-redo', anchor);
-        image.alt = reset;
-
-        return container;
-      },
-    });
+      return false;
+    }
 
     /**
      *
      * @private
      */
     let _drawMap = function () {
-      map = webtrees.buildLeafletJsMap('wt-map', config)
-        .addControl(new resetControl());
+      map = webtrees.buildLeafletJsMap('wt-map', config, resetActions);
     };
 
     /**

--- a/resources/views/modules/place-hierarchy/map.phtml
+++ b/resources/views/modules/place-hierarchy/map.phtml
@@ -35,37 +35,22 @@ use Fisharebest\Webtrees\View;
       showCoverageOnHover: false,
     });
 
-    let resetControl = L.Control.extend({
-      options: {
-        position: 'topleft',
-      },
+    /**
+     * Passed to resetControl to
+     * perform necessary reset actions on map
+     */
+     let resetActions = function () {
+      map.flyToBounds(markers.getBounds(), {padding: [50, 30], maxZoom: 15 });
+      sidebar.firstElementChild.scrollIntoView(scrollOptions);
 
-      onAdd: function (map) {
-        let container = L.DomUtil.create('div', 'leaflet-bar leaflet-control leaflet-control-custom');
-        container.onclick = function () {
-          map.flyToBounds(markers.getBounds(), { padding: [50, 30], maxZoom: 15 });
-          sidebar.firstElementChild.scrollIntoView(scrollOptions);
-          return false;
-        };
-        let anchor = L.DomUtil.create('a', 'leaflet-control-reset', container);
-        let reset = config.i18n.reset;
-        anchor.setAttribute('aria-label', reset);
-        anchor.href = '#';
-        anchor.title = reset;
-        anchor.role = 'button';
-        let image = L.DomUtil.create('i', 'fas fa-redo', anchor);
-        image.alt = reset;
-
-        return container;
-      },
-    });
+      return false;
+    }
 
     /**
      * @private
      */
     let _drawMap = function () {
-      map = webtrees.buildLeafletJsMap('wt-map', config)
-        .addControl(new resetControl());
+      map = webtrees.buildLeafletJsMap('wt-map', config, resetActions);
     };
 
     /**

--- a/resources/views/modules/places/tab.phtml
+++ b/resources/views/modules/places/tab.phtml
@@ -36,38 +36,23 @@ use Fisharebest\Webtrees\I18N;
         showCoverageOnHover: false,
     });
 
-    let resetControl = L.Control.extend({
-      options: {
-          position: "topleft",
-      },
-      onAdd: function(map) {
-        let container = L.DomUtil.create("div", "leaflet-bar leaflet-control leaflet-control-custom");
-        container.onclick = function() {
-            map.flyToBounds(markers.getBounds(), {padding: [50, 30], maxZoom: 15});
-            sidebar.firstElementChild.scrollIntoView(scrollOptions);
+    /**
+     * Passed to resetControl to
+     * perform necessary reset actions on map
+     */
+      let resetActions = function () {
+      map.flyToBounds(markers.getBounds(), {padding: [50, 30], maxZoom: 15 });
+      sidebar.firstElementChild.scrollIntoView(scrollOptions);
 
-            return false;
-        };
-        let reset    = config.i18n.reset;
-        let anchor   = L.DomUtil.create('a', 'leaflet-control-reset', container);
-        anchor.setAttribute('aria-label', reset);
-        anchor.href  = '#';
-        anchor.title = reset;
-        anchor.role  = 'button';
-        let image    = L.DomUtil.create('i', 'fas fa-redo', anchor);
-        image.alt    = reset;
-
-        return container;
-      },
-  });
+      return false;
+    }
 
     /**
      *
      * @private
      */
     let _drawMap = function() {
-      map = webtrees.buildLeafletJsMap('wt-map', config)
-      .addControl(new resetControl());
+      map = webtrees.buildLeafletJsMap('wt-map', config, resetActions);
     };
 
     /**


### PR DESCRIPTION
To avoid duplication of code, move the reset control into webtrees.buildLeafletJsMap(). A small function (resetActions) needs to be created in each map view to actually perform the required reset actions.