### PR TITLE
Make _FSFTID editable

### DIFF
--- a/app/Module/CustomTagsFamilySearch.php
+++ b/app/Module/CustomTagsFamilySearch.php
@@ -51,6 +51,13 @@ class CustomTagsFamilySearch extends AbstractModule implements ModuleConfigInter
         ];
     }
 
+    public function customSubTags(): array
+    {
+        return [
+            'INDI' => [['_FSFTID', '0:1']],
+        ];
+    }
+    
     /**
      * The application for which we are supporting custom tags.
      *


### PR DESCRIPTION
See also discussion in #4251.

It makes sense to allow adding this tag, this has been requested e.g. [here](https://github.com/fisharebest/webtrees/issues/4251#issuecomment-1063246473), see also the discussion [here](https://www.webtrees.net/index.php/en/forum/help-for-2-0/35609-extra-information-block-incorrect-link-to-familysearch-afn). Basically, it is an element with an external link (just like AFN) that can be used regardless of GEDCOM imports.

(standard use case: Check whether the respective individual has a familysearch family tree ID; if yes, enter the respective link in webtrees)
