### PR TITLE
Bug fix - stop page scrolling to top on map reset (version 2)

### DIFF
--- a/resources/js/webtrees.js
+++ b/resources/js/webtrees.js
@@ -644,6 +644,7 @@
         anchor.href = '#';
         anchor.title = reset;
         anchor.role = 'button';
+        L.DomEvent.addListener(anchor, 'click', L.DomEvent.preventDefault);
         let image = L.DomUtil.create('i', 'fas fa-redo', anchor);
         image.alt = reset;
 


### PR DESCRIPTION
Modify reset control to prevent default anchor action