### PR TITLE
Change target url for FamilySearchFamilyTreeId

### DIFF
--- a/app/Elements/FamilySearchFamilyTreeId.php
+++ b/app/Elements/FamilySearchFamilyTreeId.php
@@ -28,7 +28,7 @@ use function strtoupper;
  */
 class FamilySearchFamilyTreeId extends AbstractExternalLink
 {
-    protected const EXTERNAL_URL = 'https://ancestors.familysearch.org/en/{ID}';
+    protected const EXTERNAL_URL = 'https://www.familysearch.org/tree/person/details/{ID}';
 
     protected const MAXIMUM_LENGTH = 8;
 


### PR DESCRIPTION
One final adjustment for FamilySearchFamilyTreeId: in my opinion, the actual detail page has more useful data than the shiny 'discovery page', which seems more targeted to casual users.

See e.g. [here](https://www.familysearch.org/tree/person/details/LK7V-Q4H) vs [here](https://ancestors.familysearch.org/LK7V-Q4H/).