### PR TITLE
Improve handling of sidebar click on child elements

### DIFF
--- a/app/Module/PedigreeMapModule.php
+++ b/app/Module/PedigreeMapModule.php
@@ -302,6 +302,7 @@ class PedigreeMapModule extends AbstractModule implements ModuleChartInterface, 
                         'tooltip'   => $fact->place()->gedcomName(),
                         'summary'   => view('modules/pedigree-map/events', [
                             'fact'         => $fact,
+                            'tree'         => $tree,
                             'relationship' => ucfirst($this->getSosaName($sosa)),
                             'sosa'         => $sosa,
                         ]),

--- a/app/Module/PlaceHierarchyListModule.php
+++ b/app/Module/PlaceHierarchyListModule.php
@@ -306,7 +306,6 @@ class PlaceHierarchyListModule extends AbstractModule implements ModuleListInter
                 $stats[$type] = $tmp === [] ? 0 : $tmp[0]->tot;
             }
             $sidebar .= view('modules/place-hierarchy/sidebar', [
-                'showlink'      => $show_link,
                 'id'            => $id,
                 'place'         => $place,
                 'sidebar_class' => $sidebar_class,

--- a/resources/views/modules/pedigree-map/chart.phtml
+++ b/resources/views/modules/pedigree-map/chart.phtml
@@ -127,7 +127,12 @@ use Fisharebest\Webtrees\View;
       sidebar.querySelectorAll('.gchart').forEach((element) => {
         var eventId = parseInt(element.dataset.wtFeatureId);
 
-        element.addEventListener('click', () => {
+        element.addEventListener('click', (e) => {
+          // If child link is clicked, go straight to it
+          if(e.target.href !== undefined) {
+            window.location = e.target.href;
+            return false;
+          }
           // first close any existing
           map.closePopup();
           //find the marker corresponding to the clicked event
@@ -142,13 +147,6 @@ use Fisharebest\Webtrees\View;
           });
 
           return false;
-        });
-
-        // stop click on a person also opening the popup
-        element.querySelectorAll('a').forEach((el) => {
-          el.addEventListener('click', (e) => {
-            e.stopPropagation();
-          });
         });
       });
     }

--- a/resources/views/modules/pedigree-map/events.phtml
+++ b/resources/views/modules/pedigree-map/events.phtml
@@ -20,11 +20,9 @@ use Fisharebest\Webtrees\Fact;
 <?php endif ?>
 
 <div>
-    <?= $fact->label() ?>: <?= $fact->date()->display() ?>
+    <?= $fact->label() ?>: <?= $fact->date()->display($tree) ?>
 </div>
 
 <div>
-    <a href="<?= e($fact->place()->url()) ?>">
-        <?= $fact->place()->fullName() ?>
-    </a>
+    <?= $fact->place()->fullName(true) ?>
 </div>

--- a/resources/views/modules/place-hierarchy/map.phtml
+++ b/resources/views/modules/place-hierarchy/map.phtml
@@ -133,13 +133,6 @@ use Fisharebest\Webtrees\View;
 
           return false;
         });
-
-        // stop clicking on a person also opening the popup
-        element.querySelectorAll('a').forEach((el) => {
-          el.addEventListener('click', (e) => {
-            e.stopPropagation();
-          });
-        });
       });
     }
 

--- a/resources/views/modules/place-hierarchy/sidebar.phtml
+++ b/resources/views/modules/place-hierarchy/sidebar.phtml
@@ -7,7 +7,6 @@ use Fisharebest\Webtrees\Location;
 use Fisharebest\Webtrees\Place;
 
 /**
- * @var bool                 $showlink
  * @var Place                $place
  * @var int                  $id
  * @var string               $sidebar_class
@@ -18,13 +17,7 @@ use Fisharebest\Webtrees\Place;
 <li class="gchart px-md-2 <?= $sidebar_class ?>" data-wt-feature-id="<?= $id ?>">
     <div class="row label">
         <div class="col" style="word-wrap: break-word">
-            <?php if ($showlink) : ?>
-                <a href="<?= e($place->url()) ?>">
-                    <?= $place->placeName() ?>
-                </a>
-            <?php else : ?>
-                <?= $place->placeName() ?>
-            <?php endif ?>
+            <?= $place->placeName() ?>
         </div>
     </div>
 

--- a/resources/views/modules/places/tab.phtml
+++ b/resources/views/modules/places/tab.phtml
@@ -123,7 +123,12 @@ use Fisharebest\Webtrees\I18N;
       sidebar.querySelectorAll('.gchart').forEach((element) => {
         var eventId = parseInt(element.dataset.wtFeatureId);
 
-        element.addEventListener('click', () => {
+        element.addEventListener('click', (e) => {
+          // If child link is clicked, go straight to it
+          if(e.target.href !== undefined) {
+            window.location = e.target.href;
+            return false;
+          }
           // first close any existing
           map.closePopup();
           //find the marker corresponding to the clicked event
@@ -138,13 +143,6 @@ use Fisharebest\Webtrees\I18N;
           });
 
           return false;
-        });
-
-        // stop click on a person also opening the popup
-        element.querySelectorAll('a').forEach((el) => {
-          el.addEventListener('click', (e) => {
-            e.stopPropagation();
-          });
         });
       });
     }


### PR DESCRIPTION
- Prevent the map sidebar click event action as well as whatever the child click event does.
- For place hierarchy remove redundant link on the place name (did the same as clicking on the sidebar)
- Make sidebar links for place & pedigree map modules consistent