### PR TITLE
Convert tab table to bootstrap grid

### DIFF
--- a/app/Module/IndividualFactsTabModule.php
+++ b/app/Module/IndividualFactsTabModule.php
@@ -138,6 +138,7 @@ class IndividualFactsTabModule extends AbstractModule implements ModuleTabInterf
         $associate_facts  = $this->individual_facts_service->associateFacts($individual);
         $historic_facts   = $this->individual_facts_service->historicFacts($individual);
 
+        $has_individual_facts = $individual_facts->isNotEmpty();
         $individual_facts = $individual_facts
             ->merge($family_facts)
             ->merge($relative_facts)
@@ -156,13 +157,14 @@ class IndividualFactsTabModule extends AbstractModule implements ModuleTabInterf
         ]);
 
         return view('modules/personal_facts/tab', [
-            'can_edit'            => $individual->canEdit(),
-            'clipboard_facts'     => $this->clipboard_service->pastableFacts($individual),
-            'has_associate_facts' => $associate_facts->isNotEmpty(),
-            'has_historic_facts'  => $historic_facts->isNotEmpty(),
-            'has_relative_facts'  => $relative_facts->isNotEmpty(),
-            'individual'          => $individual,
-            'facts'               => $individual_facts,
+            'can_edit'             => $individual->canEdit(),
+            'clipboard_facts'      => $this->clipboard_service->pastableFacts($individual),
+            'has_associate_facts'  => $associate_facts->isNotEmpty(),
+            'has_historic_facts'   => $historic_facts->isNotEmpty(),
+            'has_relative_facts'   => $relative_facts->isNotEmpty(),
+            'has_individual_facts' => $has_individual_facts,
+            'individual'           => $individual,
+            'facts'                => $individual_facts,
         ]);
     }
 

--- a/resources/css/clouds.css
+++ b/resources/css/clouds.css
@@ -693,17 +693,21 @@ div.fact_SHARED_NOTE {
     caption-side: top;
 }
 
