### PR TITLE
Pedigree map, provide ability to switch the parent-child lines on or off

### DIFF
--- a/app/Module/PedigreeMapModule.php
+++ b/app/Module/PedigreeMapModule.php
@@ -242,6 +242,7 @@ class PedigreeMapModule extends AbstractModule implements ModuleChartInterface, 
         ];
 
         $sosa_points = [];
+        $lines       = [];
 
         foreach ($facts as $sosa => $fact) {
             $location = new PlaceLocation($fact->place()->gedcomName());
@@ -257,16 +258,12 @@ class PedigreeMapModule extends AbstractModule implements ModuleChartInterface, 
             }
 
             if ($latitude !== null && $longitude !== null) {
-                $polyline           = null;
                 $sosa_points[$sosa] = [$latitude, $longitude];
                 $sosa_child         = intdiv($sosa, 2);
                 $color              = 'var(--wt-pedigree-map-gen-' . $sosa_child % self::GENERATION_COLORS . ')';
 
                 if (array_key_exists($sosa_child, $sosa_points)) {
-                    // Would like to use a GeometryCollection to hold LineStrings
-                    // rather than generate polylines but the MarkerCluster library
-                    // doesn't seem to like them
-                    $polyline = [
+                    $lines[] = [
                         'points'  => [
                             $sosa_points[$sosa_child],
                             [$latitude, $longitude],
@@ -284,7 +281,6 @@ class PedigreeMapModule extends AbstractModule implements ModuleChartInterface, 
                         'coordinates' => [$longitude, $latitude],
                     ],
                     'properties' => [
-                        'polyline'  => $polyline,
                         'iconcolor' => $color,
                         'tooltip'   => $fact->place()->gedcomName(),
                         'summary'   => view('modules/pedigree-map/events', [
@@ -297,7 +293,10 @@ class PedigreeMapModule extends AbstractModule implements ModuleChartInterface, 
             }
         }
 
-        return $geojson;
+        return [
+            'geoJSON'   => $geojson,
+            'polylines' => $lines,
+        ];
     }
 
     /**

--- a/resources/js/webtrees.js
+++ b/resources/js/webtrees.js
@@ -623,10 +623,10 @@
    * @param {string} id
    * @param {object} config
    * @param {function} resetCallback
-   * @param {array|undefined} polylines
+   * @param {array|undefined} overlay
    * @returns Map
    */
-  webtrees.buildLeafletJsMap = function (id, config, resetCallback, polylines) {
+  webtrees.buildLeafletJsMap = function (id, config, resetCallback, overlay) {
 
     const zoomControl = new L.control.zoom({
       zoomInTitle: config.i18n.zoomIn,
@@ -673,18 +673,11 @@
       let defaultLayer = config.mapProviders[0].children[0].layer;
     }
 
-    let featureLayer = new L.LayerGroup();
-    let overlaysTree = null;
-    if (polylines !== undefined && polylines.length) {
-      polylines.forEach((line) => {
-        featureLayer.addLayer(L.polyline(line.points, line.options));
-      });
-
-      overlaysTree = {
-          label: config.i18n.showLines ?? '?',
-          layer: featureLayer,
+    //Create a dummy overlay if not defined
+      overlay = overlay || {
+        layer: new L.LayerGroup(),
+        tree: null
       };
-    }
 
     // Create the map with all controls and layers
     return L.map(id, {
@@ -693,8 +686,8 @@
       .addControl(zoomControl)
       .addControl(new resetControl())
       .addLayer(defaultLayer)
-      .addLayer(featureLayer)
-      .addControl(L.control.layers.tree(config.mapProviders, overlaysTree, {
+      .addLayer(overlay.layer)
+      .addControl(L.control.layers.tree(config.mapProviders, overlay.tree, {
         closedSymbol: config.icons.expand,
         openedSymbol: config.icons.collapse,
       }));

--- a/resources/js/webtrees.js
+++ b/resources/js/webtrees.js
@@ -623,9 +623,11 @@
    * @param {string} id
    * @param {object} config
    * @param {function} resetCallback
+   * @param {array|undefined} polylines
    * @returns Map
    */
-  webtrees.buildLeafletJsMap = function (id, config, resetCallback) {
+  webtrees.buildLeafletJsMap = function (id, config, resetCallback, polylines) {
+
     const zoomControl = new L.control.zoom({
       zoomInTitle: config.i18n.zoomIn,
       zoomoutTitle: config.i18n.zoomOut,
@@ -671,6 +673,18 @@
       let defaultLayer = config.mapProviders[0].children[0].layer;
     }
 
+    let featureLayer = new L.LayerGroup();
+    let overlaysTree = null;
+    if (polylines !== undefined && polylines.length) {
+      polylines.forEach(function (line) {
+        featureLayer.addLayer(L.polyline(line.points, line.options));
+      });
+
+      overlaysTree = {
+          label: config.i18n.showLines ?? '?',
+          layer: featureLayer,
+      };
+    }
 
     // Create the map with all controls and layers
     return L.map(id, {
@@ -679,7 +693,8 @@
       .addControl(zoomControl)
       .addControl(new resetControl())
       .addLayer(defaultLayer)
-      .addControl(L.control.layers.tree(config.mapProviders, null, {
+      .addLayer(featureLayer)
+      .addControl(L.control.layers.tree(config.mapProviders, overlaysTree, {
         closedSymbol: config.icons.expand,
         openedSymbol: config.icons.collapse,
       }));

--- a/resources/js/webtrees.js
+++ b/resources/js/webtrees.js
@@ -676,7 +676,7 @@
     let featureLayer = new L.LayerGroup();
     let overlaysTree = null;
     if (polylines !== undefined && polylines.length) {
-      polylines.forEach(function (line) {
+      polylines.forEach((line) => {
         featureLayer.addLayer(L.polyline(line.points, line.options));
       });
 

--- a/resources/views/modules/pedigree-map/chart.phtml
+++ b/resources/views/modules/pedigree-map/chart.phtml
@@ -23,8 +23,6 @@ use Fisharebest\Webtrees\View;
     const geoJson_data = <?= json_encode($data, JSON_THROW_ON_ERROR) ?>;
     const sidebar = document.querySelector('.wt-pedigree-map-sidebar');
 
-    config.i18n.showLines = '<?= I18N::translate("Show/Hide parent to child lines") ?>';
-
     const scrollOptions = {
       behavior: "smooth",
       block: "start",
@@ -38,11 +36,21 @@ use Fisharebest\Webtrees\View;
       showCoverageOnHover: false,
     });
 
-    let polyLines = [];
+    // Add the polylines to a separate layer
+    let features = {
+      layer: new L.LayerGroup(),
+      tree: null
+    }
 
     geoJson_data.features.forEach((feature) => {
-       if (feature.properties.polyline) {
-         polyLines.push(feature.properties.polyline);
+      if (feature.properties.polyline) {
+        features.layer.addLayer(L.polyline(feature.properties.polyline.points, feature.properties.polyline.options));
+        if (!features.tree) {
+          features.tree = {
+            label: '<?= I18N::translate("Show/Hide parent to child lines") ?>',
+            layer: features.layer
+          }
+        }
       }
     });
 
@@ -60,7 +68,7 @@ use Fisharebest\Webtrees\View;
      * @private
      */
     let _drawMap = function () {
-      map = webtrees.buildLeafletJsMap('wt-map', config, resetCallback, polyLines);
+      map = webtrees.buildLeafletJsMap('wt-map', config, resetCallback, features);
     };
 
     /**

--- a/resources/views/modules/pedigree-map/chart.phtml
+++ b/resources/views/modules/pedigree-map/chart.phtml
@@ -20,7 +20,7 @@ use Fisharebest\Webtrees\View;
 
   (function () {
     const config = <?= json_encode($leaflet_config, JSON_THROW_ON_ERROR) ?>;
-    const geoJson_data = <?= json_encode($data, JSON_THROW_ON_ERROR) ?>;
+    const polylines = <?= json_encode($data['polylines'], JSON_THROW_ON_ERROR) ?>;
     const sidebar = document.querySelector('.wt-pedigree-map-sidebar');
 
     const scrollOptions = {
@@ -42,17 +42,16 @@ use Fisharebest\Webtrees\View;
       tree: null
     }
 
-    geoJson_data.features.forEach((feature) => {
-      if (feature.properties.polyline) {
-        features.layer.addLayer(L.polyline(feature.properties.polyline.points, feature.properties.polyline.options));
-        if (!features.tree) {
-          features.tree = {
-            label: '<?= I18N::translate("Show/Hide parent to child lines") ?>',
-            layer: features.layer
-          }
-        }
-      }
+    polylines.forEach((line) => {
+      features.layer.addLayer(L.polyline(line.points, line.options));
     });
+
+    if (polylines.length) {
+      features.tree = {
+        label: '<?= I18N::translate("Show/Hide parent to child lines") ?>',
+        layer: features.layer
+      }
+    }
 
     /**
      * Passed to resetControl to
@@ -76,6 +75,8 @@ use Fisharebest\Webtrees\View;
      * @private
      */
     let _buildMapData = function () {
+      const geoJson_data = <?= json_encode($data['geoJSON'], JSON_THROW_ON_ERROR) ?>;
+
       if (geoJson_data.features.length === 0) {
         map.fitWorld();
         sidebar.innerHTML = '<div class="bg-info text-white text-center">' + <?= json_encode(I18N::translate('Nothing to show'), JSON_THROW_ON_ERROR) ?> + '</div>';

--- a/resources/views/modules/pedigree-map/chart.phtml
+++ b/resources/views/modules/pedigree-map/chart.phtml
@@ -20,7 +20,10 @@ use Fisharebest\Webtrees\View;
 
   (function () {
     const config = <?= json_encode($leaflet_config, JSON_THROW_ON_ERROR) ?>;
+    const geoJson_data = <?= json_encode($data, JSON_THROW_ON_ERROR) ?>;
     const sidebar = document.querySelector('.wt-pedigree-map-sidebar');
+
+    config.i18n.showLines = '<?= I18N::translate("Show/Hide parent to child lines") ?>';
 
     const scrollOptions = {
       behavior: "smooth",
@@ -33,6 +36,14 @@ use Fisharebest\Webtrees\View;
     // Map components
     let markers = L.markerClusterGroup({
       showCoverageOnHover: false,
+    });
+
+    let polyLines = [];
+
+    geoJson_data.features.forEach((feature) => {
+       if (feature.properties.polyline) {
+         polyLines.push(feature.properties.polyline);
+      }
     });
 
     /**
@@ -49,7 +60,7 @@ use Fisharebest\Webtrees\View;
      * @private
      */
     let _drawMap = function () {
-      map = webtrees.buildLeafletJsMap('wt-map', config, resetCallback);
+      map = webtrees.buildLeafletJsMap('wt-map', config, resetCallback, polyLines);
     };
 
     /**
@@ -57,8 +68,6 @@ use Fisharebest\Webtrees\View;
      * @private
      */
     let _buildMapData = function () {
-      let geoJson_data = <?= json_encode($data, JSON_THROW_ON_ERROR) ?>;
-
       if (geoJson_data.features.length === 0) {
         map.fitWorld();
         sidebar.innerHTML = '<div class="bg-info text-white text-center">' + <?= json_encode(I18N::translate('Nothing to show'), JSON_THROW_ON_ERROR) ?> + '</div>';
@@ -89,10 +98,6 @@ use Fisharebest\Webtrees\View;
               });
           },
           onEachFeature: function (feature, layer) {
-            if (feature.properties.polyline) {
-              let pline = L.polyline(feature.properties.polyline.points, feature.properties.polyline.options);
-              markers.addLayer(pline);
-            }
             layer.bindPopup(feature.properties.summary);
             sidebar.innerHTML += `<li class="gchart px-md-2" data-wt-feature-id=${feature.id}>${feature.properties.summary}</li>`;
           },


### PR DESCRIPTION
I've noticed that some people have made comments in the forum that the parent-child lines can look like a rats nest (I tend to agree) so It was a simple job to put all the polylines into a new Layergroup, add it to the map and the control.layers.tree providing the ability to switch the lines on or off