### PR TITLE
Fix extraction of first line of multiline notes

### DIFF
--- a/app/Note.php
+++ b/app/Note.php
@@ -95,7 +95,7 @@ class Note extends GedcomRecord
             $text = Registry::markdownFactory()->autolink($this->getNote());
         }
 
-        $lines = preg_split('/\n|<br>/', strip_tags(trim($text), '<br>'), 2);
+        $lines = preg_split('/\n|<br(\s*\/)?>/', strip_tags(trim($text), '<br>'), 2);
 
         if ($lines !== false && !empty($lines)) {
             // Take the first line

--- a/app/Note.php
+++ b/app/Note.php
@@ -95,13 +95,11 @@ class Note extends GedcomRecord
             $text = Registry::markdownFactory()->autolink($this->getNote());
         }
 
+        $lines = preg_split('/\n|<br>/', strip_tags(trim($text), '<br>'), 2);
 
-        // Take the first line
-        [$text] = explode("\n", strip_tags(trim($text)));
-
-
-        if ($text !== '') {
-            $text = htmlspecialchars_decode($text, ENT_QUOTES);
+        if ($lines !== false && !empty($lines)) {
+            // Take the first line
+            $text = htmlspecialchars_decode($lines[0], ENT_QUOTES);
             $this->addName('NOTE', Str::limit($text, 100, I18N::translate('…')), $this->gedcom());
         }
     }


### PR DESCRIPTION
Split on `<br>` as well as newline. Solves https://github.com/fisharebest/webtrees/issues/4363