### PR TITLE
Fix `Invalid GEDCOM data passed to Fact` when no required new facts

### DIFF
--- a/app/Services/GedcomEditService.php
+++ b/app/Services/GedcomEditService.php
@@ -30,6 +30,7 @@ use Fisharebest\Webtrees\Registry;
 use Fisharebest\Webtrees\Site;
 use Fisharebest\Webtrees\Tree;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 
 use function array_diff;
 use function array_filter;
@@ -69,7 +70,8 @@ class GedcomEditService
     public function newFamilyFacts(Tree $tree): Collection
     {
         $dummy = Registry::familyFactory()->new('', '0 @@ FAM', null, $tree);
-        $tags  = new Collection(explode(',', $tree->getPreference('QUICK_REQUIRED_FAMFACTS')));
+        $tags  = (new Collection(explode(',', $tree->getPreference('QUICK_REQUIRED_FAMFACTS'))))
+            ->filter(static fn (string $tag): bool => Str::length($tag) > 0);
         $facts = $tags->map(fn (string $tag): Fact => $this->createNewFact($dummy, $tag));
 
         return Fact::sortFacts($facts);
@@ -85,7 +87,8 @@ class GedcomEditService
     public function newIndividualFacts(Tree $tree, string $sex, array $names): Collection
     {
         $dummy      = Registry::individualFactory()->new('', '0 @@ INDI', null, $tree);
-        $tags       = new Collection(explode(',', $tree->getPreference('QUICK_REQUIRED_FACTS')));
+        $tags       = (new Collection(explode(',', $tree->getPreference('QUICK_REQUIRED_FACTS'))))
+            ->filter(static fn (string $tag): bool => Str::length($tag) > 0);
         $facts      = $tags->map(fn (string $tag): Fact => $this->createNewFact($dummy, $tag));
         $sex_fact   = new Collection([new Fact('1 SEX ' . $sex, $dummy, '')]);
         $name_facts = Collection::make($names)->map(static fn (string $gedcom): Fact => new Fact($gedcom, $dummy, ''));


### PR DESCRIPTION
Whilst testing on one of my development environments, I stumbled across the elusive `Invalid GEDCOM data passed to Fact::_construct(1,)` error reported occasionally on the forum.

In my case, I managed to pin it down to the fact that I had no "Facts for new families" set in that environment.

![image](https://user-images.githubusercontent.com/5150782/196032264-7aabcfa2-3d3f-4db6-8c05-7a0d48e1b633.png)

From the code perspective, that means that in `Services\GedcomEditService::newFamilyFacts`, when performing `explode` on `$tree->getPreference('QUICK_REQUIRED_FAMFACTS')`, the result is an array with the empty string `[""]`. In the subsequent code, it therefore tries to create a new fact with an empty tag, which is not allowed in `Fact::construct`.

The issue can be reproduced for `Services\GedcomEditServicenewIndividualFacts` as well, by removing the "Facts for new individuals" entries.

In this PR, I am basically filtering out empty strings, but feel free to implement it any other way you prefer.