### PR TITLE
Update styling for v2.1 restriction lists

### DIFF
--- a/resources/views/modals/restriction-fields.phtml
+++ b/resources/views/modals/restriction-fields.phtml
@@ -9,7 +9,7 @@ use Fisharebest\Webtrees\I18N;
         <?= /* I18N: a restriction on viewing data */ I18N::translate('Restriction') ?>
     </label>
     <div class="col-sm-10">
-        <select class="form-control" id="restriction" name="restriction">
+        <select class="form-select" id="restriction" name="restriction">
             <option value="">&nbsp;</option>
             <option value="none">
                 <?= I18N::translate('Show to visitors') ?>


### PR DESCRIPTION
The class `form-control` should now be `form-select`