### PR TITLE
GedcomRecord format: Replace HTML in class by view

### DIFF
--- a/app/GedcomRecord.php
+++ b/app/GedcomRecord.php
@@ -501,12 +501,7 @@ class GedcomRecord
      */
     public function formatList(): string
     {
-        $html = '<a href="' . e($this->url()) . '">';
-        $html .= '<b>' . $this->fullName() . '</b>';
-        $html .= '</a>';
-        $html .= $this->formatListDetails();
-
-        return $html;
+        return view('record-list-info', ['record' => $this]);
     }
 
     /**

--- a/resources/views/record-list-info.phtml
+++ b/resources/views/record-list-info.phtml
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+
+/**
+ * @var GedcomRecord $record
+ */
+
+?>
+<a href="<?= e($record->url()) ?>">
+    <strong><?= $record->fullName() ?></strong>
+</a>
+<?= $record->formatListDetails() ?>


### PR DESCRIPTION
This is a proposal to replace the HTML hardcoded in the `GedcomRecord` class for the `formatList` by a view.
I think this is going in the global direction of managing HTML output by views (and overwriting in subclasses is still possible), and more selfishly, that would allow modules to overwrite the display of this element.

As usual, this is only a proposal, feel free to close it or amend it.