### PR TITLE
Rhode Island State Censuses

### DIFF
--- a/app/Census/Census.php
+++ b/app/Census/Census.php
@@ -42,6 +42,7 @@ class Census
                     new CensusOfFrance(),
                     new CensusOfScotland(),
                     new CensusOfUnitedStates(),
+                    new CensusOfRhodeIsland(),
                     new CensusOfWales(),
                     new CensusOfCanada(),
                 ];
@@ -56,6 +57,7 @@ class Census
                     new CensusOfScotland(),
                     new CensusOfSlovakia(),
                     new CensusOfUnitedStates(),
+                    new CensusOfRhodeIsland(),
                     new CensusOfWales(),
                     new CensusOfCanada(),
                 ];
@@ -70,6 +72,7 @@ class Census
                     new CensusOfScotland(),
                     new CensusOfSlovakia(),
                     new CensusOfUnitedStates(),
+                    new CensusOfRhodeIsland(),
                     new CensusOfWales(),
                     new CensusOfCanada(),
                 ];
@@ -82,6 +85,7 @@ class Census
                     new CensusOfWales(),
                     new CensusOfCanada(),
                     new CensusOfUnitedStates(),
+                    new CensusOfRhodeIsland(),
                     new CensusOfCzechRepublic(),
                     new CensusOfDenmark(),
                     new CensusOfDeutschland(),
@@ -92,6 +96,7 @@ class Census
             case 'en-US':
                 return [
                     new CensusOfUnitedStates(),
+                    new CensusOfRhodeIsland(),
                     new CensusOfCanada(),
                     new CensusOfCzechRepublic(),
                     new CensusOfDenmark(),
@@ -114,6 +119,7 @@ class Census
                     new CensusOfScotland(),
                     new CensusOfSlovakia(),
                     new CensusOfUnitedStates(),
+                    new CensusOfRhodeIsland(),
                     new CensusOfWales(),
                 ];
 
@@ -128,6 +134,7 @@ class Census
                     new CensusOfScotland(),
                     new CensusOfSlovakia(),
                     new CensusOfUnitedStates(),
+                    new CensusOfRhodeIsland(),
                     new CensusOfWales(),
                 ];
 
@@ -141,6 +148,7 @@ class Census
                     new CensusOfFrance(),
                     new CensusOfScotland(),
                     new CensusOfUnitedStates(),
+                    new CensusOfRhodeIsland(),
                     new CensusOfWales(),
                     new CensusOfCanada(),
                 ];
