### PR TITLE
Make table layout in tabs fixed

### DIFF
--- a/resources/css/_base.css
+++ b/resources/css/_base.css
@@ -147,3 +147,7 @@ a:hover, .btn-link:hover, .nav-link:hover {
 :fullscreen .wt-icon-enter-fullscreen {
     display: none;
 }
+
+.wt-table-fixed {
+    table-layout: fixed;
+}

--- a/resources/views/modules/media/tab.phtml
+++ b/resources/views/modules/media/tab.phtml
@@ -15,54 +15,60 @@ use Illuminate\Support\Collection;
  */
 
 ?>
-<div class="wt-tab-media py-4">
-    <table class="table wt-facts-table">
-        <tr>
-            <td colspan="2">
-                <label>
-                    <input id="show-level-2-media" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-level-two-media" data-wt-persist="level-two-media" autocomplete="off">
-                    <?= I18N::translate('Show all media') ?>
-                </label>
-            </td>
-        </tr>
 
-        <?php foreach ($facts as $fact) : ?>
-            <?php if (str_ends_with($fact->tag(), ':OBJE')) : ?>
-                <?= view('fact', ['fact' => $fact, 'record' => $individual]) ?>
-            <?php else : ?>
-                <?php
-                if ($fact->isPendingAddition()) {
-                    $styleadd = 'wt-new ';
-                } elseif ($fact->isPendingDeletion()) {
-                    $styleadd = 'wt-old ';
-                } else {
-                    $styleadd = '';
-                }
-                ?>
+<div class="row">
+    <div class="wt-tab-facts py-4 col-12">
+        <table class="table wt-facts-table wt-table-fixed">
+            <colgroup>
+                <col class="col-2">
+            </colgroup>
+            <tr>
+                <td colspan="2">
+                    <label>
+                        <input id="show-level-2-media" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-level-two-media" data-wt-persist="level-two-media" autocomplete="off">
+                        <?= I18N::translate('Show all media') ?>
+                    </label>
+                </td>
+            </tr>
 
-                <tr class="wt-level-two-media collapse">
-                    <th scope="row" class="rela <?= $styleadd ?>">
-                        <?= $fact->label() ?>
-                        <?= view('fact-edit-links', ['fact' => $fact, 'url' => $fact->record()->url() . '#tab-media']) ?>
-                    </th>
+            <?php foreach ($facts as $fact) : ?>
+                <?php if (str_ends_with($fact->tag(), ':OBJE')) : ?>
+                    <?= view('fact', ['fact' => $fact, 'record' => $individual]) ?>
+                <?php else : ?>
+                    <?php
+                    if ($fact->isPendingAddition()) {
+                        $styleadd = 'wt-new ';
+                    } elseif ($fact->isPendingDeletion()) {
+                        $styleadd = 'wt-old ';
+                    } else {
+                        $styleadd = '';
+                    }
+                    ?>
 
-                    <td class="<?= $styleadd ?>">
-                        <?php if (preg_match_all('/\n([2-4] OBJE .*)/', $fact->gedcom(), $matches, PREG_SET_ORDER) > 0) : ?>
-                            <?php foreach ($matches as $match) : ?>
-                                <?= view('fact-gedcom-fields', ['gedcom' => $match[1], 'parent' => $fact->tag(), 'tree' => $fact->record()->tree()]) ?>
-                            <?php endforeach ?>
-                        <?php endif ?>
+                    <tr class="wt-level-two-media collapse">
+                        <th scope="row" class="rela <?= $styleadd ?>">
+                            <?= $fact->label() ?>
+                            <?= view('fact-edit-links', ['fact' => $fact, 'url' => $fact->record()->url() . '#tab-media']) ?>
+                        </th>
+
+                        <td class="<?= $styleadd ?>">
+                            <?php if (preg_match_all('/\n([2-4] OBJE .*)/', $fact->gedcom(), $matches, PREG_SET_ORDER) > 0) : ?>
+                                <?php foreach ($matches as $match) : ?>
+                                    <?= view('fact-gedcom-fields', ['gedcom' => $match[1], 'parent' => $fact->tag(), 'tree' => $fact->record()->tree()]) ?>
+                                <?php endforeach ?>
+                            <?php endif ?>
+                        </td>
+                    </tr>
+                <?php endif ?>
+            <?php endforeach ?>
+
+            <?php if ($facts->isEmpty()) : ?>
+                <tr>
+                    <td colspan="2">
+                        <?= I18N::translate('There are no media objects for this individual.') ?>
                     </td>
                 </tr>
             <?php endif ?>
-        <?php endforeach ?>
-
-        <?php if ($facts->isEmpty()) : ?>
-            <tr>
-                <td colspan="2">
-                    <?= I18N::translate('There are no media objects for this individual.') ?>
-                </td>
-            </tr>
-        <?php endif ?>
-    </table>
+        </table>
+    </div>
 </div>

--- a/resources/views/modules/notes/tab.phtml
+++ b/resources/views/modules/notes/tab.phtml
@@ -21,84 +21,89 @@ use Illuminate\Support\Collection;
 
 ?>
 
-<div class="wt-tan-notes py-4">
-    <table class="table wt-facts-table">
-        <tr>
-            <td colspan="2">
-                <label>
-                    <input id="show-level-2-notes" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-level-two-note" data-wt-persist="level-two-notes" autocomplete="off">
-                    <?= I18N::translate('Show all notes') ?>
-                </label>
-            </td>
-        </tr>
+<div class="row">
+    <div class="wt-tab-facts py-4 col-12">
+        <table class="table wt-facts-table wt-table-fixed">
+            <colgroup>
+                <col class="col-2">
+            </colgroup>
+            <tr>
+                <td colspan="2">
+                    <label>
+                        <input id="show-level-2-notes" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-level-two-note" data-wt-persist="level-two-notes" autocomplete="off">
+                        <?= I18N::translate('Show all notes') ?>
+                    </label>
+                </td>
+            </tr>
 
-        <?php foreach ($facts as $fact) : ?>
-            <?php if ($fact->tag() === 'INDI:NOTE' || $fact->tag() === 'FAM:NOTE') : ?>
-                <?= view('fact', ['fact' => $fact, 'record' => $individual]) ?>
-            <?php else : ?>
-                <?php
-                if ($fact->isPendingAddition()) {
-                    $styleadd = 'wt-new ';
-                } elseif ($fact->isPendingDeletion()) {
-                    $styleadd = 'wt-old ';
-                } else {
-                    $styleadd = '';
-                }
-                ?>
+            <?php foreach ($facts as $fact) : ?>
+                <?php if ($fact->tag() === 'INDI:NOTE' || $fact->tag() === 'FAM:NOTE') : ?>
+                    <?= view('fact', ['fact' => $fact, 'record' => $individual]) ?>
+                <?php else : ?>
+                    <?php
+                    if ($fact->isPendingAddition()) {
+                        $styleadd = 'wt-new ';
+                    } elseif ($fact->isPendingDeletion()) {
+                        $styleadd = 'wt-old ';
+                    } else {
+                        $styleadd = '';
+                    }
+                    ?>
 
-                <tr class="wt-level-two-note collapse">
-                    <th scope="row" class="rela <?= $styleadd ?>">
-                        <?= $fact->label() ?>
-                        <?= view('fact-edit-links', ['fact' => $fact, 'url' => $fact->record()->url() . '#tab-notes']) ?>
-                    </th>
+                    <tr class="wt-level-two-note collapse">
+                        <th scope="row" class="rela <?= $styleadd ?>">
+                            <?= $fact->label() ?>
+                            <?= view('fact-edit-links', ['fact' => $fact, 'url' => $fact->record()->url() . '#tab-notes']) ?>
+                        </th>
 
-                    <td class="<?= $styleadd ?>">
-                        <?php preg_match_all("/\n[1-9] NOTE ?(.*(?:\n\d CONT.*)*)/", $fact->gedcom(), $matches, PREG_SET_ORDER) ?>
-                        <?php foreach ($matches as $match) : ?>
-                            <div class="mb-2">
-                                <?php $text = preg_replace('/\n\d CONT ?/', "\n", $match[1]) ?>
-                                <?php if (preg_match('/^@' . Gedcom::REGEX_XREF . '@$/', $text) === 1) : ?>
-                                    <?php $note = Registry::noteFactory()->make(trim($text, '@'), $individual->tree()) ?>
-                                    <?php if ($note instanceof Note) : ?>
-                                        <?php if ($note->canShow()) : ?>
-                                            <a href="<?= e($note->url()) ?>">
-                                                <?= I18N::translate('Shared note') ?>
-                                                <?= view('icons/note') ?>
-                                            </a>
-                                            <?= (new SubmitterText(''))->value($note->getNote(), $individual->tree()) ?>
+                        <td class="<?= $styleadd ?>">
+                            <?php preg_match_all("/\n[1-9] NOTE ?(.*(?:\n\d CONT.*)*)/", $fact->gedcom(), $matches, PREG_SET_ORDER) ?>
+                            <?php foreach ($matches as $match) : ?>
+                                <div class="mb-2">
+                                    <?php $text = preg_replace('/\n\d CONT ?/', "\n", $match[1]) ?>
+                                    <?php if (preg_match('/^@' . Gedcom::REGEX_XREF . '@$/', $text) === 1) : ?>
+                                        <?php $note = Registry::noteFactory()->make(trim($text, '@'), $individual->tree()) ?>
+                                        <?php if ($note instanceof Note) : ?>
+                                            <?php if ($note->canShow()) : ?>
+                                                <a href="<?= e($note->url()) ?>">
+                                                    <?= I18N::translate('Shared note') ?>
+                                                    <?= view('icons/note') ?>
+                                                </a>
+                                                <?= (new SubmitterText(''))->value($note->getNote(), $individual->tree()) ?>
+                                            <?php endif ?>
+                                        <?php else : ?>
+                                            <span class="error"><?= e($text) ?></span>
                                         <?php endif ?>
                                     <?php else : ?>
-                                        <span class="error"><?= e($text) ?></span>
+                                        <?= (new SubmitterText(''))->value($text, $individual->tree()) ?>
                                     <?php endif ?>
-                                <?php else : ?>
-                                    <?= (new SubmitterText(''))->value($text, $individual->tree()) ?>
-                                <?php endif ?>
-                            </div>
-                        <?php endforeach ?>
+                                </div>
+                            <?php endforeach ?>
+                        </td>
+                    </tr>
+                <?php endif ?>
+            <?php endforeach ?>
+
+            <?php if ($facts->isEmpty()) : ?>
+                <tr>
+                    <td colspan="2">
+                        <?= I18N::translate('There are no notes for this individual.') ?>
                     </td>
                 </tr>
             <?php endif ?>
-        <?php endforeach ?>
 
-        <?php if ($facts->isEmpty()) : ?>
-            <tr>
-                <td colspan="2">
-                    <?= I18N::translate('There are no notes for this individual.') ?>
-                </td>
-            </tr>
-        <?php endif ?>
-
-        <?php if ($can_edit) : ?>
-            <tr>
-                <th scope="row">
-                    <?= I18N::translate('Note') ?>
-                </th>
-                <td>
-                    <a href="<?= e(route(AddNewFact::class, ['tree' => $individual->tree()->name(), 'xref' => $individual->xref(), 'fact' => 'NOTE'])) ?>">
-                        <?= I18N::translate('Add a note') ?>
-                    </a>
-                </td>
-            </tr>
-        <?php endif ?>
-    </table>
+            <?php if ($can_edit) : ?>
+                <tr>
+                    <th scope="row">
+                        <?= I18N::translate('Note') ?>
+                    </th>
+                    <td>
+                        <a href="<?= e(route(AddNewFact::class, ['tree' => $individual->tree()->name(), 'xref' => $individual->xref(), 'fact' => 'NOTE'])) ?>">
+                            <?= I18N::translate('Add a note') ?>
+                        </a>
+                    </td>
+                </tr>
+            <?php endif ?>
+        </table>
+    </div>
 </div>

--- a/resources/views/modules/personal_facts/tab.phtml
+++ b/resources/views/modules/personal_facts/tab.phtml
@@ -19,53 +19,54 @@ use Illuminate\Support\Collection;
 
 ?>
 
-<div class="wt-tab-facts py-4">
-    <table class="table wt-facts-table" style="table-layout: fixed">
-        <colgroup>
-            <col style="width:25%">
-            <col style="width:75%">
-        </colgroup>
-        <tbody>
-            <tr>
-                <td colspan="2">
-                    <?php if ($has_associate_facts) : ?>
-                        <label>
-                            <input id="show-associate-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-associate-fact" data-wt-persist="associates" autocomplete="off">
-                            <?= I18N::translate('Associated events') ?>
-                        </label>
-                    <?php endif ?>
-
-                    <?php if ($has_relative_facts) : ?>
-                        <label>
-                            <input id="show-relatives-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-relation-fact" data-wt-persist="relatives" autocomplete="off">
-                            <?= I18N::translate('Events of close relatives') ?>
-                        </label>
-                    <?php endif ?>
-
-                    <?php if ($has_historic_facts) : ?>
-                        <label>
-                            <input id="show-historical-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-historic-fact" data-wt-persist="historic-facts" autocomplete="off">
-                            <?= I18N::translate('Historic events') ?>
-                        </label>
-                    <?php endif ?>
-                </td>
-            </tr>
-
-            <?php foreach ($facts as $fact) : ?>
-                <?= view('fact', ['fact' => $fact, 'record' => $individual]) ?>
-            <?php endforeach ?>
-
-            <?php if ($facts->isEmpty()) : ?>
+<div class="row">
+    <div class="wt-tab-facts py-4 col-12">
+        <table class="table wt-facts-table wt-table-fixed">
+            <colgroup>
+                <col class="col-2">
+            </colgroup>
+            <tbody>
                 <tr>
                     <td colspan="2">
-                        <?= I18N::translate('There are no facts for this individual.') ?>
+                        <?php if ($has_associate_facts) : ?>
+                            <label>
+                                <input id="show-associate-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-associate-fact" data-wt-persist="associates" autocomplete="off">
+                                <?= I18N::translate('Associated events') ?>
+                            </label>
+                        <?php endif ?>
+
+                        <?php if ($has_relative_facts) : ?>
+                            <label>
+                                <input id="show-relatives-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-relation-fact" data-wt-persist="relatives" autocomplete="off">
+                                <?= I18N::translate('Events of close relatives') ?>
+                            </label>
+                        <?php endif ?>
+
+                        <?php if ($has_historic_facts) : ?>
+                            <label>
+                                <input id="show-historical-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-historic-fact" data-wt-persist="historic-facts" autocomplete="off">
+                                <?= I18N::translate('Historic events') ?>
+                            </label>
+                        <?php endif ?>
                     </td>
                 </tr>
-            <?php endif ?>
 
-            <?php if ($individual->canEdit()) : ?>
-                <?= view('fact-add-new', ['record' => $individual]) ?>
-            <?php endif ?>
-        </tbody>
-    </table>
+                <?php foreach ($facts as $fact) : ?>
+                    <?= view('fact', ['fact' => $fact, 'record' => $individual]) ?>
+                <?php endforeach ?>
+
+                <?php if ($facts->isEmpty()) : ?>
+                    <tr>
+                        <td colspan="2">
+                            <?= I18N::translate('There are no facts for this individual.') ?>
+                        </td>
+                    </tr>
+                <?php endif ?>
+
+                <?php if ($individual->canEdit()) : ?>
+                    <?= view('fact-add-new', ['record' => $individual]) ?>
+                <?php endif ?>
+            </tbody>
+        </table>
+    </div>
 </div>

--- a/resources/views/modules/relatives/family.phtml
+++ b/resources/views/modules/relatives/family.phtml
@@ -24,219 +24,226 @@ use Fisharebest\Webtrees\Services\RelationshipService;
 
 ?>
 
-<table class="table table-sm wt-facts-table">
-    <caption>
-        <a href="<?= e($family->url()) ?>"><?= $label ?></a>
-    </caption>
+<div class="row">
+    <div class="wt-tab-facts col-12">
+        <table class="table wt-facts-table wt-table-fixed">
+            <colgroup>
+                <col class="col-2">
+            </colgroup>
+            <caption>
+                <a href="<?= e($family->url()) ?>"><?= $label ?></a>
+            </caption>
 
-    <tbody>
-        <?php
-        $found = false;
-        foreach ($family->facts(['HUSB'], false, $fam_access_level) as $fact) {
-            $found |= !$fact->isPendingDeletion();
-            $person = $fact->target();
-            if ($person instanceof Individual) {
-                $row_class = 'wt-sex-' . strtolower($person->sex());
-                if ($fact->isPendingAddition()) {
-                    $row_class .= ' wt-new';
-                } elseif ($fact->isPendingDeletion()) {
-                    $row_class .= ' wt-old';
-                }
-                ?>
-                <tr class="<?= $row_class ?>">
-                    <th scope="row">
-                        <?= $individual === $person ? '<i class="icon-selected"></i>' : '' ?>
-                        <?= Registry::container()->get(RelationshipService::class)->getCloseRelationshipName($individual, $person) ?>
-                    </th>
-                    <td class="border-0 p-0">
-                        <?= view('chart-box', ['individual' => $person]) ?>
-                    </td>
-                </tr>
+            <tbody>
                 <?php
-            }
-        }
-        if (!$found && $family->canEdit()) {
-            ?>
-            <tr>
-                <th scope="row"></th>
-                <td>
-                    <a href="<?= e(route(AddSpouseToFamilyPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'sex' => 'M', 'url' => $individual->url() . '#tab-relatives'])) ?>">
-                        <?= I18N::translate('Add a husband') ?>
-                    </a>
-                </td>
-            </tr>
-            <?php
-        }
-
-        $found = false;
-        foreach ($family->facts(['WIFE'], false, $fam_access_level) as $fact) {
-            $person = $fact->target();
-            if ($person instanceof Individual) {
-                $found |= !$fact->isPendingDeletion();
-                $row_class = 'wt-sex-' . strtolower($person->sex());
-                if ($fact->isPendingAddition()) {
-                    $row_class .= ' wt-new';
-                } elseif ($fact->isPendingDeletion()) {
-                    $row_class .= ' wt-old';
-                }
+                $found = false;
+                foreach ($family->facts(['HUSB'], false, $fam_access_level) as $fact) {
+                    $found |= !$fact->isPendingDeletion();
+                    $person = $fact->target();
+                    if ($person instanceof Individual) {
+                        $row_class = 'wt-sex-' . strtolower($person->sex());
+                        if ($fact->isPendingAddition()) {
+                            $row_class .= ' wt-new';
+                        } elseif ($fact->isPendingDeletion()) {
+                            $row_class .= ' wt-old';
+                        }
                 ?>
-
-                <tr class="<?= $row_class ?>">
-                    <th scope="row">
-                        <?= $individual === $person ? '<i class="icon-selected"></i>' : '' ?>
-                        <?= Registry::container()->get(RelationshipService::class)->getCloseRelationshipName($individual, $person) ?>
-                    </th>
-                    <td class="border-0 p-0">
-                        <?= view('chart-box', ['individual' => $person]) ?>
-                    </td>
-                </tr>
-                <?php
-            }
-        }
-        if (!$found && $family->canEdit()) { ?>
-            <tr>
-                <th scope="row"></th>
-                <td>
-                    <a href="<?= e(route(AddSpouseToFamilyPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'sex' => 'F', 'url' => $individual->url() . '#tab-relatives'])) ?>">
-                        <?= I18N::translate('Add a wife') ?>
-                    </a>
-                </td>
-            </tr>
-
-        <?php } ?>
-
-        <?php
-        ///// MARR /////
-        $found = false;
-        $prev  = new Date('');
-        foreach ($family->facts(array_merge(Gedcom::MARRIAGE_EVENTS, Gedcom::DIVORCE_EVENTS), true) as $fact) {
-            $found |= !$fact->isPendingDeletion();
-            if ($fact->isPendingAddition()) {
-                $row_class = 'wt-new';
-            } elseif ($fact->isPendingDeletion()) {
-                $row_class = 'wt-old';
-            } else {
-                $row_class = '';
-            }
-            ?>
-
-            <tr class="<?= $row_class ?>">
-                <th scope="row">
-                    <span class="visually-hidden"><?= $fact->label() ?></span>
-                </th>
-
-                <td>
-                    <span class="label"><?= $fact->label() ?></span>
-                    —
-                    <span class="field"><?= $fact->date()->display() ?> — <?= $fact->place()->fullName() ?></span>
-                </td>
-            </tr>
-
-            <?php
-            if (!$prev->isOK() && $fact->date()->isOK()) {
-                $prev = $fact->date();
-            }
-        }
-
-        if (!$found && $family->canShow() && $family->canEdit()) {
-            ?>
-            <tr>
-                <th scope="row">
-                    <span class="visually-hidden"><?= I18N::translate('Marriage') ?></span>
-                </th>
-
-                <td>
-                    <a href="<?= e(route(AddNewFact::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'fact' => 'MARR'])) ?>">
-                        <?= I18N::translate('Add marriage details') ?>
-                    </a>
-                </td>
-            </tr>
-            <?php
-        }
-
-        ///// CHIL /////
-        $child_number = 0;
-        foreach ($family->facts(['CHIL'], false, $fam_access_level) as $fact) {
-            $person = $fact->target();
-            if ($person instanceof Individual) {
-                $row_class = 'wt-sex-' . strtolower($person->sex());
-                if ($fact->isPendingAddition()) {
-                    $child_number++;
-                    $row_class .= ' new';
-                } elseif ($fact->isPendingDeletion()) {
-                    $row_class .= ' old';
-                } else {
-                    $child_number++;
-                }
-                $next = new Date('');
-                foreach ($person->facts(Gedcom::BIRTH_EVENTS, true) as $bfact) {
-                    if ($bfact->date()->isOK()) {
-                        $next = $bfact->date();
-                        break;
+                        <tr class="<?= $row_class ?>">
+                            <th scope="row">
+                                <?= $individual === $person ? '<i class="icon-selected"></i>' : '' ?>
+                                <?= Registry::container()->get(RelationshipService::class)->getCloseRelationshipName($individual, $person) ?>
+                            </th>
+                            <td class="border-0 p-0">
+                                <?= view('chart-box', ['individual' => $person]) ?>
+                            </td>
+                        </tr>
+                    <?php
                     }
                 }
+                if (!$found && $family->canEdit()) {
+                    ?>
+                    <tr>
+                        <th scope="row"></th>
+                        <td>
+                            <a href="<?= e(route(AddSpouseToFamilyPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'sex' => 'M', 'url' => $individual->url() . '#tab-relatives'])) ?>">
+                                <?= I18N::translate('Add a husband') ?>
+                            </a>
+                        </td>
+                    </tr>
+                    <?php
+                }
+
+                $found = false;
+                foreach ($family->facts(['WIFE'], false, $fam_access_level) as $fact) {
+                    $person = $fact->target();
+                    if ($person instanceof Individual) {
+                        $found |= !$fact->isPendingDeletion();
+                        $row_class = 'wt-sex-' . strtolower($person->sex());
+                        if ($fact->isPendingAddition()) {
+                            $row_class .= ' wt-new';
+                        } elseif ($fact->isPendingDeletion()) {
+                            $row_class .= ' wt-old';
+                        }
+                    ?>
+
+                        <tr class="<?= $row_class ?>">
+                            <th scope="row">
+                                <?= $individual === $person ? '<i class="icon-selected"></i>' : '' ?>
+                                <?= Registry::container()->get(RelationshipService::class)->getCloseRelationshipName($individual, $person) ?>
+                            </th>
+                            <td class="border-0 p-0">
+                                <?= view('chart-box', ['individual' => $person]) ?>
+                            </td>
+                        </tr>
+                    <?php
+                    }
+                }
+                if (!$found && $family->canEdit()) { ?>
+                    <tr>
+                        <th scope="row"></th>
+                        <td>
+                            <a href="<?= e(route(AddSpouseToFamilyPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'sex' => 'F', 'url' => $individual->url() . '#tab-relatives'])) ?>">
+                                <?= I18N::translate('Add a wife') ?>
+                            </a>
+                        </td>
+                    </tr>
+
+                <?php } ?>
+
+                <?php
+                ///// MARR /////
+                $found = false;
+                $prev  = new Date('');
+                foreach ($family->facts(array_merge(Gedcom::MARRIAGE_EVENTS, Gedcom::DIVORCE_EVENTS), true) as $fact) {
+                    $found |= !$fact->isPendingDeletion();
+                    if ($fact->isPendingAddition()) {
+                        $row_class = 'wt-new';
+                    } elseif ($fact->isPendingDeletion()) {
+                        $row_class = 'wt-old';
+                    } else {
+                        $row_class = '';
+                    }
                 ?>
 
-                <tr class="<?= $row_class ?>">
-                    <th scope="row">
-                        <?php if ($individual === $person) : ?>
-                            <i class="icon-selected"></i>
-                        <?php endif ?>
+                    <tr class="<?= $row_class ?>">
+                        <th scope="row">
+                            <span class="visually-hidden"><?= $fact->label() ?></span>
+                        </th>
 
-                        <?php if ($prev->isOK() && $next->isOK()) : ?>
-                            <div class="wt-date-difference collapse small">
-                                <?php $days = $next->maximumJulianDay() - $prev->minimumJulianDay(); ?>
-                                <?php if ($days < 0 || $child_number > 1 && $days > 1 && $days < 240) : ?>
-                                    <?= view('icons/warning') ?>
+                        <td>
+                            <span class="label"><?= $fact->label() ?></span>
+                            —
+                            <span class="field"><?= $fact->date()->display() ?> — <?= $fact->place()->fullName() ?></span>
+                        </td>
+                    </tr>
+
+                    <?php
+                    if (!$prev->isOK() && $fact->date()->isOK()) {
+                        $prev = $fact->date();
+                    }
+                }
+
+                if (!$found && $family->canShow() && $family->canEdit()) {
+                    ?>
+                    <tr>
+                        <th scope="row">
+                            <span class="visually-hidden"><?= I18N::translate('Marriage') ?></span>
+                        </th>
+
+                        <td>
+                            <a href="<?= e(route(AddNewFact::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'fact' => 'MARR'])) ?>">
+                                <?= I18N::translate('Add marriage details') ?>
+                            </a>
+                        </td>
+                    </tr>
+                    <?php
+                }
+
+                ///// CHIL /////
+                $child_number = 0;
+                foreach ($family->facts(['CHIL'], false, $fam_access_level) as $fact) {
+                    $person = $fact->target();
+                    if ($person instanceof Individual) {
+                        $row_class = 'wt-sex-' . strtolower($person->sex());
+                        if ($fact->isPendingAddition()) {
+                            $child_number++;
+                            $row_class .= ' new';
+                        } elseif ($fact->isPendingDeletion()) {
+                            $row_class .= ' old';
+                        } else {
+                            $child_number++;
+                        }
+                        $next = new Date('');
+                        foreach ($person->facts(Gedcom::BIRTH_EVENTS, true) as $bfact) {
+                            if ($bfact->date()->isOK()) {
+                                $next = $bfact->date();
+                                break;
+                            }
+                        }
+                    ?>
+
+                        <tr class="<?= $row_class ?>">
+                            <th scope="row">
+                                <?php if ($individual === $person) : ?>
+                                    <i class="icon-selected"></i>
                                 <?php endif ?>
 
-                                <?php $months = intdiv($days + 15, 30); ?>
-                                <?php if (abs($months) === 12 || abs($months) >= 24) : ?>
-                                    <?= I18N::plural('%s year', '%s years', intdiv($months, 12), I18N::number(round($months / 12))) ?>
-                                <?php elseif ($months !== 0) : ?>
-                                    <?= I18N::plural('%s month', '%s months', $months, I18N::number($months)) ?>
-                                <?php endif ?>
-                            </div>
-                        <?php endif ?>
+                                <?php if ($prev->isOK() && $next->isOK()) : ?>
+                                    <div class="wt-date-difference collapse small">
+                                        <?php $days = $next->maximumJulianDay() - $prev->minimumJulianDay(); ?>
+                                        <?php if ($days < 0 || $child_number > 1 && $days > 1 && $days < 240) : ?>
+                                            <?= view('icons/warning') ?>
+                                        <?php endif ?>
 
-                        <?= Registry::container()->get(RelationshipService::class)->getCloseRelationshipName($individual, $person) ?>
-                    </th>
-                    <td class="border-0 p-0">
-                        <?= view('chart-box', ['individual' => $person]) ?>
-                    </td>
-                </tr>
+                                        <?php $months = intdiv($days + 15, 30); ?>
+                                        <?php if (abs($months) === 12 || abs($months) >= 24) : ?>
+                                            <?= I18N::plural('%s year', '%s years', intdiv($months, 12), I18N::number(round($months / 12))) ?>
+                                        <?php elseif ($months !== 0) : ?>
+                                            <?= I18N::plural('%s month', '%s months', $months, I18N::number($months)) ?>
+                                        <?php endif ?>
+                                    </div>
+                                <?php endif ?>
+
+                                <?= Registry::container()->get(RelationshipService::class)->getCloseRelationshipName($individual, $person) ?>
+                            </th>
+                            <td class="border-0 p-0">
+                                <?= view('chart-box', ['individual' => $person]) ?>
+                            </td>
+                        </tr>
                 <?php
-                $prev = $next;
-            }
-        } ?>
+                        $prev = $next;
+                    }
+                } ?>
 
-        <?php if ($family->canEdit()) : ?>
-            <tr>
-                <th scope="row">
-                    <span class="visually-hidden"><?= I18N::translate('Children') ?></span>
-                </th>
+                <?php if ($family->canEdit()) : ?>
+                    <tr>
+                        <th scope="row">
+                            <span class="visually-hidden"><?= I18N::translate('Children') ?></span>
+                        </th>
 
-                <td>
-                    <a href="<?= e(route(AddChildToFamilyPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'sex' => 'M', 'url' => $individual->url() . '#tab-relatives'])) ?>">
-                        <?= $type === 'FAMS' ? I18N::translate('Add a son') : I18N::translate('Add a brother') ?>
-                    </a>
-                    |
-                    <a href="<?= e(route(AddChildToFamilyPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'sex' => 'F', 'url' => $individual->url() . '#tab-relatives'])) ?>">
-                        <?= $type === 'FAMS' ? I18N::translate('Add a daughter') : I18N::translate('Add a sister') ?>
-                    </a>
-                    |
-                    <a href="<?= e(route(AddChildToFamilyPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'sex' => 'U', 'url' => $individual->url() . '#tab-relatives'])) ?>">
-                        <?= $type === 'FAMS' ? I18N::translate('Add a child') : I18N::translate('Add a sibling') ?>
-                    </a>
+                        <td>
+                            <a href="<?= e(route(AddChildToFamilyPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'sex' => 'M', 'url' => $individual->url() . '#tab-relatives'])) ?>">
+                                <?= $type === 'FAMS' ? I18N::translate('Add a son') : I18N::translate('Add a brother') ?>
+                            </a>
+                            |
+                            <a href="<?= e(route(AddChildToFamilyPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'sex' => 'F', 'url' => $individual->url() . '#tab-relatives'])) ?>">
+                                <?= $type === 'FAMS' ? I18N::translate('Add a daughter') : I18N::translate('Add a sister') ?>
+                            </a>
+                            |
+                            <a href="<?= e(route(AddChildToFamilyPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'sex' => 'U', 'url' => $individual->url() . '#tab-relatives'])) ?>">
+                                <?= $type === 'FAMS' ? I18N::translate('Add a child') : I18N::translate('Add a sibling') ?>
+                            </a>
 
-                    <?php if ($family->children()->count() > 1) : ?>
-                        <br>
-                        <a href="<?= e(route(ReorderChildrenPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'url' => $individual->url() . '#tab-relatives'])) ?>">
-                            <?= I18N::translate('Re-order children') ?>
-                        </a>
-                    <?php endif; ?>
-                </td>
-            </tr>
-        <?php endif ?>
-    </tbody>
-</table>
+                            <?php if ($family->children()->count() > 1) : ?>
+                                <br>
+                                <a href="<?= e(route(ReorderChildrenPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'url' => $individual->url() . '#tab-relatives'])) ?>">
+                                    <?= I18N::translate('Re-order children') ?>
+                                </a>
+                            <?php endif; ?>
+                        </td>
+                    </tr>
+                <?php endif ?>
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/resources/views/modules/sources_tab/tab.phtml
+++ b/resources/views/modules/sources_tab/tab.phtml
@@ -17,67 +17,72 @@ use Illuminate\Support\Collection;
 
 ?>
 
-<div class="wt-tab-sources py-4">
-    <table class="table wt-facts-table">
-        <tr>
-            <td colspan="2">
-                <label>
-                    <input id="show-level-2-sources" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-level-two-source" data-wt-persist="level-two-sources" autocomplete="off">
-                    <?= I18N::translate('Show all sources') ?>
-                </label>
-            </td>
-        </tr>
+<div class="row">
+    <div class="wt-tab-facts py-4 col-12">
+        <table class="table wt-facts-table wt-table-fixed">
+            <colgroup>
+                <col class="col-2">
+            </colgroup>
+            <tr>
+                <td colspan="2">
+                    <label>
+                        <input id="show-level-2-sources" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-level-two-source" data-wt-persist="level-two-sources" autocomplete="off">
+                        <?= I18N::translate('Show all sources') ?>
+                    </label>
+                </td>
+            </tr>
 
-        <?php foreach ($facts as $fact) : ?>
-            <?php if (str_ends_with($fact->tag(), ':SOUR')) : ?>
-                <?= view('fact', ['fact' => $fact, 'record' => $individual]) ?>
-            <?php else : ?>
-                <?php
-                if ($fact->isPendingAddition()) {
-                    $styleadd = 'wt-new ';
-                } elseif ($fact->isPendingDeletion()) {
-                    $styleadd = 'wt-old ';
-                } else {
-                    $styleadd = '';
-                }
-                ?>
+            <?php foreach ($facts as $fact) : ?>
+                <?php if (str_ends_with($fact->tag(), ':SOUR')) : ?>
+                    <?= view('fact', ['fact' => $fact, 'record' => $individual]) ?>
+                <?php else : ?>
+                    <?php
+                    if ($fact->isPendingAddition()) {
+                        $styleadd = 'wt-new ';
+                    } elseif ($fact->isPendingDeletion()) {
+                        $styleadd = 'wt-old ';
+                    } else {
+                        $styleadd = '';
+                    }
+                    ?>
 
-                <tr class="wt-level-two-source collapse">
-                    <th scope="row" class="rela <?= $styleadd ?>">
-                        <?= $fact->label() ?>
-                        <?= view('fact-edit-links', ['fact' => $fact, 'url' => $fact->record()->url() . '#tab-sources']) ?>
-                    </th>
+                    <tr class="wt-level-two-source collapse">
+                        <th scope="row" class="rela <?= $styleadd ?>">
+                            <?= $fact->label() ?>
+                            <?= view('fact-edit-links', ['fact' => $fact, 'url' => $fact->record()->url() . '#tab-sources']) ?>
+                        </th>
 
-                    <td class="<?= $styleadd ?>">
-                        <?php if (preg_match_all('/\n(2 SOUR\b.*(?:\n[^2].*)*)/', $fact->gedcom(), $matches, PREG_SET_ORDER) > 0) : ?>
-                            <?php foreach ($matches as $match) : ?>
-                                <?= view('fact-gedcom-fields', ['gedcom' => $match[1], 'parent' => $fact->tag(), 'tree' => $fact->record()->tree()]) ?>
-                            <?php endforeach ?>
-                        <?php endif ?>
+                        <td class="<?= $styleadd ?>">
+                            <?php if (preg_match_all('/\n(2 SOUR\b.*(?:\n[^2].*)*)/', $fact->gedcom(), $matches, PREG_SET_ORDER) > 0) : ?>
+                                <?php foreach ($matches as $match) : ?>
+                                    <?= view('fact-gedcom-fields', ['gedcom' => $match[1], 'parent' => $fact->tag(), 'tree' => $fact->record()->tree()]) ?>
+                                <?php endforeach ?>
+                            <?php endif ?>
+                        </td>
+                    </tr>
+                <?php endif ?>
+            <?php endforeach ?>
+
+            <?php if ($facts->isEmpty()) : ?>
+                <tr>
+                    <td colspan="2">
+                        <?= I18N::translate('There are no source citations for this individual.') ?>
                     </td>
                 </tr>
             <?php endif ?>
-        <?php endforeach ?>
 
-        <?php if ($facts->isEmpty()) : ?>
-            <tr>
-                <td colspan="2">
-                    <?= I18N::translate('There are no source citations for this individual.') ?>
-                </td>
-            </tr>
-        <?php endif ?>
-
-        <?php if ($can_edit) : ?>
-            <tr>
-                <th scope="row">
-                    <?= I18N::translate('Source') ?>
-                </th>
-                <td>
-                    <a href="<?= e(route(AddNewFact::class, ['tree' => $individual->tree()->name(), 'xref' => $individual->xref(), 'fact' => 'SOUR'])) ?>">
-                        <?= I18N::translate('Add a source citation') ?>
-                    </a>
-                </td>
-            </tr>
-        <?php endif ?>
-    </table>
+            <?php if ($can_edit) : ?>
+                <tr>
+                    <th scope="row">
+                        <?= I18N::translate('Source') ?>
+                    </th>
+                    <td>
+                        <a href="<?= e(route(AddNewFact::class, ['tree' => $individual->tree()->name(), 'xref' => $individual->xref(), 'fact' => 'SOUR'])) ?>">
+                            <?= I18N::translate('Add a source citation') ?>
+                        </a>
+                    </td>
+                </tr>
+            <?php endif ?>
+        </table>
+    </div>
 </div>


### PR DESCRIPTION
Apply table-layout: fixed and add a column-group to the main table in the personal facts, family, notes, media and source tabs. This prevents wide content (e.g census shared notes) from overflowing the tables right margin but instead adds a scroll bar.

NB I've used bootstrap classes where possible and used col-2 for the 1st column in the column group. I can't see any instances where the content exceeds that width in any language, however simply change to col-3 if preferred.