### PR TITLE
Fix replacement images

### DIFF
--- a/app/Factories/ImageFactory.php
+++ b/app/Factories/ImageFactory.php
@@ -324,9 +324,7 @@ class ImageFactory implements ImageFactoryInterface
         $svg = view('errors/image-svg', ['status' => $text]);
 
         // We can't send the actual status code, as browsers won't show images with 4xx/5xx.
-        return response($svg, StatusCodeInterface::STATUS_OK, [
-            'content-type' => 'image/svg+xml',
-        ]);
+        return response($svg, StatusCodeInterface::STATUS_OK)->withHeader('content-type', 'image/svg+xml');
     }
 
     /**


### PR DESCRIPTION
Replacement images aren't actually shown in browsers (tested with Firefox and Chrome) without this fix, because the intended content-type response header set via the headers array [is overwritten here](https://github.com/fisharebest/webtrees/blob/35e7ad0c309aa084344904fc9471036d7c215055/app/Factories/ResponseFactory.php#L109).

A more robust solution avoiding similar issues would be to check in ResponseFactory whether a content-type header is already set (case-insensitively!)