### PR TITLE
Improve sidebar click handling

### DIFF
--- a/resources/views/modules/pedigree-map/chart.phtml
+++ b/resources/views/modules/pedigree-map/chart.phtml
@@ -128,6 +128,11 @@ use Fisharebest\Webtrees\View;
         var eventId = parseInt(element.dataset.wtFeatureId);
 
         element.addEventListener('click', () => {
+          // If child link is clicked, go straight to it
+          if(e.target.href !== undefined) {
+            window.location = e.target.href;
+            return false;
+          }
           // first close any existing
           map.closePopup();
           //find the marker corresponding to the clicked event
@@ -142,13 +147,6 @@ use Fisharebest\Webtrees\View;
           });
 
           return false;
-        });
-
-        // stop click on a person also opening the popup
-        element.querySelectorAll('a').forEach((el) => {
-          el.addEventListener('click', (e) => {
-            e.stopPropagation();
-          });
         });
       });
     }

--- a/resources/views/modules/place-hierarchy/map.phtml
+++ b/resources/views/modules/place-hierarchy/map.phtml
@@ -118,6 +118,11 @@ use Fisharebest\Webtrees\View;
         var eventId = parseInt(element.dataset.wtFeatureId);
 
         element.addEventListener('click', () => {
+          // If child link is clicked, go straight to it
+          if(e.target.href !== undefined) {
+            window.location = e.target.href;
+            return false;
+          }
           // first close any existing
           map.closePopup();
           //find the marker corresponding to the clicked event
@@ -132,13 +137,6 @@ use Fisharebest\Webtrees\View;
           });
 
           return false;
-        });
-
-        // stop clicking on a person also opening the popup
-        element.querySelectorAll('a').forEach((el) => {
-          el.addEventListener('click', (e) => {
-            e.stopPropagation();
-          });
         });
       });
     }

--- a/resources/views/modules/places/tab.phtml
+++ b/resources/views/modules/places/tab.phtml
@@ -124,6 +124,11 @@ use Fisharebest\Webtrees\I18N;
         var eventId = parseInt(element.dataset.wtFeatureId);
 
         element.addEventListener('click', () => {
+          // If child link is clicked, go straight to it
+          if(e.target.href !== undefined) {
+            window.location = e.target.href;
+            return false;
+          }
           // first close any existing
           map.closePopup();
           //find the marker corresponding to the clicked event
@@ -138,13 +143,6 @@ use Fisharebest\Webtrees\I18N;
           });
 
           return false;
-        });
-
-        // stop click on a person also opening the popup
-        element.querySelectorAll('a').forEach((el) => {
-          el.addEventListener('click', (e) => {
-            e.stopPropagation();
-          });
         });
       });
     }


### PR DESCRIPTION
For click handler, when child element is clicked, run it immediately and exit the handler so the map popup action doesn't also run