### PR TITLE
Fixes: #2755 Adding privacy for source display to visitors

### DIFF
--- a/app/Http/RequestHandlers/TreePrivacyAction.php
+++ b/app/Http/RequestHandlers/TreePrivacyAction.php
@@ -113,8 +113,8 @@ class TreePrivacyAction implements RequestHandlerInterface
         $show_dead_people           = Validator::parsedBody($request)->string('SHOW_DEAD_PEOPLE');
         $show_living_names          = Validator::parsedBody($request)->string('SHOW_LIVING_NAMES');
         $show_private_relationships = Validator::parsedBody($request)->string('SHOW_PRIVATE_RELATIONSHIPS');
-		$show_source_detail_toggles = Validator::parsedBody($request)->string('SHOW_SOURCE_DETAIL_TOGGLES');
-		$show_source_titles         = Validator::parsedBody($request)->string('SHOW_SOURCE_TITLES');
+	$show_source_detail_toggles = Validator::parsedBody($request)->string('SHOW_SOURCE_DETAIL_TOGGLES');
+	$show_source_titles         = Validator::parsedBody($request)->string('SHOW_SOURCE_TITLES');
 		
         $tree->setPreference('HIDE_LIVE_PEOPLE', $hide_live_people);
         $tree->setPreference('KEEP_ALIVE_YEARS_BIRTH', (string) $keep_alive_years_birth);
@@ -124,8 +124,8 @@ class TreePrivacyAction implements RequestHandlerInterface
         $tree->setPreference('SHOW_DEAD_PEOPLE', $show_dead_people);
         $tree->setPreference('SHOW_LIVING_NAMES', $show_living_names);
         $tree->setPreference('SHOW_PRIVATE_RELATIONSHIPS', $show_private_relationships);
-		$tree->setPreference('SHOW_SOURCE_DETAIL_TOGGLES', $show_source_detail_toggles);
-		$tree->setPreference('SHOW_SOURCE_TITLES', $show_source_titles);
+	$tree->setPreference('SHOW_SOURCE_DETAIL_TOGGLES', $show_source_detail_toggles);
+	$tree->setPreference('SHOW_SOURCE_TITLES', $show_source_titles);
 
         FlashMessages::addMessage(I18N::translate('The preferences for the family tree “%s” have been updated.', e($tree->title())), 'success');
 

--- a/app/Http/RequestHandlers/TreePrivacyAction.php
+++ b/app/Http/RequestHandlers/TreePrivacyAction.php
@@ -113,7 +113,9 @@ class TreePrivacyAction implements RequestHandlerInterface
         $show_dead_people           = Validator::parsedBody($request)->string('SHOW_DEAD_PEOPLE');
         $show_living_names          = Validator::parsedBody($request)->string('SHOW_LIVING_NAMES');
         $show_private_relationships = Validator::parsedBody($request)->string('SHOW_PRIVATE_RELATIONSHIPS');
-
+		$show_source_detail_toggles = Validator::parsedBody($request)->string('SHOW_SOURCE_DETAIL_TOGGLES');
+		$show_source_titles         = Validator::parsedBody($request)->string('SHOW_SOURCE_TITLES');
+		
         $tree->setPreference('HIDE_LIVE_PEOPLE', $hide_live_people);
         $tree->setPreference('KEEP_ALIVE_YEARS_BIRTH', (string) $keep_alive_years_birth);
         $tree->setPreference('KEEP_ALIVE_YEARS_DEATH', (string) $keep_alive_years_death);
@@ -122,6 +124,8 @@ class TreePrivacyAction implements RequestHandlerInterface
         $tree->setPreference('SHOW_DEAD_PEOPLE', $show_dead_people);
         $tree->setPreference('SHOW_LIVING_NAMES', $show_living_names);
         $tree->setPreference('SHOW_PRIVATE_RELATIONSHIPS', $show_private_relationships);
+		$tree->setPreference('SHOW_SOURCE_DETAIL_TOGGLES', $show_source_detail_toggles);
+		$tree->setPreference('SHOW_SOURCE_TITLES', $show_source_titles);
 
         FlashMessages::addMessage(I18N::translate('The preferences for the family tree “%s” have been updated.', e($tree->title())), 'success');
 

--- a/app/Http/RequestHandlers/TreePrivacyAction.php
+++ b/app/Http/RequestHandlers/TreePrivacyAction.php
@@ -113,9 +113,9 @@ class TreePrivacyAction implements RequestHandlerInterface
         $show_dead_people           = Validator::parsedBody($request)->string('SHOW_DEAD_PEOPLE');
         $show_living_names          = Validator::parsedBody($request)->string('SHOW_LIVING_NAMES');
         $show_private_relationships = Validator::parsedBody($request)->string('SHOW_PRIVATE_RELATIONSHIPS');
