### PR TITLE
All map pages -add fullscreen css

### DIFF
--- a/resources/css/_chart-pedigree-map.css
+++ b/resources/css/_chart-pedigree-map.css
@@ -90,3 +90,11 @@
     height: var(--wt-pedigree-map-height);
     overflow-y: auto;
 }
+
+:fullscreen .wt-pedigree-map-map {
+    height:100%;
+}
+
+:fullscreen .wt-pedigree-map-sidebar {
+    height:100%;
+}

--- a/resources/css/_list-places.css
+++ b/resources/css/_list-places.css
@@ -31,3 +31,11 @@
     height: var(--wt-place-hierarchy-map-height);
     overflow-y: auto;
 }
+
+:fullscreen .wt-place-hierarchy-map {
+    height:100%;
+}
+
+:fullscreen .wt-place-hierarchy-sidebar {
+    height:100%;
+}

--- a/resources/css/_tab-places.css
+++ b/resources/css/_tab-places.css
@@ -31,3 +31,11 @@
     height: var(--wt-places-tab-map-height);
     overflow-y: auto;
 }
+
+:fullscreen .wt-places-tab-map {
+    height:100%;
+}
+
+:fullscreen .wt-places-tab-sidebar {
+    height:100%;
+}

--- a/resources/css/administration.css
+++ b/resources/css/administration.css
@@ -23,6 +23,7 @@
     --link-color: #0d6efd;
     --link-decoration-hover: underline;
     --link-decoration: none;
+    --location-edit-map: 70vh;
 }
 
 /* Heading sizes */
@@ -58,10 +59,18 @@ h4 {
 
 /* Location edit maps */
 .wt-location-edit-map {
-    height: 55vh;
+    height: var(--location-edit-map);
+}
+
+.wt-location-edit-sidebar {
+    height: var(--location-edit-map);
 }
 
 :fullscreen .wt-location-edit-map {
+    height: 100%;
+}
+
+:fullscreen .wt-location-edit-sidebar {
     height: 100%;
 }
 

--- a/resources/views/admin/location-edit.phtml
+++ b/resources/views/admin/location-edit.phtml
@@ -29,7 +29,7 @@ use Fisharebest\Webtrees\View;
 <div class="row wt-location-edit-wrapper wt-fullscreen-container">
     <div id="wt-map" class="col-sm-9 wt-ajax-load wt-location-edit-map" dir="ltr"></div>
 
-    <div class="col-sm-3">
+    <div class="col-sm-3 wt-location-edit-sidebar wt-global">
         <form method="post" action="<?= e(route(MapDataSave::class)) ?>">
             <input type="hidden" name="parent_id" value="<?= $parent->id() ?>">
             <input type="hidden" name="place_id" value="<?= $location->id() ?>">


### PR DESCRIPTION
Adds fullscreen css missing after https://github.com/fisharebest/webtrees/commit/2210ec835179836edcccab2d4e4acfcc5f6b4f74

and includes fixes to Control panel > Geographic data mentioned in https://github.com/fisharebest/webtrees/issues/4802