### PR TITLE
Fix TomSelect virtual scroll

### DIFF
--- a/resources/js/webtrees.js
+++ b/resources/js/webtrees.js
@@ -711,7 +711,9 @@
           fetch(this.getUrl(query))
             .then(response => response.json())
             .then(json => {
-              this.setNextUrl(query, json.nextUrl + '&query=' + encodeURIComponent(query));
+              if (json.nextUrl !== null) {
+                this.setNextUrl(query, json.nextUrl + '&query=' + encodeURIComponent(query));
+              }
               callback(json.data);
             })
             .catch(callback);


### PR DESCRIPTION
Do not display "Loading more results ..." if there aren't any (in particular in case of few results, or none at all). See below for current 'ugly' behavior (screenshot from demo server).
<img width="419" alt="vs" src="https://user-images.githubusercontent.com/18174787/155836988-55c29843-7cdb-4607-852e-8858d866d25e.PNG">