-	$show_source_detail_toggles = Validator::parsedBody($request)->string('SHOW_SOURCE_DETAIL_TOGGLES');
-	$show_source_titles         = Validator::parsedBody($request)->string('SHOW_SOURCE_TITLES');
-		
+        $show_source_detail_toggles = Validator::parsedBody($request)->string('SHOW_SOURCE_DETAIL_TOGGLES');
+        $show_source_titles         = Validator::parsedBody($request)->string('SHOW_SOURCE_TITLES');
+
         $tree->setPreference('HIDE_LIVE_PEOPLE', $hide_live_people);
         $tree->setPreference('KEEP_ALIVE_YEARS_BIRTH', (string) $keep_alive_years_birth);
         $tree->setPreference('KEEP_ALIVE_YEARS_DEATH', (string) $keep_alive_years_death);
@@ -124,8 +124,8 @@ class TreePrivacyAction implements RequestHandlerInterface
         $tree->setPreference('SHOW_DEAD_PEOPLE', $show_dead_people);
         $tree->setPreference('SHOW_LIVING_NAMES', $show_living_names);
         $tree->setPreference('SHOW_PRIVATE_RELATIONSHIPS', $show_private_relationships);
-	$tree->setPreference('SHOW_SOURCE_DETAIL_TOGGLES', $show_source_detail_toggles);
-	$tree->setPreference('SHOW_SOURCE_TITLES', $show_source_titles);
+        $tree->setPreference('SHOW_SOURCE_DETAIL_TOGGLES', $show_source_detail_toggles);
+        $tree->setPreference('SHOW_SOURCE_TITLES', $show_source_titles);
 
         FlashMessages::addMessage(I18N::translate('The preferences for the family tree “%s” have been updated.', e($tree->title())), 'success');
 

--- a/resources/views/admin/trees-preferences.phtml
+++ b/resources/views/admin/trees-preferences.phtml
@@ -544,7 +544,7 @@ use Illuminate\Support\Collection;
             <?= view('components/radios-inline', ['name' => 'EXPAND_SOURCES', 'options' => [I18N::translate('no'), I18N::translate('yes')], 'selected' => (int) $tree->getPreference('EXPAND_SOURCES')]) ?>
             <div class="form-text">
                 <?= /* I18N: Help text for the “Automatically expand sources” configuration setting */
-                I18N::translate('This option controls whether or not to automatically display content of a <i>Source</i> record on the Individual page.') ?>
+                I18N::translate('This option controls whether or not to automatically display content of a <i>Source</i> record on the Individual page. A yes setting may be overriden by tree privacy settings regarding the display of source details and titles.') ?>
             </div>
         </div>
     </fieldset>

--- a/resources/views/admin/trees-privacy.phtml
+++ b/resources/views/admin/trees-privacy.phtml
@@ -153,6 +153,45 @@ use Fisharebest\Webtrees\View;
             </div>
         </div>
     </div>
+	
+	<!-- SHOW_SOURCE_DETAIL_TOGGLES -->
+    <div class="row mb-3">
+        <div class="col-form-label col-sm-4">
+            <label for="SHOW_SOURCE_DETAIL_TOGGLES">
+                <?= /* I18N: A configuration setting */ I18N::translate('Show source detail toggles in facts and events tables') ?>
+            </label>
+            <div class="hidden-xs">
+                <span class="badge visitors"><?= I18N::translate('visitors') ?></span>
+                <span class="badge members"><?= I18N::translate('members') ?></span>
+            </div>
+        </div>
+        <div class="col-sm-8">
+            <?= view('components/select', ['name' => 'SHOW_SOURCE_DETAIL_TOGGLES', 'selected' => $tree->getPreference('SHOW_SOURCE_DETAIL_TOGGLES'), 'options' => ['0' => I18N::translate('Show to visitors'), '1' => I18N::translate('Show to members')]]) ?>
+            <div class="form-text">
+                <?= /* I18N: Help text for the “Show source detail toggles in facts and events tables” configuration setting */ I18N::translate('This option will display the arrow toggles to expand source details in facts and events tables for individuals and families. This will override any automatic display of source details.') ?>
+            </div>
+        </div>
+    </div>
+
+	<!-- SHOW_SOURCE_TITLES -->
+    <div class="row mb-3">
+        <div class="col-form-label col-sm-4">
+            <label for="SHOW_SOURCE_TITLES">
+                <?= /* I18N: A configuration setting */ I18N::translate('Show source titles in facts and events tables') ?>
+            </label>
+            <div class="hidden-xs">
+                <span class="badge visitors"><?= I18N::translate('visitors') ?></span>
+                <span class="badge members"><?= I18N::translate('members') ?></span>
+            </div>
+        </div>
+        <div class="col-sm-8">
+            <?= view('components/select', ['name' => 'SHOW_SOURCE_TITLES', 'selected' => $tree->getPreference('SHOW_SOURCE_TITLES'), 'options' => ['0' => I18N::translate('Show to visitors'), '1' => I18N::translate('Show to members')]]) ?>
+            <div class="form-text">
+                <?= /* I18N: Help text for the “Show source titles in facts and events tables” configuration setting */ I18N::translate('This option will display the source titles in facts and events tables for individuals and families. If not allowed, no source details will be available, and the source title will be replaced with PRIVATE.') ?>
+            </div>
+        </div>
+    </div>
+	
     <h2><?= /* I18N: Privacy restrictions are set by RESN tags in GEDCOM. */ I18N::translate('Privacy restrictions') ?></h2>
     <p>
         <?= /* I18N: Privacy restrictions are RESN tags in GEDCOM. */ I18N::translate('You can set the access for a specific record, fact, or event by adding a restriction to it. If a record, fact, or event does not have a restriction, the following default restrictions will be used.') ?>
