### PR TITLE
Suggestion: allow autoformatting on ResearchTask element

### DIFF
--- a/app/Elements/ResearchTask.php
+++ b/app/Elements/ResearchTask.php
@@ -57,4 +57,17 @@ class ResearchTask extends AbstractElement
     {
         return $this->editTextArea($id, $name, $value);
     }
+
+    /**
+     * Display the value of this type of element.
+     *
+     * @param string $value
+     * @param Tree   $tree
+     *
+     * @return string
+     */
+    public function value(string $value, Tree $tree): string
+    {
+        return $this->valueFormatted($value, $tree);
+    }
 }


### PR DESCRIPTION
This is a suggestion to allow autoformatting on _TODO elements, if there is no side effects I have not anticipated.

As its purpose is close to a note, I think it would be beneficial to allow for more advanced formatting than just plain text (to display lists, URL for instance).