### PR TITLE
Bugfix for GEDCOM-L tag customization in order to enable entering data for _LOC:NAME:ABBR:TYPE

### DIFF
--- a/app/CustomTags/GedcomL.php
+++ b/app/CustomTags/GedcomL.php
@@ -258,7 +258,7 @@ class GedcomL implements CustomTagInterface
             '_LOC:MAP:LATI'                   => new PlaceLatitude(I18N::translate('Latitude')),
             '_LOC:MAP:LONG'                   => new PlaceLongtitude(I18N::translate('Longitude')),
             '_LOC:NAME'                       => new PlaceName(I18N::translate('Place'), ['ABBR' => '0:1', 'DATE' => '0:1', 'LANG' => '0:1', 'SOUR' => '0:M']),
-            '_LOC:NAME:ABBR'                  => new CustomElement(I18N::translate('Abbreviation')), ['TYPE' => '0:1']),
+            '_LOC:NAME:ABBR'                  => new CustomElement(I18N::translate('Abbreviation'), ['TYPE' => '0:1']),
             '_LOC:NAME:ABBR:TYPE'             => new CustomElement(I18N::translate('Type of abbreviation')),
             '_LOC:NAME:DATE'                  => new DateValue(I18N::translate('Date')),
             '_LOC:NAME:LANG'                  => new LanguageId(I18N::translate('Language')),

--- a/app/CustomTags/GedcomL.php
+++ b/app/CustomTags/GedcomL.php
@@ -258,7 +258,7 @@ class GedcomL implements CustomTagInterface
             '_LOC:MAP:LATI'                   => new PlaceLatitude(I18N::translate('Latitude')),
             '_LOC:MAP:LONG'                   => new PlaceLongtitude(I18N::translate('Longitude')),
             '_LOC:NAME'                       => new PlaceName(I18N::translate('Place'), ['ABBR' => '0:1', 'DATE' => '0:1', 'LANG' => '0:1', 'SOUR' => '0:M']),
-            '_LOC:NAME:ABBR'                  => new CustomElement(I18N::translate('Abbreviation')),
+            '_LOC:NAME:ABBR'                  => new CustomElement(I18N::translate('Abbreviation')), ['TYPE' => '0:1']),
             '_LOC:NAME:ABBR:TYPE'             => new CustomElement(I18N::translate('Type of abbreviation')),
             '_LOC:NAME:DATE'                  => new DateValue(I18N::translate('Date')),
             '_LOC:NAME:LANG'                  => new LanguageId(I18N::translate('Language')),


### PR DESCRIPTION
Currenty, it is not possible to enter data in webtrees 2.1.15 for _LOC:NAME:ABBR:TYPE

From the GEDCOM-L Addendum specification, it should be available:
```
0 @<XREF:_LOC>@ _LOC {1:1}
1 NAME <PLACE_NAME> {1:M}
2 DATE <DATE_VALUE> {0:1}
2 ABBR <ABBREVIATION_OF_NAME> {0:M}
3 TYPE <TYPE_OF_ABBREVIATION> {0:1}
```

In webtrees 2.1.15, it is only possible to **view** _LOC:NAME:ABBR:TYPE. 
![_LOC ABBR TYPE existing](https://user-images.githubusercontent.com/81484983/212669108-734a35ec-ab53-46d1-988d-8f154e60cc4e.JPG)

However, it is not possible to **enter new** data:
![_LOC ABBR TYPE](https://user-images.githubusercontent.com/81484983/212669144-96cfa803-0959-4484-8ff3-91d2b9ee389a.JPG)
