### PR TITLE
Bug fix for issue 4147

### DIFF
--- a/resources/views/admin/locations.phtml
+++ b/resources/views/admin/locations.phtml
@@ -31,7 +31,7 @@ use Illuminate\Support\Collection;
 
 <p>
     <label>
-        <input id="hide-unused-locations" type="checkbox" data-bs-toggle="collapse" data-bs-target=".unused-location" data-wt-persist="hide-unused-locations">
+        <input id="hide-unused-locations" type="checkbox" data-bs-toggle="collapse" data-bs-target=".unused-location" data-wt-persist="hide-unused-locations" autocomplete="off">
         <?= I18N::translate('Hide unused locations') ?>
     </label>
 </p>
@@ -177,4 +177,3 @@ use Illuminate\Support\Collection;
         </tr>
     </tfoot>
 </table>
-

--- a/resources/views/lists/families-table.phtml
+++ b/resources/views/lists/families-table.phtml
@@ -416,11 +416,11 @@ $marriageAgeData = [
             <tr>
                 <th colspan="14">
                     <div class="btn-group btn-group-sm">
-                        <input type="checkbox" class="btn-check" id="btn-toggle-parents" autocomplete="off" data-wt-persist="families-parents">
+                        <input type="checkbox" class="btn-check" id="btn-toggle-parents" autocomplete="off" data-wt-persist="families-parents" autocomplete="off">
                         <label class="btn btn-secondary" for="btn-toggle-parents">
                             <?= I18N::translate('Show parents') ?>
                         </label>
-                        <input type="checkbox" class="btn-check" id="btn-toggle-statistics" autocomplete="off" data-wt-persist="families-statistics">
+                        <input type="checkbox" class="btn-check" id="btn-toggle-statistics" autocomplete="off" data-wt-persist="families-statistics" autocomplete="off">
                         <label class="btn btn-secondary" for="btn-toggle-statistics">
                             <?= I18N::translate('Show statistics charts') ?>
                         </label>

--- a/resources/views/lists/individuals-table.phtml
+++ b/resources/views/lists/individuals-table.phtml
@@ -98,7 +98,7 @@ $("#<?= e($table_id) ?>")
     });
 </script>
 <?php View::endpush() ?>
-    
+
 <?php
 $max_age = (int) $tree->getPreference('MAX_ALIVE_AGE');
 
@@ -209,7 +209,7 @@ $deathAgeData = [
                         </div>
 
                         <div class="btn-group btn-group-sm" role="group">
-                        
+
                             <input id="<?= e($table_id) ?>-bg-born-YES" class="btn-check" type="checkbox" data-filter-column="13" data-filter-value="YES" autocomplete="off">
                             <label for="<?= e($table_id) ?>-bg-born-YES" class="btn btn-outline-secondary" title="<?= I18N::translate('Show individuals born more than 100 years ago.') ?>">
                                 <?= I18N::translate('Birth') ?>&gt;100
@@ -424,11 +424,11 @@ $deathAgeData = [
             <tr>
                 <th colspan="16">
                     <div class="btn-group btn-group-sm">
-                        <input type="checkbox" class="btn-check" id="btn-toggle-parents" autocomplete="off" data-wt-persist="individuals-parents">
+                        <input type="checkbox" class="btn-check" id="btn-toggle-parents" autocomplete="off" data-wt-persist="individuals-parents" autocomplete="off">
                         <label class="btn btn-secondary" for="btn-toggle-parents">
                             <?= I18N::translate('Show parents') ?>
                         </label>
-                        <input type="checkbox" class="btn-check" id="btn-toggle-statistics" autocomplete="off" data-wt-persist="individuals-statistics">
+                        <input type="checkbox" class="btn-check" id="btn-toggle-statistics" autocomplete="off" data-wt-persist="individuals-statistics" autocomplete="off">
                         <label class="btn btn-secondary" for="btn-toggle-statistics">
                             <?= I18N::translate('Show statistics charts') ?>
                         </label>

--- a/resources/views/modules/media/tab.phtml
+++ b/resources/views/modules/media/tab.phtml
@@ -18,7 +18,7 @@ use Illuminate\Support\Collection;
         <tr>
             <td colspan="2">
                 <label>
-                    <input id="show-level-2-media" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-level-two-media" data-wt-persist="level-two-media">
+                    <input id="show-level-2-media" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-level-two-media" data-wt-persist="level-two-media" autocomplete="off">
                     <?= I18N::translate('Show all media') ?>
                 </label>
             </td>

--- a/resources/views/modules/notes/tab.phtml
+++ b/resources/views/modules/notes/tab.phtml
@@ -24,7 +24,7 @@ use Illuminate\Support\Collection;
         <tr>
             <td colspan="2">
                 <label>
-                    <input id="show-level-2-notes" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-level-two-note" data-wt-persist="level-two-notes">
+                    <input id="show-level-2-notes" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-level-two-note" data-wt-persist="level-two-notes" autocomplete="off">
                     <?= I18N::translate('Show all notes') ?>
                 </label>
             </td>

--- a/resources/views/modules/personal_facts/tab.phtml
+++ b/resources/views/modules/personal_facts/tab.phtml
@@ -28,21 +28,21 @@ use Illuminate\Support\Collection;
                 <td colspan="2">
                     <?php if ($has_associate_facts) : ?>
                         <label>
-                            <input id="show-associate-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-associate-fact" data-wt-persist="associates">
+                            <input id="show-associate-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-associate-fact" data-wt-persist="associates" autocomplete="off">
                             <?= I18N::translate('Associated events') ?>
                         </label>
                     <?php endif ?>
 
                     <?php if ($has_relative_facts) : ?>
                         <label>
-                            <input id="show-relatives-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-relation-fact" data-wt-persist="relatives">
+                            <input id="show-relatives-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-relation-fact" data-wt-persist="relatives" autocomplete="off">
                             <?= I18N::translate('Events of close relatives') ?>
                         </label>
                     <?php endif ?>
 
                     <?php if ($has_historic_facts) : ?>
                         <label>
-                            <input id="show-historical-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-historic-fact" data-wt-persist="historic-facts">
+                            <input id="show-historical-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-historic-fact" data-wt-persist="historic-facts" autocomplete="off">
                             <?= I18N::translate('Historic events') ?>
                         </label>
                     <?php endif ?>

--- a/resources/views/modules/relatives/tab.phtml
+++ b/resources/views/modules/relatives/tab.phtml
@@ -31,7 +31,7 @@ use Illuminate\Support\Collection;
         <tr>
             <td>
                 <label>
-                    <input id="show-date-differences" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-date-difference" data-wt-persist="date-differences">
+                    <input id="show-date-differences" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-date-difference" data-wt-persist="date-differences" autocomplete="off">
                     <?= I18N::translate('Date differences') ?>
                 </label>
             </td>

--- a/resources/views/modules/sources_tab/tab.phtml
+++ b/resources/views/modules/sources_tab/tab.phtml
@@ -20,7 +20,7 @@ use Illuminate\Support\Collection;
         <tr>
             <td colspan="2">
                 <label>
-                    <input id="show-level-2-sources" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-level-two-source" data-wt-persist="level-two-sources">
+                    <input id="show-level-2-sources" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-level-two-source" data-wt-persist="level-two-sources" autocomplete="off">
                     <?= I18N::translate('Show all sources') ?>
                 </label>
             </td>


### PR DESCRIPTION
Added `autocomplete="off"` to check boxes that save state across page refreshes (Firefox reported - marked as "working as intended")

Fixes https://github.com/fisharebest/webtrees/issues/4147