### PR TITLE
Leaflet controls fix

### DIFF
--- a/resources/js/webtrees.js
+++ b/resources/js/webtrees.js
@@ -743,7 +743,7 @@
       zoomControl: false,
     })
       .addControl(zoomControl)
-      .addControl(new fullscreenControl)
+      .addControl(new fullscreenControl())
       .addControl(new resetControl())
       .addLayer(defaultLayer)
       .addControl(L.control.layers.tree(config.mapProviders, null, {

--- a/resources/js/webtrees.js
+++ b/resources/js/webtrees.js
@@ -692,7 +692,7 @@
         anchor.href = '#';
         anchor.setAttribute('aria-label', config.i18n.reset); /* Firefox doesn't yet support element.ariaLabel */
         anchor.title = config.i18n.reset;
-        anchor.role = 'button';
+        anchor.setAttribute('role', 'button');
         anchor.innerHTML = config.icons.reset;
         anchor.onclick = resetCallback;
 
@@ -708,6 +708,7 @@
         const container = L.DomUtil.create('div', 'leaflet-bar leaflet-control leaflet-control-custom');
         const anchor = L.DomUtil.create('a', 'leaflet-control-fullscreen', container);
 
+        anchor.href = '#';
         anchor.setAttribute('role', 'button');
         anchor.dataset.wtFullscreen = '.wt-fullscreen-container';
         anchor.innerHTML = config.icons.fullScreen;


### PR DESCRIPTION
I've been modifying resources\views\admin\location-edit.phtml so that when requesting fullscreen the form is also fullscreened. For some time I couldn't figure out why occasionally a coloured bar appeared on the right hand side of the map (blue on Firefox, black on Chrome and Edge) - eventually (after 2 days of fiddling) it turned out to be the omission of the `href="#"` line in the leaflet fullscreen control (element focused?). In addition, for the reset control, the line `anchor.role = 'button';` doesn't work - changed to  `anchor.setAttribute('role', 'button');`