### PR TITLE
Resize map to fit viewport on enter/exit of fullscreen

### DIFF
--- a/resources/js/webtrees.js
+++ b/resources/js/webtrees.js
@@ -676,6 +676,14 @@
    * @returns Map
    */
   webtrees.buildLeafletJsMap = function (id, config, resetCallback) {
+    // Resize map on enter/exit fullscreen
+    document.addEventListener("fullscreenchange", (event) => {
+      map.on('resize', () => {
+        map.closePopup();
+        resetCallback(event);
+      });
+    });
+
     const zoomControl = new L.control.zoom({
       zoomInTitle: config.i18n.zoomIn,
       zoomoutTitle: config.i18n.zoomOut,
@@ -737,9 +745,8 @@
       defaultLayer = config.mapProviders[0].children[0].layer;
     }
 
-
     // Create the map with all controls and layers
-    return L.map(id, {
+    const map = L.map(id, {
       zoomControl: false,
     })
       .addControl(zoomControl)
@@ -751,6 +758,7 @@
         openedSymbol: config.icons.collapse,
       }));
 
+    return map;
   };
 
   /**

--- a/resources/views/modules/place-hierarchy/map.phtml
+++ b/resources/views/modules/place-hierarchy/map.phtml
@@ -95,7 +95,7 @@ use Fisharebest\Webtrees\View;
 
       map.fitBounds(<?= json_encode($data['bounds'], JSON_THROW_ON_ERROR) ?>, { padding: [50, 30] });
       sidebar.innerHTML = <?= json_encode($data['sidebar'], JSON_THROW_ON_ERROR) ?>;
-   };
+    };
 
     window.onload = function() {
       // Activate marker popup when sidebar entry clicked

--- a/resources/views/modules/places/tab.phtml
+++ b/resources/views/modules/places/tab.phtml
@@ -102,7 +102,7 @@ use Fisharebest\Webtrees\I18N;
       }
     };
 
-    // Can't use window.onload here. seems to be because of AJAX loading
+    // Cannot use window.onload here. seems to be because of AJAX loading
     const _loadListeners = function() {
       // Activate marker popup when sidebar entry clicked
       sidebar.querySelectorAll('.gchart').forEach((element) => {


### PR DESCRIPTION
On fullscreen transition reset the map to initial conditions.

**Note**: I would like to carry forward any open popup on fullscreen transition but leaflet triggers the popupclose function at strange times, which currently I can't figure out

**NOTE2:** The changes to the map & tab phtml view files are hangovers from when the resize code was added to each view file rather than putting it into webtrees.js