### PR TITLE
Fix #4700 - "Show all" does not display all individuals in list

### DIFF
--- a/app/Module/IndividualListModule.php
+++ b/app/Module/IndividualListModule.php
@@ -456,14 +456,21 @@ class IndividualListModule extends AbstractModule implements ModuleListInterface
                         }
                     }
                     if ($show === 'indi') {
+                        /** @var array<string> $surnames */
+                        $surnames = collect($surns)
+                            ->map(static fn (array $surn_variants, string $surn_norm): array => array_keys($surn_variants))
+                            ->flatten()
+                            ->filter(static fn ($surn_variant): bool => is_string($surn_variant) && $surn_variant !== '')
+                            ->toArray();
+
                         if ($families) {
                             echo view('lists/families-table', [
-                                'families' => $this->families($tree, $surname, array_keys($all_surnames[$surname] ?? []), $falpha, $show_marnm === 'yes'),
+                                'families' => $this->families($tree, $surname, $surnames, $falpha, $show_marnm === 'yes'),
                                 'tree'     => $tree,
                             ]);
                         } else {
                             echo view('lists/individuals-table', [
-                                'individuals' => $this->individuals($tree, $surname, array_keys($all_surnames[$surname] ?? []), $falpha, $show_marnm === 'yes', false),
+                                'individuals' => $this->individuals($tree, $surname, $surnames, $falpha, $show_marnm === 'yes', false),
                                 'sosa'        => false,
                                 'tree'        => $tree,
                             ]);


### PR DESCRIPTION
Most of my comments about it are already in the bug section.

In the PR, I am giving a slightly different version than in my last comment, but hopefully, it has the same behavior.

It is the first time I have dug into the `n_surn` / `n_surname` logic, and I hope I have not missing something fundamentals. Whilst testing, I noted some oddities around the "no surname" case, and case sensitivity, but I feel they go beyond that PR, and I will probably raise further issues to discuss those.
