### PR TITLE
Fix Gedcom Tags preferences mixup

### DIFF
--- a/resources/views/admin/tags.phtml
+++ b/resources/views/admin/tags.phtml
@@ -420,7 +420,7 @@ use Fisharebest\Webtrees\Site;
                 </td>
 
                 <td>
-                    <?= view('components/checkbox-inline', ['name' => 'HIDE_SOUR_DATA', 'label' => I18N::translate('hide'), 'checked' => (bool) Site::getPreference('HIDE_SOUR_EVEN')]) ?>
+                    <?= view('components/checkbox-inline', ['name' => 'HIDE_SOUR_DATA', 'label' => I18N::translate('hide'), 'checked' => (bool) Site::getPreference('HIDE_SOUR_DATA')]) ?>
                 </td>
             </tr>
         </tbody>


### PR DESCRIPTION
Fixes part of #4239
(see comment:

> Note: While I can un-hide other tags in the config, unhiding SOUR:DATA:XXX doesn't seem to work: After saving, the checkbox is back.

)