@@ -344,7 +383,9 @@ use Fisharebest\Webtrees\View;
     var hideLivePeople = parseInt($('[name=HIDE_LIVE_PEOPLE]').val(), 10);
     var showLivingNames = parseInt($('[name=SHOW_LIVING_NAMES]').val(), 10);
     var showPrivateRelationships = parseInt($('[name=SHOW_PRIVATE_RELATIONSHIPS]').val(), 10);
-
+	var showSourceDetailToggles = parseInt($('[name=SHOW_SOURCE_DETAIL_TOGGLES]').val(), 10);
+	var showSourceTitles = parseInt($('[name=SHOW_SOURCE_TITLES]').val(), 10);
+	
     setPrivacyFeedback('[name=REQUIRE_AUTHENTICATION]', 'visitors', requireAuthentication === 0);
     setPrivacyFeedback('[name=REQUIRE_AUTHENTICATION]', 'members', true);
 
@@ -360,11 +401,17 @@ use Fisharebest\Webtrees\View;
 
     setPrivacyFeedback('[name=SHOW_PRIVATE_RELATIONSHIPS]', 'visitors', requireAuthentication === 0 && showPrivateRelationships >= 1);
     setPrivacyFeedback('[name=SHOW_PRIVATE_RELATIONSHIPS]', 'members', showPrivateRelationships >= 1);
+
+	setPrivacyFeedback('[name=SHOW_SOURCE_DETAIL_TOGGLES]', 'visitors', requireAuthentication === 0 && showSourceDetailToggles === 0);
+    setPrivacyFeedback('[name=SHOW_SOURCE_DETAIL_TOGGLES]', 'members', true);
+	
+	setPrivacyFeedback('[name=SHOW_SOURCE_TITLES]', 'visitors', requireAuthentication === 0 && showSourceTitles === 0);
+    setPrivacyFeedback('[name=SHOW_SOURCE_TITLES]', 'members', true);	
   }
 
   // Activate the privacy feedback labels.
   updatePrivacyFeedback();
