### PR TITLE
Use class instead of hardcoded style in read-only name input

### DIFF
--- a/app/Elements/NamePersonal.php
+++ b/app/Elements/NamePersonal.php
@@ -148,7 +148,8 @@ class NamePersonal extends AbstractElement
         return
             '<div class="input-group">' .
             view('edit/input-addon-edit-name', ['id' => $id]) .
-            '<input class="form-control" style="background-color:#e9ecef" type="text" id="' . e($id) . '" name="' . e($name) . '" value="' . e($value) . '" readonly="readonly" />' .
+            '<input class="form-control" type="text" id="' . e($id) . '-disabled" name="' . e($name) . '" value="' . e($value) . '" readonly="readonly" disabled="disabled" />' .
+            '<input class="form-control d-none" type="text" id="' . e($id) . '" name="' . e($name) . '" value="' . e($value) . '" />' .
             view('edit/input-addon-keyboard', ['id' => $id]) .
             view('edit/input-addon-help', ['topic' => 'NAME']) .
             '</div>';

--- a/app/Elements/NameRomanizedVariation.php
+++ b/app/Elements/NameRomanizedVariation.php
@@ -72,7 +72,8 @@ class NameRomanizedVariation extends NamePersonal
         return
             '<div class="input-group">' .
             view('edit/input-addon-edit-name', ['id' => $id]) .
-            '<input class="form-control" style="background-color:#e9ecef" type="text" id="' . e($id) . '" name="' . e($name) . '" value="' . e($value) . '" readonly="readonly" />' .
+            '<input class="form-control" type="text" id="' . e($id) . '-disabled" name="' . e($name) . '" value="' . e($value) . '" readonly="readonly" disabled="disabled" />' .
+            '<input class="form-control d-none" type="text" id="' . e($id) . '" name="' . e($name) . '" value="' . e($value) . '" />' .
             view('edit/input-addon-keyboard', ['id' => $id]) .
             view('edit/input-addon-help', ['topic' => 'ROMN']) .
             '</div>';

--- a/resources/views/edit/input-addon-edit-name.phtml
+++ b/resources/views/edit/input-addon-edit-name.phtml
@@ -22,16 +22,26 @@ use Fisharebest\Webtrees\I18N;
 <script>
   document.getElementById('<?= e($id) ?>-edit').addEventListener('click', function (event) {
     event.preventDefault();
-    let element = document.getElementById('<?= e($id) ?>');
-    element.readOnly = false;
-    element.style.backgroundColor = null; // Initially set to #e9ecef to match input-group-addon
-    element.focus();
+    // Toggle the visibility of the full name inputs
+    // Hide the disable input - does not send any value when posting the form
+    let disabledElement = document.getElementById('<?= e($id) ?>-disabled');
+    disabledElement.classList.add('d-none');
+    // Show the editable input - send value when posting the form
+    let editElement = document.getElementById('<?= e($id) ?>');
+    editElement.classList.remove('d-none');
+    editElement.focus();
 
     this.parentNode.removeChild(this);
   });
   document.addEventListener('DOMContentLoaded', function () {
     let NAME = document.getElementById('<?= e($id) ?>');
+    let NAME_DISABLED = document.getElementById('<?= e($id) ?>-disabled');
     let container = NAME.parentNode.parentNode.parentNode;
+
+    let setNameValue = function(name_value) {
+      NAME.value = name_value;
+      NAME_DISABLED.value = name_value;
+    }
 
     if (NAME.id.endsWith('-INDI-NAME')) {
       // NAME has children at the same level.
@@ -56,21 +66,21 @@ use Fisharebest\Webtrees\I18N;
     );
 
     if (NAME.value === '') {
-      NAME.value = generated_name;
+      setNameValue(generated_name);
     }
     if (NAME.value !== generated_name) {
       document.getElementById('<?= e($id) ?>-edit').click();
     } else {
       let fn = function () {
-        if (NAME.readOnly === true) {
-          NAME.value = webtrees.buildNameFromParts(
+        if (NAME.classList.contains("d-none") === true) {
+          setNameValue(webtrees.buildNameFromParts(
             NPFX ? NPFX.value : '',
             GIVN ? GIVN.value : '',
             SPFX ? SPFX.value : '',
             SURN ? SURN.value : '',
             NSFX ? NSFX.value : '',
             'U',
-          );
+          ));
         }
       };
       NPFX && NPFX.addEventListener('input', fn);


### PR DESCRIPTION
Commit 62cb0f58 introduces hardcoded styling to indicate that the full name input is read-only.
This is however relying on the standard Bootstrap color scheme, which custom themes may not be using (I am using a different color scheme in the Rural theme), and creates an inconsistent background color.

![image](https://user-images.githubusercontent.com/5150782/209882240-c54237c0-e2a4-4714-94e2-871a41bedcf8.png)

I am suggesting to switch to the use of the `disabled` attribute, which is styled in Bootstrap, and allow for the themes to apply its color scheme, like below:

_Read-only_
![image](https://user-images.githubusercontent.com/5150782/209882344-9f8c544e-a489-47fc-8560-ad01c80bf3ee.png)

_Editable_
![image](https://user-images.githubusercontent.com/5150782/209882353-0b32a72c-3105-4cc5-a626-11c80f87786d.png)

I am pushing the PR to `main`, but that would need to be backported to the `2.1` branch as well.