### PR TITLE
Change order of I18N initialisation in webtrees Test Case

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -94,13 +94,13 @@ class TestCase extends \PHPUnit\Framework\TestCase
         if (static::$uses_database) {
             static::createTestDatabase();
 
+            I18N::init('en-US');
+
             // This is normally set in middleware.
             (new Gedcom())->registerTags(Registry::elementFactory(), true);
 
             // Boot modules
             (new ModuleService())->bootModules(new WebtreesTheme());
-
-            I18N::init('en-US');
         } else {
             I18N::init('en-US', true);
         }


### PR DESCRIPTION
PhpUnit cannot be run when targeting a specific test class using database, for instance:

```
phpunit tests\app\Services\GedcomEditServiceTest.php

1) Fisharebest\Webtrees\Services\GedcomEditServiceTest::testEditLinesToGedcom
Error: Typed static property Fisharebest\Webtrees\I18N::$translator must not be accessed before initialization
```

This is because when using the database, the generic `Fisharebest\Webtrees\TestCase` initialise I18N after registering Gedcom tags, which itself calls `I18N::translate` therefore requiring `I18N` to have already been initialised.
I guess this is not exhibited when running the full test suite because the first tests called do not require the database, therefore I18N is initialised nonetheless.

I suggest to just change the order so that I18N is initialised after the database is created, but before the gedcom tags are registered, which I believe is coherent with the middleware load order anyway:

```php
UseDatabase::class,
..., 
UseLanguage::class,
..., 
RegisterGedcomTags::class,
BootModules::class,
```