### PR TITLE
Improve detection of map provider with missing Api key

### DIFF
--- a/app/Module/BingMaps.php
+++ b/app/Module/BingMaps.php
@@ -19,11 +19,8 @@ declare(strict_types=1);
 
 namespace Fisharebest\Webtrees\Module;
 
-use Fisharebest\Webtrees\Auth;
 use Fisharebest\Webtrees\FlashMessages;
-use Fisharebest\Webtrees\Http\Exceptions\HttpServerErrorException;
 use Fisharebest\Webtrees\I18N;
-use Fisharebest\Webtrees\Registry;
 use Fisharebest\Webtrees\Validator;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -110,16 +107,6 @@ class BingMaps extends AbstractModule implements ModuleConfigInterface, ModuleMa
     public function leafletJsTileLayers(): array
     {
         $api_key = $this->getPreference('api_key');
-
-        if ($api_key === '') {
-            $message = I18N::translate('This service requires an API key.');
-
-            if (Auth::isAdmin()) {
-                $message = '<a href="' . e($this->getConfigLink()) . '">' . $message . '</a>';
-            }
-
-            throw new HttpServerErrorException($message);
-        }
 
         return [
             (object) [

--- a/app/Module/GoogleMaps.php
+++ b/app/Module/GoogleMaps.php
@@ -19,15 +19,12 @@ declare(strict_types=1);
 
 namespace Fisharebest\Webtrees\Module;
 
-use Fisharebest\Webtrees\Auth;
 use Fisharebest\Webtrees\FlashMessages;
-use Fisharebest\Webtrees\Http\Exceptions\HttpServerErrorException;
 use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\Validator;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-use function e;
 use function redirect;
 
 /**
@@ -110,16 +107,6 @@ class GoogleMaps extends AbstractModule implements ModuleConfigInterface, Module
     public function leafletJsTileLayers(): array
     {
         $api_key = $this->getPreference('api_key');
-
-        if ($api_key === '') {
-            $message = I18N::translate('This service requires an API key.');
-
-            if (Auth::isAdmin()) {
-                $message = '<a href="' . e($this->getConfigLink()) . '">' . $message . '</a>';
-            }
-
-            throw new HttpServerErrorException($message);
-        }
 
         return [
             (object) [

--- a/app/Module/HereMaps.php
+++ b/app/Module/HereMaps.php
@@ -19,15 +19,12 @@ declare(strict_types=1);
 
 namespace Fisharebest\Webtrees\Module;
 
-use Fisharebest\Webtrees\Auth;
 use Fisharebest\Webtrees\FlashMessages;
-use Fisharebest\Webtrees\Http\Exceptions\HttpServerErrorException;
 use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\Validator;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-use function e;
 use function redirect;
 
 /**
@@ -69,16 +66,6 @@ class HereMaps extends AbstractModule implements ModuleConfigInterface, ModuleMa
         $this->layout = 'layouts/administration';
 
         $api_key = $this->getPreference('api_key');
-
-        if ($api_key === '') {
-            $message = I18N::translate('This service requires an API key.');
-
-            if (Auth::isAdmin()) {
-                $message = '<a href="' . e($this->getConfigLink()) . '">' . $message . '</a>';
-            }
-
-            throw new HttpServerErrorException($message);
-        }
 
         return $this->viewResponse('modules/here-maps/config', [
             'api_key' => $api_key,

--- a/app/Module/MapBox.php
+++ b/app/Module/MapBox.php
@@ -19,15 +19,12 @@ declare(strict_types=1);
 
 namespace Fisharebest\Webtrees\Module;
 
-use Fisharebest\Webtrees\Auth;
 use Fisharebest\Webtrees\FlashMessages;
-use Fisharebest\Webtrees\Http\Exceptions\HttpServerErrorException;
 use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\Validator;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-use function e;
 use function redirect;
 
 /**
@@ -69,16 +66,6 @@ class MapBox extends AbstractModule implements ModuleConfigInterface, ModuleMapP
         $this->layout = 'layouts/administration';
 
         $api_key = $this->getPreference('api_key');
-
-        if ($api_key === '') {
-            $message = I18N::translate('This service requires an API key.');
-
-            if (Auth::isAdmin()) {
-                $message = '<a href="' . e($this->getConfigLink()) . '">' . $message . '</a>';
-            }
-
-            throw new HttpServerErrorException($message);
-        }
 
         return $this->viewResponse('modules/map-box/config', [
             'api_key' => $api_key,

--- a/app/Module/ModuleMapProviderInterface.php
+++ b/app/Module/ModuleMapProviderInterface.php
@@ -30,4 +30,11 @@ interface ModuleMapProviderInterface extends ModuleInterface
      * @return array<object>
      */
     public function leafletJsTileLayers(): array;
+
+    /**
+     * Check if provider has valid api key
+     *
+     * @return bool
+     */
+    public function hasApiKey(): bool;
 }

--- a/app/Module/ModuleMapProviderTrait.php
+++ b/app/Module/ModuleMapProviderTrait.php
@@ -19,11 +19,19 @@ declare(strict_types=1);
 
 namespace Fisharebest\Webtrees\Module;
 
+use Fisharebest\Webtrees\Auth;
+use Fisharebest\Webtrees\Http\Exceptions\HttpServerErrorException;
+use Fisharebest\Webtrees\I18N;
+
+use function e;
+
 /**
  * Trait ModuleMapProviderTrait - default implementation of ModuleMapProviderInterface
  */
 trait ModuleMapProviderTrait
 {
+    use ModuleConfigTrait;
+
     /**
      * Parameters to create a TileLayer in LeafletJs.
      *
@@ -32,5 +40,24 @@ trait ModuleMapProviderTrait
     public function leafletJsTileLayers(): array
     {
         return [];
+    }
+
+    /**
+     *  If module requires an api key then return false if not valid
+     *
+     * @return bool
+     * @throws HttpServerErrorException
+     */
+    public function hasApiKey(): bool
+    {
+        $api_key = $this->getPreference('api_key', 'not-needed');
+
+        if ($api_key !== 'not-needed' && $api_key === '' && Auth::isAdmin()) {
+            $message = I18N::translate('<a href="%s">The %s service requires an API key.', e($this->getConfigLink()), $this->title());
+
+            throw new HttpServerErrorException($message);
+        }
+
+        return $api_key !== '';
     }
 }

--- a/app/Module/ModuleMapProviderTrait.php
+++ b/app/Module/ModuleMapProviderTrait.php
@@ -50,14 +50,18 @@ trait ModuleMapProviderTrait
      */
     public function hasApiKey(): bool
     {
-        $api_key = $this->getPreference('api_key', 'not-needed');
+        $api_key = $this->getPreference('api_key');
 
-        if ($api_key !== 'not-needed' && $api_key === '' && Auth::isAdmin()) {
+        // Do the functions to manage the config page exist in the provider module?
+        $function_diff = array_diff(get_class_methods(get_class($this)), get_class_methods((string) get_parent_class($this)));
+
+        $error = in_array("getAdminAction", $function_diff) && $api_key === '';
+        if ($error && Auth::isAdmin()) {
             $message = I18N::translate('<a href="%s">The %s service requires an API key.', e($this->getConfigLink()), $this->title());
 
             throw new HttpServerErrorException($message);
         }
 
-        return $api_key !== '';
+        return !$error;
     }
 }

--- a/app/Module/ModuleMapProviderTrait.php
+++ b/app/Module/ModuleMapProviderTrait.php
@@ -43,21 +43,18 @@ trait ModuleMapProviderTrait
     }
 
     /**
-     *  Check if Module contains the functions for a config page,
-     *  If so then an api key is required so check if it is empty
+     *  If module requires an api key then return false if not valid
      *
      * @return bool
      * @throws HttpServerErrorException
      */
     public function hasApiKey(): bool
     {
-        $error = in_array("getAdminAction", get_class_methods($this)) && $this->getPreference('api_key') === '';
-        if ($error && Auth::isAdmin()) {
+        $api_key = $this->getPreference('api_key', 'not-needed');
+        if ($api_key !== 'not-needed' && $api_key === '' && Auth::isAdmin()) {
             $message = I18N::translate('<a href="%s">The %s service requires an API key.', e($this->getConfigLink()), $this->title());
-
             throw new HttpServerErrorException($message);
         }
-
-        return !$error;
+        return $api_key !== '';
     }
 }

--- a/app/Module/ModuleMapProviderTrait.php
+++ b/app/Module/ModuleMapProviderTrait.php
@@ -43,19 +43,15 @@ trait ModuleMapProviderTrait
     }
 
     /**
-     *  If module requires an api key then return false if not valid
+     *  Check if Module contains the functions for a config page,
+     *  If so then an api key is required so check if it is empty
      *
      * @return bool
      * @throws HttpServerErrorException
      */
     public function hasApiKey(): bool
     {
-        $api_key = $this->getPreference('api_key');
-
-        // Do the functions to manage the config page exist in the provider module?
-        $function_diff = array_diff(get_class_methods(get_class($this)), get_class_methods((string) get_parent_class($this)));
-
-        $error = in_array("getAdminAction", $function_diff) && $api_key === '';
+        $error = in_array("getAdminAction", get_class_methods($this)) && $this->getPreference('api_key') === '';
         if ($error && Auth::isAdmin()) {
             $message = I18N::translate('<a href="%s">The %s service requires an API key.', e($this->getConfigLink()), $this->title());
 

--- a/app/Services/LeafletJsService.php
+++ b/app/Services/LeafletJsService.php
@@ -53,7 +53,7 @@ class LeafletJsService
             ->filter(function ($item) {
                 $hasApiKey = $item->hasApiKey();
                 if (!$hasApiKey) {
-                    Log::addErrorLog('Map provider "' . $item->title() . '" does not have a valid api key');
+                    Log::addErrorLog('Map provider "' . $item->title() . '" does not have an api key');
                 }
 
                 return $hasApiKey;


### PR DESCRIPTION
fixs https://github.com/fisharebest/webtrees/issues/4758 (now closed)

Applies to map providers that are enabled and require an api key but the key has been omitted.

For users without Admin permissions, previously for the offending provider an exception was raised which blocked access to all the maps. Now the offending provider is silently omitted from the list of available providers and an entry in the error log is made.

For Admin users an exception is raised with a link to the offending providers configuration page. (same as previously)