-  $('[name=REQUIRE_AUTHENTICATION], [name=HIDE_LIVE_PEOPLE], [name=SHOW_DEAD_PEOPLE], [name=SHOW_LIVING_NAMES], [name=SHOW_PRIVATE_RELATIONSHIPS]').on('change', function () {
+  $('[name=REQUIRE_AUTHENTICATION], [name=HIDE_LIVE_PEOPLE], [name=SHOW_DEAD_PEOPLE], [name=SHOW_LIVING_NAMES], [name=SHOW_PRIVATE_RELATIONSHIPS], [name=SHOW_SOURCE_DETAIL_TOGGLES], [name=SHOW_SOURCE_TITLES]').on('change', function () {
     updatePrivacyFeedback();
   });
 

--- a/resources/views/fact-gedcom-fields.phtml
+++ b/resources/views/fact-gedcom-fields.phtml
@@ -10,6 +10,7 @@ use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\Registry;
 use Fisharebest\Webtrees\Source;
 use Fisharebest\Webtrees\Tree;
+use Fisharebest\Webtrees\Auth;
 
 /**
  * @var string $gedcom
@@ -58,16 +59,24 @@ foreach ($keys as $key) {
         <?php $id = Registry::idFactory()->id() ?>
         <?php $expanded = $tree->getPreference('EXPAND_SOURCES') === '1' ?>
         <div>
-            <button type="button" class="btn btn-text p-0" href="#<?= e($id) ?>" data-bs-toggle="collapse" aria-controls="<?= e($id) ?>" aria-expanded="<?= $expanded ? 'true' : 'false' ?>">
-                <?= view('icons/expand') ?>
-                <?= view('icons/collapse') ?>
-             </button>
+			<?php if (Auth::isMember($tree) || ($tree->getPreference('SHOW_SOURCE_DETAIL_TOGGLES') === '0' && $tree->getPreference('SHOW_SOURCE_TITLES') === '0')) : ?>
+				<button type="button" class="btn btn-text p-0" href="#<?= e($id) ?>" data-bs-toggle="collapse" aria-controls="<?= e($id) ?>" aria-expanded="<?= $expanded ? 'true' : 'false' ?>">
+					<?= view('icons/expand') ?>
+					<?= view('icons/collapse') ?>
+				</button>
+			<?php else: ?>
+				<?php $expanded = '' ?>
+			<?php endif ?>
 
             <?php $label = '<span class="label">' . I18N::translate('Source') . '</span>' ?>
-            <?php $value = '<span class="field" dir="auto"><a href="' . e($source->url()) . '">' . $source->fullName() . '</a></span>' ?>
+			<?php if (Auth::isMember($tree) || $tree->getPreference('SHOW_SOURCE_TITLES') === '0') : ?>
+				<?php $value = '<span class="field" dir="auto"><a href="' . e($source->url()) . '">' . $source->fullName() . '</a></span>' ?>
+			<?php else: ?>
+				<?php $value = '<span class="field" dir="auto">' . I18N::translate('PRIVATE') . '</span>' ?>
+				<?php $expanded = '' ?>
+			<?php endif ?>
             <?= I18N::translate('%1$s: %2$s', $label, $value) ?>
         </div>
-
         <div id="<?= e($id) ?>" class="ps-4 collapse <?= $expanded ? 'show' : '' ?>">
             <?php array_shift($keys) ?>
             <?php foreach ($keys as $key) : ?>

--- a/resources/views/fact-gedcom-fields.phtml
+++ b/resources/views/fact-gedcom-fields.phtml
@@ -72,7 +72,7 @@ foreach ($keys as $key) {
 			<?php if (Auth::isMember($tree) || $tree->getPreference('SHOW_SOURCE_TITLES') === '0') : ?>
 				<?php $value = '<span class="field" dir="auto"><a href="' . e($source->url()) . '">' . $source->fullName() . '</a></span>' ?>
 			<?php else: ?>
-				<?php $value = '<span class="field" dir="auto">' . I18N::translate('PRIVATE') . '</span>' ?>
+				<?php $value = '<span class="field" dir="auto">' . I18N::translate('Private') . '</span>' ?>
 				<?php $expanded = '' ?>
 			<?php endif ?>
             <?= I18N::translate('%1$s: %2$s', $label, $value) ?>


### PR DESCRIPTION
Long-time user, first-time contributor.  Please be gentle :-)

In November of 2019, I suggested both in the forums and through a git suggestion (#2755) that I'd like there to be a way to hide source details from visitors and make them available only to members.  From my original forum post, "Even though my main site contains only the non-living people I export out of RootsMagic, I'm suddenly not fond of my full source broadcasting. However, I want something there so people don't think my work is sourceless and I'm some kind of noob hack (I do still consider myself a noob hack, but the rest of the world doesn't need to know that)."

My modifications add two new options to the tree privacy page:

![2023-02-04_210612](https://user-images.githubusercontent.com/43183321/216800527-a61754cc-d104-45e6-a096-dceef1ddb3f2.jpg)

These are a few sources for my dad.  This is how they normally look:

![2023-02-04_210855](https://user-images.githubusercontent.com/43183321/216800573-98ff4e62-b7d0-4e84-a5ea-268ad6a794ac.jpg)

If the source detail toggles are disabled for visitors, they look like this.

![2023-02-04_210924](https://user-images.githubusercontent.com/43183321/216800601-7ef05379-8f7e-4260-a884-37e21281c2fa.jpg)

Finally, if the source titles are disabled or visitors, they look like this:

![2023-02-04_210948](https://user-images.githubusercontent.com/43183321/216800624-73ed61cf-530f-4cc2-9790-a07d99254d02.jpg)

That's about it.  The fact that sources exist can be conveyed to non-authenticated visitors without revealing any detailed information (or any information at all).

Even if these changes don't get accepted into Webtrees proper, no worries, it was a good coding experience dabbling into .phtml files for the first time and learning the submission process.

Cheers,

Bill