### PR TITLE
Pedigree map - Fix page scroll on click of sidebar element

### DIFF
--- a/resources/css/_chart-pedigree-map.css
+++ b/resources/css/_chart-pedigree-map.css
@@ -93,3 +93,8 @@
     height: 100%;
     overflow-y: auto;
 }
+
+.leaflet-popup-content .wt-popup {
+    pointer-events: none;
+    color: var(--link-color);
+}

--- a/resources/css/_chart-pedigree-map.css
+++ b/resources/css/_chart-pedigree-map.css
@@ -93,8 +93,3 @@
     height: 100%;
     overflow-y: auto;
 }
-
-.leaflet-popup-content .wt-popup {
-    pointer-events: none;
-    color: var(--link-color);
-}

--- a/resources/views/modules/pedigree-map/chart.phtml
+++ b/resources/views/modules/pedigree-map/chart.phtml
@@ -109,6 +109,7 @@ use Fisharebest\Webtrees\View;
     window.onload = function() {
       // Activate marker popup when sidebar entry clicked
       sidebar.addEventListener('click', (e) => {
+        e.preventDefault();
         if (e.target.matches('[data-wt-sosa]')) {
           map.closePopup();
 

--- a/resources/views/modules/pedigree-map/chart.phtml
+++ b/resources/views/modules/pedigree-map/chart.phtml
@@ -108,16 +108,16 @@ use Fisharebest\Webtrees\View;
 
     window.onload = function() {
       // Activate marker popup when sidebar entry clicked
-      sidebar.addEventListener('click', (e) => {
-        if (e.target.matches('[data-wt-sosa]')) {
-          e.preventDefault();
-          map.closePopup();
-
-          let marker = markers.getLayers().filter(function (v) {
-            return v.feature !== undefined && v.feature.id === parseInt(e.target.dataset.wtSosa);
-          }).pop();
-
-          markers.zoomToShowLayer(marker, () => marker.openPopup());
+      sidebar.addEventListener('click', (evt) => {
+        // Only perform map action if evt was not initiated from an anchor element
+        if (!evt.target.closest('a')) {
+          //find the marker corresponding to the clicked event
+          const eventId = parseInt(evt.target.closest('.gchart').dataset.wtFeatureId);
+          let mkrLayer = markers.getLayers().filter(function (v) {
+            return v.feature !== undefined && v.feature.id === eventId;
+          });
+          const mkr = mkrLayer.pop();
+          markers.zoomToShowLayer(mkr, () => mkr.openPopup());
 
           return false;
         }

--- a/resources/views/modules/pedigree-map/chart.phtml
+++ b/resources/views/modules/pedigree-map/chart.phtml
@@ -109,8 +109,8 @@ use Fisharebest\Webtrees\View;
     window.onload = function() {
       // Activate marker popup when sidebar entry clicked
       sidebar.addEventListener('click', (e) => {
-        e.preventDefault();
         if (e.target.matches('[data-wt-sosa]')) {
+          e.preventDefault();
           map.closePopup();
 
           let marker = markers.getLayers().filter(function (v) {

--- a/resources/views/modules/pedigree-map/events.phtml
+++ b/resources/views/modules/pedigree-map/events.phtml
@@ -14,11 +14,9 @@ use Fisharebest\Webtrees\Fact;
 ?>
 <div class="d-flex justify-content-between">
     <div>
-        <div>
+        <div class="label">
             <span class="<?= $class ?>"><?= view('icons/location') ?></span>
-            <a href="#" data-wt-sosa="<?= $sosa ?>">
-                <?= $relationship ?>
-            </a>
+            <?= $relationship ?>
         </div>
 
         <div>

--- a/resources/views/modules/pedigree-map/events.phtml
+++ b/resources/views/modules/pedigree-map/events.phtml
@@ -15,7 +15,7 @@ use Fisharebest\Webtrees\Fact;
 <div class="d-flex justify-content-between">
     <div>
         <div>
-            <a href="#" data-wt-sosa="<?= $sosa ?>">
+            <a href="#" class ="wt-popup" data-wt-sosa="<?= $sosa ?>">
                 <span class="<?= $class ?>"><?= view('icons/location') ?></span>
                 <?= $relationship ?>
             </a>

--- a/resources/views/modules/pedigree-map/events.phtml
+++ b/resources/views/modules/pedigree-map/events.phtml
@@ -15,8 +15,8 @@ use Fisharebest\Webtrees\Fact;
 <div class="d-flex justify-content-between">
     <div>
         <div>
-            <a href="#" class ="wt-popup" data-wt-sosa="<?= $sosa ?>">
-                <span class="<?= $class ?>"><?= view('icons/location') ?></span>
+            <span class="<?= $class ?>"><?= view('icons/location') ?></span>
+            <a href="#" data-wt-sosa="<?= $sosa ?>">
                 <?= $relationship ?>
             </a>
         </div>


### PR DESCRIPTION
(2nd submission - code tidy)

See [Forum message](https://www.webtrees.net/index.php/en/forum/9-request-for-new-feature/37850-pedigree-map-scrolling-home). Prevent page scroll to top when clicking on the sidebar Relationship field.

(I thought we fixed this some time ago)