@@ -148,6 +156,7 @@ class Census
             default:
                 return [
                     new CensusOfUnitedStates(),
+                    new CensusOfRhodeIsland(),
                     new CensusOfEngland(),
                     new CensusOfScotland(),
                     new CensusOfWales(),

--- a/app/Census/CensusOfRhodeIsland.php
+++ b/app/Census/CensusOfRhodeIsland.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2021 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Fisharebest\Webtrees\Census;
+
+/**
+ * Definitions for a census
+ */
+class CensusOfRhodeIsland extends Census implements CensusPlaceInterface
+{
+    /**
+     * All available censuses for this census place.
+     *
+     * @return array<CensusInterface>
+     */
+    public function allCensusDates(): array
+    {
+        return [
+            new CensusOfRhodeIsland1905(),
+            new CensusOfRhodeIsland1915(),
+            new CensusOfRhodeIsland1925(),
+        ];
+    }
+
+    /**
+     * Where did this census occur, in GEDCOM format.
+     *
+     * @return string
+     */
+    public function censusPlace(): string
+    {
+        return 'Rhode Island, United States';
+    }
+
+    /**
+     * In which language was this census written.
+     *
+     * @return string
+     */
+    public function censusLanguage(): string
+    {
+        return 'en-US';
+    }
+}

--- a/app/Census/CensusOfRhodeIsland1905.php
+++ b/app/Census/CensusOfRhodeIsland1905.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2021 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Fisharebest\Webtrees\Census;
+
+/**
+ * Definitions for a census
+ */
+class CensusOfRhodeIsland1905 extends CensusOfRhodeIsland implements CensusInterface
+{
+    /**
+     * When did this census occur.
+     *
+     * @return string
+     */
+    public function censusDate(): string
+    {
+        return 'JUN 1905';
+    }
+
+    /**
+     * The columns of the census.
+     *
+     * @return array<CensusColumnInterface>
+     */
+    public function columns(): array
+    {
+        return [
+            new CensusColumnSexMF($this, 'Sex', 'Sex'),
+            new CensusColumnNull($this, 'Num', 'Number of people in the family'),
+            new CensusColumnSurnameGivenNameInitial($this, 'Name', 'Name'),
+            new CensusColumnRelationToHeadEnglish($this, 'Relation', 'Relationship to head of household'),
+            new CensusColumnNull($this, 'Race', 'Color or race'),
+            new CensusColumnAge($this, 'Age', 'Age at last birthday'),
+            new CensusColumnConditionUs($this, 'Cond', 'Congugal Condition'),
+            new CensusColumnBirthYear($this, 'Year', 'Year of Birth'),
+            new CensusColumnBirthMonthDay($this, 'Month Day', 'Month Day'),
+            new CensusColumnBirthPlaceSimple($this, 'BP', 'Place of birth'),
+            new CensusColumnNull($this, 'N/F', 'Native or Foreign Born'),
+            new CensusColumnNull($this, 'R', 'Read'),
+            new CensusColumnNull($this, 'W', 'Write'),
+            new CensusColumnNull($this, 'Imm', 'Year of immigration to the United States'),
+            new CensusColumnNull($this, 'US yrs', 'Years in US'),
+            new CensusColumnNull($this, 'RI yrs', 'Years resident of Rhode Island'),
+            new CensusColumnNull($this, 'Town mnths', 'Months in current year as a Rhode Island resident'),
+            new CensusColumnFatherBirthPlaceSimple($this, 'FBP', 'Place of birth of father of this person'),
+            new CensusColumnMotherBirthPlaceSimple($this, 'MBP', 'Place of birth of mother of this person'),
+            new CensusColumnOccupation($this, 'Occupation', 'Occupation'),
+            new CensusColumnNull($this, 'Unemp', 'Months unemployed during Census Year'),
+            new CensusColumnNull($this, 'Pen', 'Did you receive a pension'),
+            new CensusColumnReligion($this, 'Rel', 'Religious preference'),
+            new CensusColumnNull($this, 'Mil', 'Military or widow of military'),
+            new CensusColumnNull($this, 'Nat', 'Naturalization information'),
+            new CensusColumnNull($this, 'Vtr', 'Voter information'),
+            new CensusColumnChildrenBornAlive($this, 'Chil born', 'Mother of how many children'),
+            new CensusColumnChildrenLiving($this, 'Chil liv', 'Number of these children living on June 1 1905'),
+        ];
+    }
+}

--- a/app/Census/CensusOfRhodeIsland1915.php
+++ b/app/Census/CensusOfRhodeIsland1915.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2021 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Fisharebest\Webtrees\Census;
+
+/**
+ * Definitions for a census
+ */
+class CensusOfRhodeIsland1915 extends CensusOfRhodeIsland implements CensusInterface
+{
+    /**
+     * When did this census occur.
+     *
+     * @return string
+     */
+    public function censusDate(): string
+    {
+        return 'APR 1915';
+    }
+
+    /**
+     * The columns of the census.
+     *
+     * @return array<CensusColumnInterface>
+     */
+    public function columns(): array
+    {
+        return [
+            new CensusColumnSurnameGivenNameInitial($this, 'Name', 'Name'),
+            new CensusColumnRelationToHeadEnglish($this, 'Relation', 'Relationship of this person to head of the family'),
+            new CensusColumnSexMF($this, 'Sex', 'Sex'),
+            new CensusColumnNull($this, 'Race', 'Color or race'),
+            new CensusColumnAge($this, 'Age', 'Age at last birthday'),
+            new CensusColumnBirthPlaceSimple($this, 'BP', 'Place of birth of this person'),
+            new CensusColumnFatherBirthPlaceSimple($this, 'FBP', 'Place of birth of Father of this person'),
+            new CensusColumnMotherBirthPlaceSimple($this, 'MBP', 'Place of birth of Mother of this person'),
+            new CensusColumnNull($this, 'Cit', 'Whether naturalized or alien'),
+            new CensusColumnNull($this, 'Trade', 'Trade or profession'),
+            new CensusColumnNull($this, 'Ind', 'Nature of industry'),
+            new CensusColumnNull($this, 'Type', 'Whether an employer, employee or working on own account'),
+            new CensusColumnNull($this, 'Uemp', 'If Employee, Whether out of work on Apr 15, 1915'),
+        ];
+    }
+}

--- a/app/Census/CensusOfRhodeIsland1925.php
+++ b/app/Census/CensusOfRhodeIsland1925.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2021 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Fisharebest\Webtrees\Census;
+
+/**
+ * Definitions for a census
+ */
+class CensusOfRhodeIsland1925 extends CensusOfRhodeIsland implements CensusInterface
+{
+    /**
+     * When did this census occur.
+     *
+     * @return string
+     */
+    public function censusDate(): string
+    {
+        return 'APR 1925';
+    }
+
+    /**
+     * The columns of the census.
+     *
+     * @return array<CensusColumnInterface>
+     */
+    public function columns(): array
+    {
+        return [
+            new CensusColumnSurnameGivenNameInitial($this, 'Name', 'Name'),
+            new CensusColumnRelationToHeadEnglish($this, 'Relation', 'Relationship of this person to head of the family'),
+            new CensusColumnSexMF($this, 'Sex', 'Sex'),
+            new CensusColumnNull($this, 'Race', 'Color or race'),
+            new CensusColumnAge($this, 'Age', 'Age at last birthday'),
+            new CensusColumnBirthPlaceSimple($this, 'BP', 'Place of birth'),
+            new CensusColumnNull($this, 'Cit', 'Citzenship'),
+        ];
+    }
+}

--- a/tests/app/Census/CensusOfRhodeIsland1905Test.php
+++ b/tests/app/Census/CensusOfRhodeIsland1905Test.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2021 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Fisharebest\Webtrees\Census;
+
+use Fisharebest\Webtrees\TestCase;
+
+/**
+ * Test harness for the class CensusOfRhodeIsland1905
+ */
+class CensusOfRhodeIsland1905Test extends TestCase
+{
+    /**
+     * Test the census place and date
+     *
+     * @covers \Fisharebest\Webtrees\Census\CensusOfRhodeIsland1905
+     *
+     * @return void
+     */
+    public function testPlaceAndDate(): void
+    {
+        $census = new CensusOfRhodeIsland1905();
+
+        self::assertSame('Rhode Island, United States', $census->censusPlace());
+        self::assertSame('JUN 1905', $census->censusDate());
+    }
+
+    /**
+     * Test the census columns
+     *
+     * @covers \Fisharebest\Webtrees\Census\CensusOfRhodeIsland1905
+     * @covers \Fisharebest\Webtrees\Census\AbstractCensusColumn
+     *
+     * @return void
+     */
+    public function testColumns(): void
+    {
+        $census  = new CensusOfRhodeIsland1905();
+        $columns = $census->columns();
+        self::assertCount(28, $columns);
+        self::assertInstanceOf(CensusColumnSexMF::class, $columns[0]);
+        self::assertInstanceOf(CensusColumnNull::class, $columns[1]);
+        self::assertInstanceOf(CensusColumnSurnameGivenNameInitial::class, $columns[2]);
+        self::assertInstanceOf(CensusColumnRelationToHeadEnglish::class, $columns[3]);
+        self::assertInstanceOf(CensusColumnNull::class, $columns[4]);
+        self::assertInstanceOf(CensusColumnAge::class, $columns[5]);
+        self::assertInstanceOf(CensusColumnConditionUs::class, $columns[6]);
+        self::assertInstanceOf(CensusColumnBirthYear::class, $columns[7]);
+        self::assertInstanceOf(CensusColumnBirthMonthDay::class, $columns[8]);
+        self::assertInstanceOf(CensusColumnBirthPlaceSimple::class, $columns[9]);
+        self::assertInstanceOf(CensusColumnNull::class, $columns[10]);
+        self::assertInstanceOf(CensusColumnNull::class, $columns[11]);
+        self::assertInstanceOf(CensusColumnNull::class, $columns[12]);
+        self::assertInstanceOf(CensusColumnNull::class, $columns[13]);
+        self::assertInstanceOf(CensusColumnNull::class, $columns[14]);
+        self::assertInstanceOf(CensusColumnNull::class, $columns[15]);
+        self::assertInstanceOf(CensusColumnNull::class, $columns[16]);
+        self::assertInstanceOf(CensusColumnFatherBirthPlaceSimple::class, $columns[17]);
+        self::assertInstanceOf(CensusColumnMotherBirthPlaceSimple::class, $columns[18]);
+        self::assertInstanceOf(CensusColumnOccupation::class, $columns[19]);
+        self::assertInstanceOf(CensusColumnNull::class, $columns[20]);
+        self::assertInstanceOf(CensusColumnNull::class, $columns[21]);
+        self::assertInstanceOf(CensusColumnReligion::class, $columns[22]);
+        self::assertInstanceOf(CensusColumnNull::class, $columns[23]);
+        self::assertInstanceOf(CensusColumnNull::class, $columns[24]);
+        self::assertInstanceOf(CensusColumnNull::class, $columns[25]);
+        self::assertInstanceOf(CensusColumnChildrenBornAlive::class, $columns[26]);
+        self::assertInstanceOf(CensusColumnChildrenLiving::class, $columns[27]);
+
+        self::assertSame('Sex', $columns[0]->abbreviation());
+        self::assertSame('Num', $columns[1]->abbreviation());
+        self::assertSame('Name', $columns[2]->abbreviation());
+        self::assertSame('Relation', $columns[3]->abbreviation());
+        self::assertSame('Race', $columns[4]->abbreviation());
+        self::assertSame('Age', $columns[5]->abbreviation());
+        self::assertSame('Cond', $columns[6]->abbreviation());
+        self::assertSame('Year', $columns[7]->abbreviation());
+        self::assertSame('Month Day', $columns[8]->abbreviation());
+        self::assertSame('BP', $columns[9]->abbreviation());
+        self::assertSame('N/F', $columns[10]->abbreviation());
+        self::assertSame('R', $columns[11]->abbreviation());
+        self::assertSame('W', $columns[12]->abbreviation());
+        self::assertSame('Imm', $columns[13]->abbreviation());
+        self::assertSame('US yrs', $columns[14]->abbreviation());
+        self::assertSame('RI yrs', $columns[15]->abbreviation());
+        self::assertSame('Town mnths', $columns[16]->abbreviation());
+        self::assertSame('FBP', $columns[17]->abbreviation());
+        self::assertSame('MBP', $columns[18]->abbreviation());
+        self::assertSame('Occupation', $columns[19]->abbreviation());
+        self::assertSame('Unemp', $columns[20]->abbreviation());
+        self::assertSame('Pen', $columns[21]->abbreviation());
+        self::assertSame('Rel', $columns[22]->abbreviation());
+        self::assertSame('Mil', $columns[23]->abbreviation());
+        self::assertSame('Nat', $columns[24]->abbreviation());
+        self::assertSame('Vtr', $columns[25]->abbreviation());
+        self::assertSame('Chil born', $columns[26]->abbreviation());
+        self::assertSame('Chil liv', $columns[27]->abbreviation());
+
+        self::assertSame('Sex', $columns[0]->title());
+        self::assertSame('Number of people in the family', $columns[1]->title());
+        self::assertSame('Name', $columns[2]->title());
+        self::assertSame('Relationship to head of household', $columns[3]->title());
+        self::assertSame('Color or race', $columns[4]->title());
+        self::assertSame('Age at last birthday', $columns[5]->title());
+        self::assertSame('Congugal Condition', $columns[6]->title());
+        self::assertSame('Year of Birth', $columns[7]->title());
+        self::assertSame('Month Day', $columns[8]->title());
+        self::assertSame('Place of birth', $columns[9]->title());
+        self::assertSame('Native or Foreign Born', $columns[10]->title());
+        self::assertSame('Read', $columns[11]->title());
+        self::assertSame('Write', $columns[12]->title());
+        self::assertSame('Year of immigration to the United States', $columns[13]->title());
+        self::assertSame('Years in US', $columns[14]->title());
+        self::assertSame('Years resident of Rhode Island', $columns[15]->title());
+        self::assertSame('Months in current year as a Rhode Island resident', $columns[16]->title());
+        self::assertSame('Place of birth of father of this person', $columns[17]->title());
+        self::assertSame('Place of birth of mother of this person', $columns[18]->title());
+        self::assertSame('Occupation', $columns[19]->title());
+        self::assertSame('Months unemployed during Census Year', $columns[20]->title());
+        self::assertSame('Did you receive a pension', $columns[21]->title());
+        self::assertSame('Religious preference', $columns[22]->title());
+        self::assertSame('Military or widow of military', $columns[23]->title());
+        self::assertSame('Naturalization information', $columns[24]->title());
+        self::assertSame('Voter information', $columns[25]->title());
+        self::assertSame('Mother of how many children', $columns[26]->title());
+        self::assertSame('Number of these children living on June 1 1905', $columns[27]->title());
+    }
+}

--- a/tests/app/Census/CensusOfRhodeIsland1915Test.php
+++ b/tests/app/Census/CensusOfRhodeIsland1915Test.php
@@ -80,7 +80,7 @@ class CensusOfRhodeIsland1915Test extends TestCase
         self::assertSame('Trade', $columns[9]->abbreviation());
         self::assertSame('Ind', $columns[10]->abbreviation());
         self::assertSame('Type', $columns[11]->abbreviation());
-        self::assertSame('Uemp', $columns[12]->abbreviation());   
+        self::assertSame('Uemp', $columns[12]->abbreviation());
         self::assertSame('Name', $columns[0]->title());
         self::assertSame('Relationship of this person to head of the family', $columns[1]->title());
         self::assertSame('Sex', $columns[2]->title());

--- a/tests/app/Census/CensusOfRhodeIsland1915Test.php
+++ b/tests/app/Census/CensusOfRhodeIsland1915Test.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2021 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Fisharebest\Webtrees\Census;
+
+use Fisharebest\Webtrees\TestCase;
+
+/**
+ * Test harness for the class CensusOfRhodeIsland1915
+ */
+class CensusOfRhodeIsland1915Test extends TestCase
+{
+    /**
+     * Test the census place and date
+     *
+     * @covers \Fisharebest\Webtrees\Census\CensusOfRhodeIsland1915
+     *
+     * @return void
+     */
+    public function testPlaceAndDate(): void
+    {
+        $census = new CensusOfRhodeIsland1915();
+
+        self::assertSame('Rhode Island, United States', $census->censusPlace());
+        self::assertSame('APR 1915', $census->censusDate());
+    }
+
+    /**
+     * Test the census columns
+     *
+     * @covers \Fisharebest\Webtrees\Census\CensusOfRhodeIsland1915
+     * @covers \Fisharebest\Webtrees\Census\AbstractCensusColumn
+     *
+     * @return void
+     */
+    public function testColumns(): void
+    {
+        $census  = new CensusOfRhodeIsland1915();
+        $columns = $census->columns();
+        self::assertCount(13, $columns);
+        self::assertInstanceOf(CensusColumnSurnameGivenNameInitial::class, $columns[0]);
+        self::assertInstanceOf(CensusColumnRelationToHeadEnglish::class, $columns[1]);
+        self::assertInstanceOf(CensusColumnSexMF::class, $columns[2]);
+        self::assertInstanceOf(CensusColumnNull::class, $columns[3]);
+        self::assertInstanceOf(CensusColumnAge::class, $columns[4]);
+        self::assertInstanceOf(CensusColumnBirthPlaceSimple::class, $columns[5]);
+        self::assertInstanceOf(CensusColumnFatherBirthPlaceSimple::class, $columns[6]);
+        self::assertInstanceOf(CensusColumnMotherBirthPlaceSimple::class, $columns[7]);
+        self::assertInstanceOf(CensusColumnNull::class, $columns[8]);
+        self::assertInstanceOf(CensusColumnNull::class, $columns[9]);
+        self::assertInstanceOf(CensusColumnNull::class, $columns[10]);
+        self::assertInstanceOf(CensusColumnNull::class, $columns[11]);
+        self::assertInstanceOf(CensusColumnNull::class, $columns[12]);
+
+        self::assertSame('Name', $columns[0]->abbreviation());
+        self::assertSame('Relation', $columns[1]->abbreviation());
+        self::assertSame('Sex', $columns[2]->abbreviation());
+        self::assertSame('Race', $columns[3]->abbreviation());
+        self::assertSame('Age', $columns[4]->abbreviation());
+        self::assertSame('BP', $columns[5]->abbreviation());
+        self::assertSame('FBP', $columns[6]->abbreviation());
+        self::assertSame('MBP', $columns[7]->abbreviation());
+        self::assertSame('Cit', $columns[8]->abbreviation());
+        self::assertSame('Trade', $columns[9]->abbreviation());
+        self::assertSame('Ind', $columns[10]->abbreviation());
+        self::assertSame('Type', $columns[11]->abbreviation());
+        self::assertSame('Uemp', $columns[12]->abbreviation());        
+        self::assertSame('Name', $columns[0]->title());
+        self::assertSame('Relationship of this person to head of the family', $columns[1]->title());
+        self::assertSame('Sex', $columns[2]->title());
+        self::assertSame('Color or race', $columns[3]->title());
+        self::assertSame('Age at last birthday', $columns[4]->title());
+        self::assertSame('Place of birth of this person', $columns[5]->title());
+        self::assertSame('Place of birth of Father of this person', $columns[6]->title());
+        self::assertSame('Place of birth of Mother of this person', $columns[7]->title());
+        self::assertSame('Whether naturalized or alien', $columns[8]->title());
+        self::assertSame('Trade or profession', $columns[9]->title());
+        self::assertSame('Nature of industry', $columns[10]->title());
+        self::assertSame('Whether an employer, employee or working on own account', $columns[11]->title());
+        self::assertSame('If Employee, Whether out of work on Apr 15, 1915', $columns[12]->title());
+    }
+}

--- a/tests/app/Census/CensusOfRhodeIsland1915Test.php
+++ b/tests/app/Census/CensusOfRhodeIsland1915Test.php
@@ -80,7 +80,7 @@ class CensusOfRhodeIsland1915Test extends TestCase
         self::assertSame('Trade', $columns[9]->abbreviation());
         self::assertSame('Ind', $columns[10]->abbreviation());
         self::assertSame('Type', $columns[11]->abbreviation());
-        self::assertSame('Uemp', $columns[12]->abbreviation());        
+        self::assertSame('Uemp', $columns[12]->abbreviation());   
         self::assertSame('Name', $columns[0]->title());
         self::assertSame('Relationship of this person to head of the family', $columns[1]->title());
         self::assertSame('Sex', $columns[2]->title());

--- a/tests/app/Census/CensusOfRhodeIsland1925Test.php
+++ b/tests/app/Census/CensusOfRhodeIsland1925Test.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2021 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Fisharebest\Webtrees\Census;
+
+use Fisharebest\Webtrees\TestCase;
+
+/**
+ * Test harness for the class CensusOfRhodeIsland1915
+ */
+class CensusOfRhodeIsland1925Test extends TestCase
+{
+    /**
+     * Test the census place and date
+     *
+     * @covers \Fisharebest\Webtrees\Census\CensusOfRhodeIsland1925
+     *
+     * @return void
+     */
+    public function testPlaceAndDate(): void
+    {
+        $census = new CensusOfRhodeIsland1925();
+
+        self::assertSame('Rhode Island, United States', $census->censusPlace());
+        self::assertSame('APR 1925', $census->censusDate());
+    }
+
+    /**
+     * Test the census columns
+     *
+     * @covers \Fisharebest\Webtrees\Census\CensusOfRhodeIsland1925
+     * @covers \Fisharebest\Webtrees\Census\AbstractCensusColumn
+     *
+     * @return void
+     */
+    public function testColumns(): void
+    {
+        $census  = new CensusOfRhodeIsland1925();
+        $columns = $census->columns();
+        self::assertCount(7, $columns);
+        self::assertInstanceOf(CensusColumnSurnameGivenNameInitial::class, $columns[0]);
+        self::assertInstanceOf(CensusColumnRelationToHeadEnglish::class, $columns[1]);
+        self::assertInstanceOf(CensusColumnSexMF::class, $columns[2]);
+        self::assertInstanceOf(CensusColumnNull::class, $columns[3]);
+        self::assertInstanceOf(CensusColumnAge::class, $columns[4]);
+        self::assertInstanceOf(CensusColumnBirthPlaceSimple::class, $columns[5]);
+        self::assertInstanceOf(CensusColumnNull::class, $columns[6]);
+
+        self::assertSame('Name', $columns[0]->abbreviation());
+        self::assertSame('Relation', $columns[1]->abbreviation());
+        self::assertSame('Sex', $columns[2]->abbreviation());
+        self::assertSame('Race', $columns[3]->abbreviation());
+        self::assertSame('Age', $columns[4]->abbreviation());
+        self::assertSame('BP', $columns[5]->abbreviation());
+        self::assertSame('Cit', $columns[6]->abbreviation());
+        
+        self::assertSame('Name', $columns[0]->title());
+        self::assertSame('Relationship of this person to head of the family', $columns[1]->title());
+        self::assertSame('Sex', $columns[2]->title());
+        self::assertSame('Color or race', $columns[3]->title());
+        self::assertSame('Age at last birthday', $columns[4]->title());
+        self::assertSame('Place of birth', $columns[5]->title());
+        self::assertSame('Citzenship', $columns[6]->title());
+    }
+}

--- a/tests/app/Census/CensusOfRhodeIsland1925Test.php
+++ b/tests/app/Census/CensusOfRhodeIsland1925Test.php
@@ -69,7 +69,7 @@ class CensusOfRhodeIsland1925Test extends TestCase
         self::assertSame('Age', $columns[4]->abbreviation());
         self::assertSame('BP', $columns[5]->abbreviation());
         self::assertSame('Cit', $columns[6]->abbreviation());
-        
+
         self::assertSame('Name', $columns[0]->title());
         self::assertSame('Relationship of this person to head of the family', $columns[1]->title());
         self::assertSame('Sex', $columns[2]->title());

--- a/tests/app/Census/CensusOfRhodeIslandTest.php
+++ b/tests/app/Census/CensusOfRhodeIslandTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2021 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Fisharebest\Webtrees\Census;
+
+use Fisharebest\Webtrees\TestCase;
+
+/**
+ * Test harness for the class CensusOfRhodeIsland
+ */
+class CensusOfRhodeIslandTest extends TestCase
+{
+    /**
+     * Test the census place
+     *
+     * @covers \Fisharebest\Webtrees\Census\CensusOfRhodeIsland
+     *
+     * @return void
+     */
+    public function testPlace(): void
+    {
+        $census = new CensusOfRhodeIsland();
+
+        self::assertSame('Rhode Island, United States', $census->censusPlace());
+    }
+
+    /**
+     * Test the census language
+     *
+     * @covers \Fisharebest\Webtrees\Census\CensusOfRhodeIsland
+     *
+     * @return void
+     */
+    public function testLanguage(): void
+    {
+        $census = new CensusOfRhodeIsland();
+
+        self::assertSame('en-US', $census->censusLanguage());
+    }
+
+    /**
+     * Test the census dates
+     *
+     * @covers \Fisharebest\Webtrees\Census\CensusOfRhodeIsland
+     *
+     * @return void
+     */
+    public function testAllDates(): void
+    {
+        $census = new CensusOfRhodeIsland();
+
+        $census_dates = $census->allCensusDates();
+
+        self::assertCount(3, $census_dates);
+        self::assertInstanceOf(CensusOfRhodeIsland1905::class, $census_dates[0]);
+        self::assertInstanceOf(CensusOfRhodeIsland1915::class, $census_dates[1]);
+        self::assertInstanceOf(CensusOfRhodeIsland1925::class, $census_dates[2]);
+    }
+}

--- a/tests/app/Census/CensusTest.php
+++ b/tests/app/Census/CensusTest.php
@@ -35,7 +35,7 @@ class CensusTest extends TestCase
     {
         $censuses = Census::censusPlaces('cs');
 
-        self::assertCount(10, $censuses);
+        self::assertCount(11, $censuses);
         self::assertInstanceOf(CensusOfCzechRepublic::class, $censuses[0]);
         self::assertInstanceOf(CensusOfSlovakia::class, $censuses[1]);
         self::assertInstanceOf(CensusOfDenmark::class, $censuses[2]);
@@ -44,8 +44,9 @@ class CensusTest extends TestCase
         self::assertInstanceOf(CensusOfFrance::class, $censuses[5]);
         self::assertInstanceOf(CensusOfScotland::class, $censuses[6]);
         self::assertInstanceOf(CensusOfUnitedStates::class, $censuses[7]);
-        self::assertInstanceOf(CensusOfWales::class, $censuses[8]);
-        self::assertInstanceOf(CensusOfCanada::class, $censuses[9]);
+        self::assertInstanceOf(CensusOfRhodeIsland::class, $censuses[8]);
+        self::assertInstanceOf(CensusOfWales::class, $censuses[9]);
+        self::assertInstanceOf(CensusOfCanada::class, $censuses[10]);
     }
 
     /**
@@ -57,7 +58,7 @@ class CensusTest extends TestCase
     {
         $censuses = Census::censusPlaces('da');
 
-        self::assertCount(10, $censuses);
+        self::assertCount(11, $censuses);
         self::assertInstanceOf(CensusOfDenmark::class, $censuses[0]);
         self::assertInstanceOf(CensusOfDeutschland::class, $censuses[1]);
         self::assertInstanceOf(CensusOfCzechRepublic::class, $censuses[2]);
@@ -66,8 +67,9 @@ class CensusTest extends TestCase
         self::assertInstanceOf(CensusOfScotland::class, $censuses[5]);
         self::assertInstanceOf(CensusOfSlovakia::class, $censuses[6]);
         self::assertInstanceOf(CensusOfUnitedStates::class, $censuses[7]);
-        self::assertInstanceOf(CensusOfWales::class, $censuses[8]);
-        self::assertInstanceOf(CensusOfCanada::class, $censuses[9]);
+        self::assertInstanceOf(CensusOfRhodeIsland::class, $censuses[8]);
+        self::assertInstanceOf(CensusOfWales::class, $censuses[9]);
+        self::assertInstanceOf(CensusOfCanada::class, $censuses[10]);
     }
 
     /**
@@ -79,6 +81,7 @@ class CensusTest extends TestCase
     {
         $censuses = Census::censusPlaces('de');
 
+        self::assertCount(11, $censuses);
         self::assertInstanceOf(CensusOfDeutschland::class, $censuses[0]);
         self::assertInstanceOf(CensusOfCzechRepublic::class, $censuses[1]);
         self::assertInstanceOf(CensusOfDenmark::class, $censuses[2]);
@@ -87,8 +90,9 @@ class CensusTest extends TestCase
         self::assertInstanceOf(CensusOfScotland::class, $censuses[5]);
         self::assertInstanceOf(CensusOfSlovakia::class, $censuses[6]);
         self::assertInstanceOf(CensusOfUnitedStates::class, $censuses[7]);
-        self::assertInstanceOf(CensusOfWales::class, $censuses[8]);
-        self::assertInstanceOf(CensusOfCanada::class, $censuses[9]);
+        self::assertInstanceOf(CensusOfRhodeIsland::class, $censuses[8]);
+        self::assertInstanceOf(CensusOfWales::class, $censuses[9]);
+        self::assertInstanceOf(CensusOfCanada::class, $censuses[10]);
     }
 
     /**
@@ -100,17 +104,18 @@ class CensusTest extends TestCase
     {
         $censuses = Census::censusPlaces('en-AU');
 
-        self::assertCount(10, $censuses);
+        self::assertCount(11, $censuses);
         self::assertInstanceOf(CensusOfEngland::class, $censuses[0]);
         self::assertInstanceOf(CensusOfScotland::class, $censuses[1]);
         self::assertInstanceOf(CensusOfWales::class, $censuses[2]);
         self::assertInstanceOf(CensusOfCanada::class, $censuses[3]);
         self::assertInstanceOf(CensusOfUnitedStates::class, $censuses[4]);
-        self::assertInstanceOf(CensusOfCzechRepublic::class, $censuses[5]);
-        self::assertInstanceOf(CensusOfDenmark::class, $censuses[6]);
-        self::assertInstanceOf(CensusOfDeutschland::class, $censuses[7]);
-        self::assertInstanceOf(CensusOfFrance::class, $censuses[8]);
-        self::assertInstanceOf(CensusOfSlovakia::class, $censuses[9]);
+        self::assertInstanceOf(CensusOfRhodeIsland::class, $censuses[5]);
+        self::assertInstanceOf(CensusOfCzechRepublic::class, $censuses[6]);
+        self::assertInstanceOf(CensusOfDenmark::class, $censuses[7]);
+        self::assertInstanceOf(CensusOfDeutschland::class, $censuses[8]);
+        self::assertInstanceOf(CensusOfFrance::class, $censuses[9]);
+        self::assertInstanceOf(CensusOfSlovakia::class, $censuses[10]);
     }
 
     /**
@@ -122,17 +127,18 @@ class CensusTest extends TestCase
     {
         $censuses = Census::censusPlaces('en-GB');
 
-        self::assertCount(10, $censuses);
+        self::assertCount(11, $censuses);
         self::assertInstanceOf(CensusOfEngland::class, $censuses[0]);
         self::assertInstanceOf(CensusOfScotland::class, $censuses[1]);
         self::assertInstanceOf(CensusOfWales::class, $censuses[2]);
         self::assertInstanceOf(CensusOfCanada::class, $censuses[3]);
         self::assertInstanceOf(CensusOfUnitedStates::class, $censuses[4]);
-        self::assertInstanceOf(CensusOfCzechRepublic::class, $censuses[5]);
-        self::assertInstanceOf(CensusOfDenmark::class, $censuses[6]);
-        self::assertInstanceOf(CensusOfDeutschland::class, $censuses[7]);
-        self::assertInstanceOf(CensusOfFrance::class, $censuses[8]);
-        self::assertInstanceOf(CensusOfSlovakia::class, $censuses[9]);
+        self::assertInstanceOf(CensusOfRhodeIsland::class, $censuses[5]);
+        self::assertInstanceOf(CensusOfCzechRepublic::class, $censuses[6]);
+        self::assertInstanceOf(CensusOfDenmark::class, $censuses[7]);
+        self::assertInstanceOf(CensusOfDeutschland::class, $censuses[8]);
+        self::assertInstanceOf(CensusOfFrance::class, $censuses[9]);
+        self::assertInstanceOf(CensusOfSlovakia::class, $censuses[10]);
     }
 
     /**
@@ -144,17 +150,18 @@ class CensusTest extends TestCase
     {
         $censuses = Census::censusPlaces('en-US');
 
-        self::assertCount(10, $censuses);
+        self::assertCount(11, $censuses);
         self::assertInstanceOf(CensusOfUnitedStates::class, $censuses[0]);
-        self::assertInstanceOf(CensusOfCanada::class, $censuses[1]);
-        self::assertInstanceOf(CensusOfCzechRepublic::class, $censuses[2]);
-        self::assertInstanceOf(CensusOfDenmark::class, $censuses[3]);
-        self::assertInstanceOf(CensusOfDeutschland::class, $censuses[4]);
-        self::assertInstanceOf(CensusOfEngland::class, $censuses[5]);
-        self::assertInstanceOf(CensusOfFrance::class, $censuses[6]);
-        self::assertInstanceOf(CensusOfScotland::class, $censuses[7]);
-        self::assertInstanceOf(CensusOfSlovakia::class, $censuses[8]);
-        self::assertInstanceOf(CensusOfWales::class, $censuses[9]);
+        self::assertInstanceOf(CensusOfRhodeIsland::class, $censuses[1]);
+        self::assertInstanceOf(CensusOfCanada::class, $censuses[2]);
+        self::assertInstanceOf(CensusOfCzechRepublic::class, $censuses[3]);
+        self::assertInstanceOf(CensusOfDenmark::class, $censuses[4]);
+        self::assertInstanceOf(CensusOfDeutschland::class, $censuses[5]);
+        self::assertInstanceOf(CensusOfEngland::class, $censuses[6]);
+        self::assertInstanceOf(CensusOfFrance::class, $censuses[7]);
+        self::assertInstanceOf(CensusOfScotland::class, $censuses[8]);
+        self::assertInstanceOf(CensusOfSlovakia::class, $censuses[9]);
+        self::assertInstanceOf(CensusOfWales::class, $censuses[10]);
     }
 
     /**
@@ -166,7 +173,7 @@ class CensusTest extends TestCase
     {
         $censuses = Census::censusPlaces('fr');
 
-        self::assertCount(10, $censuses);
+        self::assertCount(11, $censuses);
         self::assertInstanceOf(CensusOfFrance::class, $censuses[0]);
         self::assertInstanceOf(CensusOfCanada::class, $censuses[1]);
         self::assertInstanceOf(CensusOfCzechRepublic::class, $censuses[2]);
@@ -176,7 +183,8 @@ class CensusTest extends TestCase
         self::assertInstanceOf(CensusOfScotland::class, $censuses[6]);
         self::assertInstanceOf(CensusOfSlovakia::class, $censuses[7]);
         self::assertInstanceOf(CensusOfUnitedStates::class, $censuses[8]);
-        self::assertInstanceOf(CensusOfWales::class, $censuses[9]);
+        self::assertInstanceOf(CensusOfRhodeIsland::class, $censuses[9]);
+        self::assertInstanceOf(CensusOfWales::class, $censuses[10]);
     }
 
     /**
@@ -188,7 +196,7 @@ class CensusTest extends TestCase
     {
         $censuses = Census::censusPlaces('fr-CA');
 
-        self::assertCount(10, $censuses);
+        self::assertCount(11, $censuses);
         self::assertInstanceOf(CensusOfCanada::class, $censuses[0]);
         self::assertInstanceOf(CensusOfFrance::class, $censuses[1]);
         self::assertInstanceOf(CensusOfCzechRepublic::class, $censuses[2]);
@@ -198,7 +206,8 @@ class CensusTest extends TestCase
         self::assertInstanceOf(CensusOfScotland::class, $censuses[6]);
         self::assertInstanceOf(CensusOfSlovakia::class, $censuses[7]);
         self::assertInstanceOf(CensusOfUnitedStates::class, $censuses[8]);
-        self::assertInstanceOf(CensusOfWales::class, $censuses[9]);
+        self::assertInstanceOf(CensusOfRhodeIsland::class, $censuses[9]);
+        self::assertInstanceOf(CensusOfWales::class, $censuses[10]);
     }
 
     /**
@@ -210,7 +219,7 @@ class CensusTest extends TestCase
     {
         $censuses = Census::censusPlaces('sk');
 
-        self::assertCount(10, $censuses);
+        self::assertCount(11, $censuses);
         self::assertInstanceOf(CensusOfSlovakia::class, $censuses[0]);
         self::assertInstanceOf(CensusOfCzechRepublic::class, $censuses[1]);
         self::assertInstanceOf(CensusOfDenmark::class, $censuses[2]);
@@ -219,8 +228,9 @@ class CensusTest extends TestCase
         self::assertInstanceOf(CensusOfFrance::class, $censuses[5]);
         self::assertInstanceOf(CensusOfScotland::class, $censuses[6]);
         self::assertInstanceOf(CensusOfUnitedStates::class, $censuses[7]);
-        self::assertInstanceOf(CensusOfWales::class, $censuses[8]);
-        self::assertInstanceOf(CensusOfCanada::class, $censuses[9]);
+        self::assertInstanceOf(CensusOfRhodeIsland::class, $censuses[8]);
+        self::assertInstanceOf(CensusOfWales::class, $censuses[9]);
+        self::assertInstanceOf(CensusOfCanada::class, $censuses[10]);
     }
 
     /**
@@ -232,16 +242,17 @@ class CensusTest extends TestCase
     {
         $censuses = Census::censusPlaces('XX');
 
-        self::assertCount(10, $censuses);
+        self::assertCount(11, $censuses);
         self::assertInstanceOf(CensusOfUnitedStates::class, $censuses[0]);
-        self::assertInstanceOf(CensusOfEngland::class, $censuses[1]);
-        self::assertInstanceOf(CensusOfScotland::class, $censuses[2]);
-        self::assertInstanceOf(CensusOfWales::class, $censuses[3]);
-        self::assertInstanceOf(CensusOfDeutschland::class, $censuses[4]);
-        self::assertInstanceOf(CensusOfFrance::class, $censuses[5]);
-        self::assertInstanceOf(CensusOfCzechRepublic::class, $censuses[6]);
-        self::assertInstanceOf(CensusOfSlovakia::class, $censuses[7]);
-        self::assertInstanceOf(CensusOfDenmark::class, $censuses[8]);
-        self::assertInstanceOf(CensusOfCanada::class, $censuses[9]);
+        self::assertInstanceOf(CensusOfRhodeIsland::class, $censuses[1]);
+        self::assertInstanceOf(CensusOfEngland::class, $censuses[2]);
+        self::assertInstanceOf(CensusOfScotland::class, $censuses[3]);
+        self::assertInstanceOf(CensusOfWales::class, $censuses[4]);
+        self::assertInstanceOf(CensusOfDeutschland::class, $censuses[5]);
+        self::assertInstanceOf(CensusOfFrance::class, $censuses[6]);
+        self::assertInstanceOf(CensusOfCzechRepublic::class, $censuses[7]);
+        self::assertInstanceOf(CensusOfSlovakia::class, $censuses[8]);
+        self::assertInstanceOf(CensusOfDenmark::class, $censuses[9]);
+        self::assertInstanceOf(CensusOfCanada::class, $censuses[10]);
     }
 }


### PR DESCRIPTION
New feature to add Rhode Island State Censuses from 1905, 1915, 1925. 

- Includes automated tests for all censuses
- The order in drop down places Rhode Island after US (others appear alphabetical, except first based on local)
  