### PR TITLE
Fix map pages: force footer to bottom and tidy pedigree map & place hierarchy layouts

### DIFF
--- a/resources/css/_chart-pedigree-map.css
+++ b/resources/css/_chart-pedigree-map.css
@@ -31,6 +31,7 @@
     --wt-pedigree-map-gen-9: pink;
     --wt-pedigree-map-gen-10: magenta;
     --wt-pedigree-map-gen-11: maroon;
+    --wt-pedigree-map-height: 70vh;
 }
 
 .wt-pedigree-map-gen-0 {
@@ -81,15 +82,11 @@
     color: var(--wt-pedigree-map-gen-11);
 }
 
-.wt-pedigree-map-wrapper {
-    height: 70vh;
-}
-
 .wt-pedigree-map-map {
-    height: 100%;
+    height: var(--wt-pedigree-map-height);
 }
 
 .wt-pedigree-map-sidebar {
-    height: 100%;
+    height: var(--wt-pedigree-map-height);
     overflow-y: auto;
 }

--- a/resources/css/_list-places.css
+++ b/resources/css/_list-places.css
@@ -18,15 +18,16 @@
  *
  * wt-route-place-list
  */
- .wt-place-hierarchy-wrapper {
-    height: 70vh;
+
+ :root {
+    --wt-place-hierarchy-map-height: 70vh;
 }
 
 .wt-place-hierarchy-map {
-    height: 100%;
+    height: var(--wt-place-hierarchy-map-height);
 }
 
 .wt-place-hierarchy-sidebar {
-    height: 100%;
+    height: var(--wt-place-hierarchy-map-height);
     overflow-y: auto;
 }

--- a/resources/css/_tab-places.css
+++ b/resources/css/_tab-places.css
@@ -19,15 +19,15 @@
  * wt-tabs-individual
  * +--- wt-tab-places
  */
-.wt-places-tab-wrapper {
-    height: 70vh
-}
 
+:root {
+    --wt-places-tab-map-height: 70vh;
+}
 .wt-places-tab-map {
-    height: 100%
+    height: var(--wt-places-tab-map-height);
 }
 
 .wt-places-tab-sidebar {
-    height: 100%;
+    height: var(--wt-places-tab-map-height);
     overflow-y: auto;
 }

--- a/resources/views/modules/pedigree-map/chart.phtml
+++ b/resources/views/modules/pedigree-map/chart.phtml
@@ -13,7 +13,7 @@ use Fisharebest\Webtrees\View;
 
 <div class="row my-4 gchart wt-pedigree-map-wrapper wt-fullscreen-container">
     <div id="wt-map" class="col-sm-9 wt-ajax-load wt-map wt-pedigree-map-map" dir="ltr"></div>
-    <ul class="col-sm-3 wt-pedigree-map-sidebar wt-page-options-value list-unstyled px-1"></ul>
+    <ul class="col-sm-3 wt-pedigree-map-sidebar wt-page-options-value list-unstyled px-1 mb-0"></ul>
 </div>
 
 <?php View::push('javascript') ?>
@@ -97,7 +97,7 @@ use Fisharebest\Webtrees\View;
             }
 
             layer.bindPopup(feature.properties.summary);
-            sidebar.innerHTML += `<li class="gchart my-1" data-wt-feature-id=${feature.id}>${feature.properties.summary}</li>`;
+            sidebar.innerHTML += `<li class="gchart p-1 mb-1" data-wt-feature-id=${feature.id}>${feature.properties.summary}</li>`;
           },
         });
         markers.addLayer(geoJsonLayer);

--- a/resources/views/modules/place-hierarchy/map.phtml
+++ b/resources/views/modules/place-hierarchy/map.phtml
@@ -13,7 +13,7 @@ use Fisharebest\Webtrees\View;
 
 <div class="row gchart wt-place-hierarchy-wrapper wt-fullscreen-container">
     <div id="wt-map" class="col-sm-9 wt-ajax-load wt-map wt-place-hierarchy-map" dir="ltr"></div>
-    <ul class="col-sm-3 wt-place-hierarchy-sidebar wt-page-options-value list-unstyled px-md-1"></ul>
+    <ul class="col-sm-3 wt-place-hierarchy-sidebar wt-page-options-value list-unstyled px-md-1 mb-0"></ul>
 </div>
 
 <?php View::push('javascript') ?>

--- a/resources/views/modules/place-hierarchy/sidebar.phtml
+++ b/resources/views/modules/place-hierarchy/sidebar.phtml
@@ -18,7 +18,7 @@ use Fisharebest\Webtrees\Place;
  */
 ?>
 
-<li class="gchart px-md-2 <?= $sidebar_class ?>" data-wt-feature-id="<?= $id ?>">
+<li class="gchart px-md-2 mb-1 <?= $sidebar_class ?>" data-wt-feature-id="<?= $id ?>">
     <div class="row label">
         <div class="col" style="word-wrap: break-word">
             <?php if ($showlink) : ?>

--- a/resources/views/modules/place-hierarchy/sidebar.phtml
+++ b/resources/views/modules/place-hierarchy/sidebar.phtml
@@ -20,7 +20,7 @@ use Fisharebest\Webtrees\Place;
 
 <li class="gchart px-md-2 mb-1 <?= $sidebar_class ?>" data-wt-feature-id="<?= $id ?>">
     <div class="row label">
-        <div class="col" style="word-wrap: break-word">
+        <div class="col text-break">
             <?php if ($showlink) : ?>
                 <a href="<?= e($place->url()) ?>">
                     <?= $place->placeName() ?>


### PR DESCRIPTION
Fixes https://github.com/fisharebest/webtrees/issues/4789

For all user map pages, It is necessary to give the map and sidebar elements a defined height so that on small devices where the elements are stacked, the footer is pushed below them.

In addition tidy margin and padding on pedigree map & place hierarchy layouts