-.wt-facts-table th {
+.wt-facts-table th, .wt-fact-controls {
     background-color: #95b8e0;
     color: #039;
     border: 1px solid #acf;
     border-radius: 3px;
     font-weight: normal;
     text-align: center;
+    height: 100%;
+}
+
+.wt-facts-table > tbody > tr > th {
     min-width: 20%;
 }
 
-.wt-facts-table td {
+.wt-facts-table td, .wt-fact-content {
     border: solid #999 1px;
     border-radius: 3px;
     background-color: #fff;

--- a/resources/css/colors.css
+++ b/resources/css/colors.css
@@ -160,9 +160,13 @@
 .wt-facts-table th, .wt-facts-table .dropdown-toggle,
 .descriptionbox, .descriptionbox a,
 .topbottombar, .topbottombar a,
-.list_label, .list_label a {
+.list_label, .list_label a, .wt-fact-controls {
     background-color: var(--color-3);
     color: var(--color-6);
+}
+
+.wt-fact-controls {
+    height: 100%;
 }
 
 .wt-page-options-value,
@@ -170,10 +174,10 @@
 .wt-facts-table td,
 .ui-widget-header,
 .optionbox, .ui-state-active a:link,
-.list_value, .list_value_wrap, .list_value_wrap a {
+.list_value, .list_value_wrap,
+.list_value_wrap a, .wt-fact-content {
     background: var(--color-4);
 }
-
 
 .menu-tree .nav-link::before {
     content: url(colors/menu/tree.png);

--- a/resources/css/fab.css
+++ b/resources/css/fab.css
@@ -447,18 +447,19 @@ div.fact_SHARED_NOTE {
     caption-side: top;
 }
 
-.wt-facts-table th {
+.wt-facts-table th, .wt-fact-controls {
     background-color: #ccc;
     border-radius: 4px;
     text-align: center;
     font-weight: normal;
+    height: 100%;
 }
 
 .wt-facts-table > tbody > tr > th {
     min-width: 20%;
 }
 
-.wt-facts-table td {
+.wt-facts-table td, .wt-fact-content {
     border-radius: 4px;
     background-color: #ddd;
 }

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -409,16 +409,17 @@ table {
     caption-side: top;
 }
 
-.wt-facts-table th {
+.wt-facts-table th, .wt-fact-controls {
     border: 1px solid #000;
     font-weight: normal;
+    height: 100%;
 }
 
 .wt-facts-table > tbody > tr > th {
     min-width: 20%;
 }
 
-.wt-facts-table td {
+.wt-facts-table td, .wt-fact-content {
     border: solid #000 1px;
 }
 

--- a/resources/css/webtrees.css
+++ b/resources/css/webtrees.css
@@ -639,18 +639,19 @@ div.fact_SHARED_NOTE {
     caption-side: top;
 }
 
-.wt-facts-table th {
+.wt-facts-table th, .wt-fact-controls {
     background-color: #81a9cb;
     border: solid #81a9cb 1px;
     text-align: center;
     font-weight: normal;
+    height: 100%;
 }
 
 .wt-facts-table > tbody > tr > th {
     min-width: 20%;
 }
 
-.wt-facts-table td {
+.wt-facts-table td, .wt-fact-content {
     background-color: #edf7fd;
     border: 1px solid #81a9cb;
 }
@@ -1353,19 +1354,4 @@ a > .wt-icon-arrow-up:hover {
 /* Forms */
 .col-form-label {
     font-weight: bold;
-}
-
-.wt-fact-controls {
-    background-color: #81a9cb;
-    border: solid #81a9cb 1px;
-    text-align: center;
-    font-weight: normal;
-    height: 100%;
-}
-
-.wt-fact-content {
-    background-color: #edf7fd;
-    border: solid #81a9cb 1px;
-    white-space: normal;
-    height: 100%;
 }

--- a/resources/css/webtrees.css
+++ b/resources/css/webtrees.css
@@ -1354,3 +1354,18 @@ a > .wt-icon-arrow-up:hover {
 .col-form-label {
     font-weight: bold;
 }
+
+.wt-fact-controls {
+    background-color: #81a9cb;
+    border: solid #81a9cb 1px;
+    text-align: center;
+    font-weight: normal;
+    height: 100%;
+}
+
+.wt-fact-content {
+    background-color: #edf7fd;
+    border: solid #81a9cb 1px;
+    white-space: normal;
+    height: 100%;
+}

--- a/resources/css/xenea.css
+++ b/resources/css/xenea.css
@@ -631,18 +631,19 @@ div.fact_SHARED_NOTE {
     caption-side: top;
 }
 
-.wt-facts-table th {
+.wt-facts-table th, .wt-fact-controls {
     background-color: #c3dfff;
     color: #006;
     text-align: center;
     font-weight: normal;
+    height: 100%;
 }
 
 .wt-facts-table > tbody > tr > th {
     min-width: 20%;
 }
 
-.wt-facts-table td {
+.wt-facts-table td, .wt-fact-content {
     background-color: #ecf5ff;
     border: 1px solid #c3dfff;
 }

--- a/resources/views/edit/add-fact-row.phtml
+++ b/resources/views/edit/add-fact-row.phtml
@@ -15,13 +15,15 @@ use Fisharebest\Webtrees\I18N;
 
 ?>
 
-<tr>
-    <th scope="row">
-        <label for="add-fact">
-            <?= I18N::translate('Add a fact') ?>
-        </label>
-    </th>
-    <td>
+<div class="row pt-1">
+    <div class="col-sm-3 pe-1 ps-0">
+        <div class="wt-fact-controls">
+            <label for="add-fact">
+                <?= I18N::translate('Add a fact') ?>
+            </label>
+        </div>
+    </div>
+    <div class="col-sm-9 wt-fact-content pt-2">
         <?php if ($add_facts !== []) : ?>
             <form method="post" action="<?= e(route(SelectNewFact::class, ['tree' => $record->tree()->name(), 'xref' => $record->xref()])) ?>" onsubmit="if ($('#add-fact').val() === null) {event.preventDefault();}">
                 <div class="input-group">
@@ -46,13 +48,13 @@ use Fisharebest\Webtrees\I18N;
         <div class="wt-quick-facts">
             <?php foreach ($quick_facts as $fact => $label) : ?>
                 <a class="btn btn-link wt-quick-fact" href="<?= e(route(AddNewFact::class, [
-                    'fact' => $fact,
-                    'xref' => $record->xref(),
-                    'tree' => $record->tree()->name(),
-                ])) ?>">
+                        'fact' => $fact,
+                        'xref' => $record->xref(),
+                        'tree' => $record->tree()->name(),
+                    ])) ?>">
                     <?= $label ?>
                 </a>
             <?php endforeach ?>
         </div>
-    </td>
-</tr>
+    </div>
+</div>

--- a/resources/views/edit/add-fact-row.phtml
+++ b/resources/views/edit/add-fact-row.phtml
@@ -16,14 +16,14 @@ use Fisharebest\Webtrees\I18N;
 ?>
 
 <div class="row pt-1">
-    <div class="col-sm-3 pe-1 ps-0">
+    <div class="col-sm-2 pe-1 ps-0">
         <div class="wt-fact-controls">
             <label for="add-fact">
                 <?= I18N::translate('Add a fact') ?>
             </label>
         </div>
     </div>
-    <div class="col-sm-9 wt-fact-content pt-2">
+    <div class="col-sm-10 wt-fact-content pt-2">
         <?php if ($add_facts !== []) : ?>
             <form method="post" action="<?= e(route(SelectNewFact::class, ['tree' => $record->tree()->name(), 'xref' => $record->xref()])) ?>" onsubmit="if ($('#add-fact').val() === null) {event.preventDefault();}">
                 <div class="input-group">

--- a/resources/views/fact.phtml
+++ b/resources/views/fact.phtml
@@ -58,7 +58,6 @@ if ($element instanceof UnknownElement && $tree->getPreference('HIDE_GEDCOM_ERRO
     $styles[] = 'd-none';
 }
 
-
 // historical facts
 if ($id === 'histo') {
     $styles[] = 'wt-historic-fact collapse';
@@ -71,20 +70,23 @@ if ($tag === 'MARR') {
 }
 
 ?>
-<tr class="<?= implode(' ', $styles) ?>">
-    <th scope="row">
-        <div class="wt-fact-label ut"><?= $label?></div>
 
-        <?php if ($id !== 'histo' && $id !== 'asso' && $fact->canEdit() && !in_array($tag, ['HUSB', 'WIFE', 'CHIL', 'FAMC', 'FAMS'], true)) : ?>
-            <?= view('fact-edit-links', ['fact' => $fact, 'url' => $record->url()]) ?>
-        <?php endif ?>
+<div class="row pt-1 <?= implode(' ', $styles) ?>">
+    <div class="col-sm-3 pe-1 ps-0">
+        <div class="wt-fact-controls">
+            <div class="wt-fact-label ut"><?= $label?></div>
 
-        <?php if ($tree->getPreference('SHOW_FACT_ICONS') === '1') : ?>
-            <span class="wt-fact-icon wt-fact-icon-<?= e($tag) ?>" title="<?= strip_tags($label) ?>"></span>
-        <?php endif ?>
-    </th>
+            <?php if ($id !== 'histo' && $id !== 'asso' && $fact->canEdit() && !in_array($tag, ['HUSB', 'WIFE', 'CHIL', 'FAMC', 'FAMS'], true)) : ?>
+                <?= view('fact-edit-links', ['fact' => $fact, 'url' => $record->url()]) ?>
+            <?php endif ?>
 
-    <td>
+            <?php if ($tree->getPreference('SHOW_FACT_ICONS') === '1') : ?>
+                <span class="wt-fact-icon wt-fact-icon-<?= e($tag) ?>" title="<?= strip_tags($label) ?>"></span>
+            <?php endif ?>
+        </div>
+    </div>
+
+    <div class="col-sm-9 wt-fact-content">
         <?php if ($fact->target() instanceof Media) : ?>
             <div class="d-flex flex-wrap">
                 <?php foreach ($fact->target()->mediaFiles() as $media_file) : ?>
@@ -158,5 +160,5 @@ if ($tag === 'MARR') {
             <?= view('fact-notes', ['fact' => $fact]) ?>
             <?= view('fact-media', ['fact' => $fact]) ?>
         <?php endif ?>
-    </td>
-</tr>
+    </div>
+</div>

--- a/resources/views/fact.phtml
+++ b/resources/views/fact.phtml
@@ -72,7 +72,7 @@ if ($tag === 'MARR') {
 ?>
 
 <div class="row pt-1 <?= implode(' ', $styles) ?>">
-    <div class="col-sm-3 pe-1 ps-0">
+    <div class="col-sm-2 pe-1 ps-0">
         <div class="wt-fact-controls">
             <div class="wt-fact-label ut"><?= $label?></div>
 
@@ -86,7 +86,7 @@ if ($tag === 'MARR') {
         </div>
     </div>
 
-    <div class="col-sm-9 wt-fact-content">
+    <div class="col-sm-10 wt-fact-content">
         <?php if ($fact->target() instanceof Media) : ?>
             <div class="d-flex flex-wrap">
                 <?php foreach ($fact->target()->mediaFiles() as $media_file) : ?>

--- a/resources/views/modules/personal_facts/tab.phtml
+++ b/resources/views/modules/personal_facts/tab.phtml
@@ -19,7 +19,7 @@ use Illuminate\Support\Collection;
 
 ?>
 
-<div class="container py-4">
+<div class="container py-4 wt-facts-table">
 
     <div class="row wt-fact-content py-1">
         <div class="col-sm-auto">

--- a/resources/views/modules/personal_facts/tab.phtml
+++ b/resources/views/modules/personal_facts/tab.phtml
@@ -20,36 +20,45 @@ use Illuminate\Support\Collection;
 ?>
 
 <div class="container py-4">
-    <?php if ($has_associate_facts || $has_relative_facts || $has_historic_facts) : ?>
-        <div class="row wt-fact-content py-1">
-            <?php if ($has_associate_facts) : ?>
-                <div class="col-sm-auto">
-                    <label>
-                        <input id="show-associate-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-associate-fact" data-wt-persist="associates" autocomplete="off">
-                        <?= I18N::translate('Associated events') ?>
-                    </label>
-                </div>
-            <?php endif ?>
 
-            <?php if ($has_relative_facts) : ?>
-                <div class="col-sm-auto">
-                    <label>
-                        <input id="show-relatives-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-relation-fact" data-wt-persist="relatives" autocomplete="off">
-                        <?= I18N::translate('Events of close relatives') ?>
-                    </label>
-                </div>
-            <?php endif ?>
-
-            <?php if ($has_historic_facts) : ?>
-                <div class="col-sm-auto">
-                    <label>
-                        <input id="show-historical-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-historic-fact" data-wt-persist="historic-facts" autocomplete="off">
-                        <?= I18N::translate('Historic events') ?>
-                    </label>
-                </div>
-            <?php endif ?>
+    <div class="row wt-fact-content py-1">
+        <div class="col-sm-auto">
+            <input id="show-associate-facts" class="form-check-input" type="checkbox"
+                data-bs-toggle="collapse"
+                data-bs-target=".wt-associate-fact"
+                data-wt-persist="associates"
+                autocomplete="off"
+                <?= !$has_associate_facts ? 'disabled="disabled"' : '' ?>
+            >
+            <label class="form-check-label" for="show-associate-facts">
+                <?= I18N::translate('Associated events') ?>
+            </label>
         </div>
-    <?php endif ?>
+        <div class="col-sm-auto">
+            <input id="show-relatives-facts" class="form-check-input" type="checkbox"
+                data-bs-toggle="collapse"
+                data-bs-target=".wt-relation-fact"
+                data-wt-persist="relatives"
+                autocomplete="off"
+                <?= !$has_relative_facts ? 'disabled="disabled"' : '' ?>
+            >
+            <label class="form-check-label" for="show-relatives-facts">
+                <?= I18N::translate('Events of close relatives') ?>
+            </label>
+        </div>
+        <div class="col-sm-auto">
+            <input id="show-historical-facts" class="form-check-input" type="checkbox"
+                data-bs-toggle="collapse"
+                data-bs-target=".wt-historic-fact"
+                data-wt-persist="historic-facts"
+                autocomplete="off"
+                <?= !$has_historic_facts ? 'disabled="disabled"' : '' ?>
+            >
+            <label class="form-check-label" for="show-historical-facts">
+                <?= I18N::translate('Historic events') ?>
+            </label>
+        </div>
+    </div>
 
     <?php foreach ($facts as $fact) : ?>
         <?= view('fact', ['fact' => $fact, 'record' => $individual]) ?>

--- a/resources/views/modules/personal_facts/tab.phtml
+++ b/resources/views/modules/personal_facts/tab.phtml
@@ -19,53 +19,51 @@ use Illuminate\Support\Collection;
 
 ?>
 
-<div class="wt-tab-facts py-4">
-    <table class="table wt-facts-table" style="table-layout: fixed">
-        <colgroup>
-            <col style="width:25%">
-            <col style="width:75%">
-        </colgroup>
-        <tbody>
-            <tr>
-                <td colspan="2">
-                    <?php if ($has_associate_facts) : ?>
-                        <label>
-                            <input id="show-associate-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-associate-fact" data-wt-persist="associates" autocomplete="off">
-                            <?= I18N::translate('Associated events') ?>
-                        </label>
-                    <?php endif ?>
-
-                    <?php if ($has_relative_facts) : ?>
-                        <label>
-                            <input id="show-relatives-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-relation-fact" data-wt-persist="relatives" autocomplete="off">
-                            <?= I18N::translate('Events of close relatives') ?>
-                        </label>
-                    <?php endif ?>
-
-                    <?php if ($has_historic_facts) : ?>
-                        <label>
-                            <input id="show-historical-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-historic-fact" data-wt-persist="historic-facts" autocomplete="off">
-                            <?= I18N::translate('Historic events') ?>
-                        </label>
-                    <?php endif ?>
-                </td>
-            </tr>
-
-            <?php foreach ($facts as $fact) : ?>
-                <?= view('fact', ['fact' => $fact, 'record' => $individual]) ?>
-            <?php endforeach ?>
-
-            <?php if ($facts->isEmpty()) : ?>
-                <tr>
-                    <td colspan="2">
-                        <?= I18N::translate('There are no facts for this individual.') ?>
-                    </td>
-                </tr>
+<div class="container py-4">
+    <?php if ($has_associate_facts || $has_relative_facts || $has_historic_facts) : ?>
+        <div class="row wt-fact-content py-1">
+            <?php if ($has_associate_facts) : ?>
+                <div class="col-sm-auto">
+                    <label>
+                        <input id="show-associate-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-associate-fact" data-wt-persist="associates" autocomplete="off">
+                        <?= I18N::translate('Associated events') ?>
+                    </label>
+                </div>
             <?php endif ?>
 
-            <?php if ($individual->canEdit()) : ?>
-                <?= view('fact-add-new', ['record' => $individual]) ?>
+            <?php if ($has_relative_facts) : ?>
+                <div class="col-sm-auto">
+                    <label>
+                        <input id="show-relatives-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-relation-fact" data-wt-persist="relatives" autocomplete="off">
+                        <?= I18N::translate('Events of close relatives') ?>
+                    </label>
+                </div>
             <?php endif ?>
-        </tbody>
-    </table>
+
+            <?php if ($has_historic_facts) : ?>
+                <div class="col-sm-auto">
+                    <label>
+                        <input id="show-historical-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-historic-fact" data-wt-persist="historic-facts" autocomplete="off">
+                        <?= I18N::translate('Historic events') ?>
+                    </label>
+                </div>
+            <?php endif ?>
+        </div>
+    <?php endif ?>
+
+    <?php foreach ($facts as $fact) : ?>
+        <?= view('fact', ['fact' => $fact, 'record' => $individual]) ?>
+    <?php endforeach ?>
+
+    <?php if (!$has_individual_facts) : ?>
+        <div class="row wt-fact-content my-3">
+            <div class="col-sm-auto py-2">
+                <?= I18N::translate('There are no facts for this individual.') ?>
+            </div>
+        </div>
+    <?php endif ?>
+
+    <?php if ($individual->canEdit()) : ?>
+        <?= view('fact-add-new', ['record' => $individual]) ?>
+    <?php endif ?>
 </div>


### PR DESCRIPTION
~~**Proof of concept - Do not use for production**~~

~~This only works on the webtrees theme for the Individual facts and events tab, (other things will break!!!)~~

I **think** this is suitable for production now

I've replaced the containing table with a bootstrap grid. This fixes all the problems with content overflowing the right margin and even looks reasonable when the browser width is reduced such that the columns fold.

It only requires two new webtrees classes, primarily for theming, everthing else is pure bootstrap.

I'd appreciate comments particularly on whether it's worth continuing down this path

BTW I've included a fix for https://github.com/fisharebest/webtrees/issues/4853

