### PR TITLE
Change method access modifiers for easier extensibility of module

### DIFF
--- a/app/Module/IndividualFactsTabModule.php
+++ b/app/Module/IndividualFactsTabModule.php
@@ -186,7 +186,7 @@ class IndividualFactsTabModule extends AbstractModule implements ModuleTabInterf
      *
      * @return Collection<Fact>
      */
-    private function spouseFacts(Individual $individual, Individual $spouse, Date $min_date, Date $max_date): Collection
+    protected function spouseFacts(Individual $individual, Individual $spouse, Date $min_date, Date $max_date): Collection
     {
         $SHOW_RELATIVES_EVENTS = $individual->tree()->getPreference('SHOW_RELATIVES_EVENTS');
 
@@ -230,7 +230,7 @@ class IndividualFactsTabModule extends AbstractModule implements ModuleTabInterf
      *
      * @return bool
      */
-    private function includeFact(Fact $fact, Date $min_date, Date $max_date): bool
+    protected function includeFact(Fact $fact, Date $min_date, Date $max_date): bool
     {
         $fact_date = $fact->date();
 
@@ -245,7 +245,7 @@ class IndividualFactsTabModule extends AbstractModule implements ModuleTabInterf
      *
      * @return Fact
      */
-    private function convertEvent(Fact $fact, string $type): Fact
+    protected function convertEvent(Fact $fact, string $type): Fact
     {
         $gedcom = $fact->gedcom();
         $gedcom = preg_replace('/\n2 TYPE .*/', '', $gedcom);
@@ -276,7 +276,7 @@ class IndividualFactsTabModule extends AbstractModule implements ModuleTabInterf
      *
      * @return Collection<Fact>
      */
-    private function childFacts(Individual $person, Family $family, string $option, string $relation, Date $min_date, Date $max_date): Collection
+    protected function childFacts(Individual $person, Family $family, string $option, string $relation, Date $min_date, Date $max_date): Collection
     {
         $SHOW_RELATIVES_EVENTS = $person->tree()->getPreference('SHOW_RELATIVES_EVENTS');
 
@@ -708,7 +708,7 @@ class IndividualFactsTabModule extends AbstractModule implements ModuleTabInterf
      *
      * @return Collection<Fact>
      */
-    private function parentFacts(Individual $person, int $sosa, Date $min_date, Date $max_date): Collection
+    protected function parentFacts(Individual $person, int $sosa, Date $min_date, Date $max_date): Collection
     {
         $SHOW_RELATIVES_EVENTS = $person->tree()->getPreference('SHOW_RELATIVES_EVENTS');
 
@@ -875,7 +875,7 @@ class IndividualFactsTabModule extends AbstractModule implements ModuleTabInterf
      *
      * @return Collection<Fact>
      */
-    private function associateFacts(Individual $person): Collection
+    protected function associateFacts(Individual $person): Collection
     {
         $facts = [];
 
@@ -919,7 +919,7 @@ class IndividualFactsTabModule extends AbstractModule implements ModuleTabInterf
      *
      * @return Collection<Fact>
      */
-    private function historicFacts(Individual $individual): Collection
+    protected function historicFacts(Individual $individual): Collection
     {
         return $this->module_service->findByInterface(ModuleHistoricEventsInterface::class)
             ->map(static function (ModuleHistoricEventsInterface $module) use ($individual): Collection {


### PR DESCRIPTION
Note: In my opinion there is little reason to have private methods in any of the module classes, so perhaps change this everywhere?