### PR TITLE
Convert individual tabs to bootstrap grid

### DIFF
--- a/app/Module/IndividualFactsTabModule.php
+++ b/app/Module/IndividualFactsTabModule.php
@@ -138,6 +138,8 @@ class IndividualFactsTabModule extends AbstractModule implements ModuleTabInterf
         $associate_facts  = $this->individual_facts_service->associateFacts($individual);
         $historic_facts   = $this->individual_facts_service->historicFacts($individual);
 
+        $has_individual_facts = $individual_facts->isNotEmpty();
+
         $individual_facts = $individual_facts
             ->merge($family_facts)
             ->merge($relative_facts)
@@ -156,13 +158,14 @@ class IndividualFactsTabModule extends AbstractModule implements ModuleTabInterf
         ]);
 
         return view('modules/personal_facts/tab', [
-            'can_edit'            => $individual->canEdit(),
-            'clipboard_facts'     => $this->clipboard_service->pastableFacts($individual),
-            'has_associate_facts' => $associate_facts->isNotEmpty(),
-            'has_historic_facts'  => $historic_facts->isNotEmpty(),
-            'has_relative_facts'  => $relative_facts->isNotEmpty(),
-            'individual'          => $individual,
-            'facts'               => $individual_facts,
+            'can_edit'             => $individual->canEdit(),
+            'clipboard_facts'      => $this->clipboard_service->pastableFacts($individual),
+            'has_associate_facts'  => $associate_facts->isNotEmpty(),
+            'has_historic_facts'   => $historic_facts->isNotEmpty(),
+            'has_relative_facts'   => $relative_facts->isNotEmpty(),
+            'has_individual_facts' => $has_individual_facts,
+            'individual'           => $individual,
+            'facts'                => $individual_facts,
         ]);
     }
 

--- a/resources/css/clouds.css
+++ b/resources/css/clouds.css
@@ -693,17 +693,20 @@ div.fact_SHARED_NOTE {
     caption-side: top;
 }
 
-.wt-facts-table th {
+.wt-facts-table th, .wt-fact-controls {
     background-color: #95b8e0;
     color: #039;
     border: 1px solid #acf;
     border-radius: 3px;
     font-weight: normal;
     text-align: center;
+}
+
+.wt-facts-table > tbody > tr > th {
     min-width: 20%;
 }
 
-.wt-facts-table td {
+.wt-facts-table td, .wt-fact-content {
     border: solid #999 1px;
     border-radius: 3px;
     background-color: #fff;

--- a/resources/css/colors.css
+++ b/resources/css/colors.css
@@ -157,23 +157,23 @@
 }
 
 .wt-page-options-label,
-.wt-facts-table th, .wt-facts-table .dropdown-toggle,
+.wt-facts-table th, .wt-facts-table .dropdown-toggle, wt-fact-controls
 .descriptionbox, .descriptionbox a,
 .topbottombar, .topbottombar a,
-.list_label, .list_label a {
+.list_label, .list_label a, .wt-fact-controls {
     background-color: var(--color-3);
     color: var(--color-6);
 }
 
 .wt-page-options-value,
 .wt-block-content,
-.wt-facts-table td,
+.wt-facts-table td, wt-fact-content
 .ui-widget-header,
 .optionbox, .ui-state-active a:link,
-.list_value, .list_value_wrap, .list_value_wrap a {
+.list_value, .list_value_wrap,
+.list_value_wrap a, .wt-fact-content {
     background: var(--color-4);
 }
-
 
 .menu-tree .nav-link::before {
     content: url(colors/menu/tree.png);

--- a/resources/css/colors.css
+++ b/resources/css/colors.css
@@ -157,7 +157,7 @@
 }
 
 .wt-page-options-label,
-.wt-facts-table th, .wt-facts-table .dropdown-toggle, wt-fact-controls
+.wt-facts-table th, .wt-facts-table .dropdown-toggle,
 .descriptionbox, .descriptionbox a,
 .topbottombar, .topbottombar a,
 .list_label, .list_label a, .wt-fact-controls {
@@ -167,7 +167,7 @@
 
 .wt-page-options-value,
 .wt-block-content,
-.wt-facts-table td, wt-fact-content
+.wt-facts-table td,
 .ui-widget-header,
 .optionbox, .ui-state-active a:link,
 .list_value, .list_value_wrap,

--- a/resources/css/fab.css
+++ b/resources/css/fab.css
@@ -447,7 +447,7 @@ div.fact_SHARED_NOTE {
     caption-side: top;
 }
 
-.wt-facts-table th {
+.wt-facts-table th, .wt-fact-controls {
     background-color: #ccc;
     border-radius: 4px;
     text-align: center;
@@ -458,7 +458,7 @@ div.fact_SHARED_NOTE {
     min-width: 20%;
 }
 
-.wt-facts-table td {
+.wt-facts-table td, .wt-fact-content {
     border-radius: 4px;
     background-color: #ddd;
 }

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -409,7 +409,7 @@ table {
     caption-side: top;
 }
 
-.wt-facts-table th {
+.wt-facts-table th, .wt-fact-controls {
     border: 1px solid #000;
     font-weight: normal;
 }
@@ -418,7 +418,7 @@ table {
     min-width: 20%;
 }
 
-.wt-facts-table td {
+.wt-facts-table td, .wt-fact-content {
     border: solid #000 1px;
 }
 

--- a/resources/css/webtrees.css
+++ b/resources/css/webtrees.css
@@ -639,7 +639,7 @@ div.fact_SHARED_NOTE {
     caption-side: top;
 }
 
-.wt-facts-table th {
+.wt-facts-table th, .wt-fact-controls {
     background-color: #81a9cb;
     border: solid #81a9cb 1px;
     text-align: center;
@@ -650,7 +650,7 @@ div.fact_SHARED_NOTE {
     min-width: 20%;
 }
 
-.wt-facts-table td {
+.wt-facts-table td, .wt-fact-content {
     background-color: #edf7fd;
     border: 1px solid #81a9cb;
 }

--- a/resources/css/xenea.css
+++ b/resources/css/xenea.css
@@ -631,7 +631,7 @@ div.fact_SHARED_NOTE {
     caption-side: top;
 }
 
-.wt-facts-table th {
+.wt-facts-table th, .wt-fact-controls {
     background-color: #c3dfff;
     color: #006;
     text-align: center;
@@ -642,7 +642,7 @@ div.fact_SHARED_NOTE {
     min-width: 20%;
 }
 
-.wt-facts-table td {
+.wt-facts-table td, .wt-fact-content {
     background-color: #ecf5ff;
     border: 1px solid #c3dfff;
 }

--- a/resources/views/edit/add-fact-row.phtml
+++ b/resources/views/edit/add-fact-row.phtml
@@ -15,13 +15,15 @@ use Fisharebest\Webtrees\I18N;
 
 ?>
 
-<tr>
-    <th scope="row">
-        <label for="add-fact">
-            <?= I18N::translate('Add a fact') ?>
-        </label>
-    </th>
-    <td>
+<div class="row mt-1">
+    <div class="col-sm-2 ps-0 pe-1">
+        <div class="h-100 pt-1 wt-fact-controls">
+            <label for="add-fact">
+                <?= I18N::translate('Add a fact') ?>
+            </label>
+        </div>
+    </div>
+    <div class="col-sm-10 pt-1 wt-fact-content">
         <?php if ($add_facts !== []) : ?>
             <form method="post" action="<?= e(route(SelectNewFact::class, ['tree' => $record->tree()->name(), 'xref' => $record->xref()])) ?>" onsubmit="if ($('#add-fact').val() === null) {event.preventDefault();}">
                 <div class="input-group">
@@ -54,5 +56,5 @@ use Fisharebest\Webtrees\I18N;
                 </a>
             <?php endforeach ?>
         </div>
-    </td>
-</tr>
+    </div>
+</div>

--- a/resources/views/fact.phtml
+++ b/resources/views/fact.phtml
@@ -72,7 +72,7 @@ if ($tag === 'MARR') {
 
 ?>
 <div class="row mt-1 <?= implode(' ', $styles) ?>">
-    <div class="col-sm-2 ps-0 px-1">
+    <div class="col-sm-2 ps-0 pe-1">
         <div class="wt-fact-controls h-100 pt-1">
             <div class="wt-fact-label ut"><?= $label?></div>
 

--- a/resources/views/fact.phtml
+++ b/resources/views/fact.phtml
@@ -71,20 +71,22 @@ if ($tag === 'MARR') {
 }
 
 ?>
-<tr class="<?= implode(' ', $styles) ?>">
-    <th scope="row">
-        <div class="wt-fact-label ut"><?= $label?></div>
+<div class="row mt-1 <?= implode(' ', $styles) ?>">
+    <div class="col-sm-2 ps-0 px-1">
+        <div class="wt-fact-controls h-100 pt-1">
+            <div class="wt-fact-label ut"><?= $label?></div>
 
-        <?php if ($id !== 'histo' && $id !== 'asso' && $fact->canEdit() && !in_array($tag, ['HUSB', 'WIFE', 'CHIL', 'FAMC', 'FAMS'], true)) : ?>
-            <?= view('fact-edit-links', ['fact' => $fact, 'url' => $record->url()]) ?>
-        <?php endif ?>
+            <?php if ($id !== 'histo' && $id !== 'asso' && $fact->canEdit() && !in_array($tag, ['HUSB', 'WIFE', 'CHIL', 'FAMC', 'FAMS'], true)) : ?>
+                <?= view('fact-edit-links', ['fact' => $fact, 'url' => $record->url()]) ?>
+            <?php endif ?>
 
-        <?php if ($tree->getPreference('SHOW_FACT_ICONS') === '1') : ?>
-            <span class="wt-fact-icon wt-fact-icon-<?= e($tag) ?>" title="<?= strip_tags($label) ?>"></span>
-        <?php endif ?>
-    </th>
+            <?php if ($tree->getPreference('SHOW_FACT_ICONS') === '1') : ?>
+                <span class="wt-fact-icon wt-fact-icon-<?= e($tag) ?>" title="<?= strip_tags($label) ?>"></span>
+            <?php endif ?>
+        </div>
+    </div>
 
-    <td>
+    <div class="col-sm-10 wt-fact-content pt-1">
         <?php if ($fact->target() instanceof Media) : ?>
             <div class="d-flex flex-wrap">
                 <?php foreach ($fact->target()->mediaFiles() as $media_file) : ?>
@@ -158,5 +160,5 @@ if ($tag === 'MARR') {
             <?= view('fact-notes', ['fact' => $fact]) ?>
             <?= view('fact-media', ['fact' => $fact]) ?>
         <?php endif ?>
-    </td>
-</tr>
+    </div>
+</div>

--- a/resources/views/modules/media/tab.phtml
+++ b/resources/views/modules/media/tab.phtml
@@ -15,54 +15,60 @@ use Illuminate\Support\Collection;
  */
 
 ?>
-<div class="wt-tab-media py-4">
-    <table class="table wt-facts-table">
-        <tr>
-            <td colspan="2">
-                <label>
-                    <input id="show-level-2-media" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-level-two-media" data-wt-persist="level-two-media" autocomplete="off">
-                    <?= I18N::translate('Show all media') ?>
-                </label>
-            </td>
-        </tr>
+<div class="container py-4 wt-facts-table">
 
-        <?php foreach ($facts as $fact) : ?>
-            <?php if (str_ends_with($fact->tag(), ':OBJE')) : ?>
-                <?= view('fact', ['fact' => $fact, 'record' => $individual]) ?>
-            <?php else : ?>
-                <?php
-                if ($fact->isPendingAddition()) {
-                    $styleadd = 'wt-new ';
-                } elseif ($fact->isPendingDeletion()) {
-                    $styleadd = 'wt-old ';
-                } else {
-                    $styleadd = '';
-                }
-                ?>
+    <div class="row wt-fact-content py-1">
+        <div class="col-sm-auto">
+            <input id="show-level-2-media" class="form-check-input" type="checkbox"
+                data-bs-toggle="collapse"
+                data-bs-target=".wt-level-two-media"
+                data-wt-persist="level-two-media"
+                autocomplete="off"
+                <?= $facts->isEmpty() ? 'disabled="disabled"' : '' ?>
+            >
+            <label class="form-check-label" for="show-level-2-media">
+                <?= I18N::translate('Show all media') ?>
+            </label>
+        </div>
+    </div>
 
-                <tr class="wt-level-two-media collapse">
-                    <th scope="row" class="rela <?= $styleadd ?>">
-                        <?= $fact->label() ?>
-                        <?= view('fact-edit-links', ['fact' => $fact, 'url' => $fact->record()->url() . '#tab-media']) ?>
-                    </th>
+    <?php foreach ($facts as $fact) : ?>
+        <?php if (str_ends_with($fact->tag(), ':OBJE')) : ?>
+            <?= view('fact', ['fact' => $fact, 'record' => $individual]) ?>
+        <?php else : ?>
+            <?php
+            if ($fact->isPendingAddition()) {
+                $styleadd = 'wt-new ';
+            } elseif ($fact->isPendingDeletion()) {
+                $styleadd = 'wt-old ';
+            } else {
+                $styleadd = '';
+            }
+            ?>
 
-                    <td class="<?= $styleadd ?>">
-                        <?php if (preg_match_all('/\n([2-4] OBJE .*)/', $fact->gedcom(), $matches, PREG_SET_ORDER) > 0) : ?>
-                            <?php foreach ($matches as $match) : ?>
-                                <?= view('fact-gedcom-fields', ['gedcom' => $match[1], 'parent' => $fact->tag(), 'tree' => $fact->record()->tree()]) ?>
-                            <?php endforeach ?>
-                        <?php endif ?>
-                    </td>
-                </tr>
-            <?php endif ?>
-        <?php endforeach ?>
 
-        <?php if ($facts->isEmpty()) : ?>
-            <tr>
-                <td colspan="2">
-                    <?= I18N::translate('There are no media objects for this individual.') ?>
-                </td>
-            </tr>
+            <div class="row wt-level-two-media collapse pt-1">
+                <div class="col-sm-2 pe-1 ps-0 rela wt-fact-controls <?= $styleadd ?>">
+                    <?= $fact->label() ?>
+                    <?= view('fact-edit-links', ['fact' => $fact, 'url' => $fact->record()->url() . '#tab-media']) ?>
+                </div>
+
+                <div class="col-sm-10 wt-fact-content <?= $styleadd ?>">
+                    <?php if (preg_match_all('/\n([2-4] OBJE .*)/', $fact->gedcom(), $matches, PREG_SET_ORDER) > 0) : ?>
+                        <?php foreach ($matches as $match) : ?>
+                            <?= view('fact-gedcom-fields', ['gedcom' => $match[1], 'parent' => $fact->tag(), 'tree' => $fact->record()->tree()]) ?>
+                        <?php endforeach ?>
+                    <?php endif ?>
+                </div>
+            </div>
         <?php endif ?>
-    </table>
+    <?php endforeach ?>
+
+    <?php if ($facts->isEmpty()) : ?>
+        <div class="row wt-fact-content my-3">
+            <div class="col-sm-auto py-2">
+                <?= I18N::translate('There are no media objects for this individual.') ?>
+            </div>
+        </div>
+    <?php endif ?>
 </div>

--- a/resources/views/modules/media/tab.phtml
+++ b/resources/views/modules/media/tab.phtml
@@ -48,9 +48,11 @@ use Illuminate\Support\Collection;
 
 
             <div class="row wt-level-two-media collapse pt-1">
-                <div class="col-sm-2 pe-1 ps-0 rela wt-fact-controls <?= $styleadd ?>">
-                    <?= $fact->label() ?>
-                    <?= view('fact-edit-links', ['fact' => $fact, 'url' => $fact->record()->url() . '#tab-media']) ?>
+                <div class="col-sm-2  ps-0 pe-1">
+                    <div class="wt-fact-controls h-100 <?= $styleadd ?>">
+                        <?= $fact->label() ?>
+                        <?= view('fact-edit-links', ['fact' => $fact, 'url' => $fact->record()->url() . '#tab-media']) ?>
+                    </div>
                 </div>
 
                 <div class="col-sm-10 wt-fact-content <?= $styleadd ?>">

--- a/resources/views/modules/notes/tab.phtml
+++ b/resources/views/modules/notes/tab.phtml
@@ -21,84 +21,92 @@ use Illuminate\Support\Collection;
 
 ?>
 
-<div class="wt-tan-notes py-4">
-    <table class="table wt-facts-table">
-        <tr>
-            <td colspan="2">
-                <label>
-                    <input id="show-level-2-notes" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-level-two-note" data-wt-persist="level-two-notes" autocomplete="off">
-                    <?= I18N::translate('Show all notes') ?>
-                </label>
-            </td>
-        </tr>
+<div class="container py-4 wt-facts-table">
 
-        <?php foreach ($facts as $fact) : ?>
-            <?php if ($fact->tag() === 'INDI:NOTE' || $fact->tag() === 'FAM:NOTE') : ?>
-                <?= view('fact', ['fact' => $fact, 'record' => $individual]) ?>
-            <?php else : ?>
-                <?php
-                if ($fact->isPendingAddition()) {
-                    $styleadd = 'wt-new ';
-                } elseif ($fact->isPendingDeletion()) {
-                    $styleadd = 'wt-old ';
-                } else {
-                    $styleadd = '';
-                }
-                ?>
+    <div class="row wt-fact-content py-1">
+        <div class="col-sm-auto">
+            <input id="show-level-2-notes" class="form-check-input" type="checkbox"
+                data-bs-toggle="collapse"
+                data-bs-target=".wt-level-two-note"
+                data-wt-persist="level-two-notes"
+                autocomplete="off"
+                <?= $facts->isEmpty() ? 'disabled="disabled"' : '' ?>
+            >
+            <label class="form-check-label" for="show-level-2-notes">
+                <?= I18N::translate('Show all notes') ?>
+            </label>
+        </div>
+    </div>
 
-                <tr class="wt-level-two-note collapse">
-                    <th scope="row" class="rela <?= $styleadd ?>">
+    <?php foreach ($facts as $fact) : ?>
+        <?php if ($fact->tag() === 'INDI:NOTE' || $fact->tag() === 'FAM:NOTE') : ?>
+            <?= view('fact', ['fact' => $fact, 'record' => $individual]) ?>
+        <?php else : ?>
+            <?php
+            if ($fact->isPendingAddition()) {
+                $styleadd = 'wt-new ';
+            } elseif ($fact->isPendingDeletion()) {
+                $styleadd = 'wt-old ';
+            } else {
+                $styleadd = '';
+            }
+            ?>
+
+            <div class="row wt-level-two-note collapse mt-1">
+                <div class="col-sm-2 pe-1 ps-0 rela <?= $styleadd ?>">
+                    <div class="wt-fact-controls h-100 pt-1">
                         <?= $fact->label() ?>
                         <?= view('fact-edit-links', ['fact' => $fact, 'url' => $fact->record()->url() . '#tab-notes']) ?>
-                    </th>
+                    </div>
+                </div>
 
-                    <td class="<?= $styleadd ?>">
-                        <?php preg_match_all("/\n[1-9] NOTE ?(.*(?:\n\d CONT.*)*)/", $fact->gedcom(), $matches, PREG_SET_ORDER) ?>
-                        <?php foreach ($matches as $match) : ?>
-                            <div class="mb-2">
-                                <?php $text = preg_replace('/\n\d CONT ?/', "\n", $match[1]) ?>
-                                <?php if (preg_match('/^@' . Gedcom::REGEX_XREF . '@$/', $text) === 1) : ?>
-                                    <?php $note = Registry::noteFactory()->make(trim($text, '@'), $individual->tree()) ?>
-                                    <?php if ($note instanceof Note) : ?>
-                                        <?php if ($note->canShow()) : ?>
-                                            <a href="<?= e($note->url()) ?>">
-                                                <?= I18N::translate('Shared note') ?>
-                                                <?= view('icons/note') ?>
-                                            </a>
-                                            <?= (new SubmitterText(''))->value($note->getNote(), $individual->tree()) ?>
-                                        <?php endif ?>
-                                    <?php else : ?>
-                                        <span class="error"><?= e($text) ?></span>
+                <div class="col-sm-10 wt-fact-content pt-1 <?= $styleadd ?>">
+                    <?php preg_match_all("/\n[1-9] NOTE ?(.*(?:\n\d CONT.*)*)/", $fact->gedcom(), $matches, PREG_SET_ORDER) ?>
+                    <?php foreach ($matches as $match) : ?>
+                        <div class="mb-2">
+                            <?php $text = preg_replace('/\n\d CONT ?/', "\n", $match[1]) ?>
+                            <?php if (preg_match('/^@' . Gedcom::REGEX_XREF . '@$/', $text) === 1) : ?>
+                                <?php $note = Registry::noteFactory()->make(trim($text, '@'), $individual->tree()) ?>
+                                <?php if ($note instanceof Note) : ?>
+                                    <?php if ($note->canShow()) : ?>
+                                        <a href="<?= e($note->url()) ?>">
+                                            <?= I18N::translate('Shared note') ?>
+                                            <?= view('icons/note') ?>
+                                        </a>
+                                        <?= (new SubmitterText(''))->value($note->getNote(), $individual->tree()) ?>
                                     <?php endif ?>
                                 <?php else : ?>
-                                    <?= (new SubmitterText(''))->value($text, $individual->tree()) ?>
+                                    <span class="error"><?= e($text) ?></span>
                                 <?php endif ?>
-                            </div>
-                        <?php endforeach ?>
-                    </td>
-                </tr>
-            <?php endif ?>
-        <?php endforeach ?>
-
-        <?php if ($facts->isEmpty()) : ?>
-            <tr>
-                <td colspan="2">
-                    <?= I18N::translate('There are no notes for this individual.') ?>
-                </td>
-            </tr>
+                            <?php else : ?>
+                                <?= (new SubmitterText(''))->value($text, $individual->tree()) ?>
+                            <?php endif ?>
+                        </div>
+                    <?php endforeach ?>
+                </div>
+            </div>
         <?php endif ?>
+    <?php endforeach ?>
 
-        <?php if ($can_edit) : ?>
-            <tr>
-                <th scope="row">
-                    <?= I18N::translate('Note') ?>
-                </th>
-                <td>
-                    <a href="<?= e(route(AddNewFact::class, ['tree' => $individual->tree()->name(), 'xref' => $individual->xref(), 'fact' => 'NOTE'])) ?>">
-                        <?= I18N::translate('Add a note') ?>
-                    </a>
-                </td>
-            </tr>
-        <?php endif ?>
-    </table>
+    <?php if ($facts->isEmpty()) : ?>
+        <div class="row wt-fact-content my-3">
+            <div class="col-sm-auto py-2">
+                <?= I18N::translate('There are no notes for this individual.') ?>
+            </div>
+        </div>
+    <?php endif ?>
+
+    <?php if ($can_edit) : ?>
+        <div class="row my-3">
+            <div class="col-sm-2 py-2 wt-fact-controls">
+                <?= I18N::translate('Note') ?>
+            </div>
+            <div class="col-sm-10 wt-fact-content py-2">
+                <a href="<?= e(route(AddNewFact::class, ['tree' => $individual->tree()->name(), 'xref' => $individual->xref(), 'fact' => 'NOTE'])) ?>">
+                    <?= I18N::translate('Add a note') ?>
+                </a>
+            </div>
+        </div>
+    <?php endif ?>
+
 </div>

--- a/resources/views/modules/notes/tab.phtml
+++ b/resources/views/modules/notes/tab.phtml
@@ -53,7 +53,7 @@ use Illuminate\Support\Collection;
             ?>
 
             <div class="row wt-level-two-note collapse mt-1">
-                <div class="col-sm-2 pe-1 ps-0 rela <?= $styleadd ?>">
+                <div class="col-sm-2 pe-1 ps-0 <?= $styleadd ?>">
                     <div class="wt-fact-controls h-100 pt-1">
                         <?= $fact->label() ?>
                         <?= view('fact-edit-links', ['fact' => $fact, 'url' => $fact->record()->url() . '#tab-notes']) ?>

--- a/resources/views/modules/personal_facts/tab.phtml
+++ b/resources/views/modules/personal_facts/tab.phtml
@@ -20,53 +20,60 @@ use Illuminate\Support\Collection;
 
 ?>
 
-<div class="wt-tab-facts py-4">
-    <table class="table wt-facts-table" style="table-layout: fixed">
-        <colgroup>
-            <col style="width:25%">
-            <col style="width:75%">
-        </colgroup>
-        <tbody>
-            <tr>
-                <td colspan="2">
-                    <?php if ($has_associate_facts) : ?>
-                        <label>
-                            <input id="show-associate-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-associate-fact" data-wt-persist="associates" autocomplete="off">
-                            <?= I18N::translate('Associated events') ?>
-                        </label>
-                    <?php endif ?>
+<div class="container py-4 wt-facts-table">
 
-                    <?php if ($has_relative_facts) : ?>
-                        <label>
-                            <input id="show-relatives-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-relation-fact" data-wt-persist="relatives" autocomplete="off">
-                            <?= I18N::translate('Events of close relatives') ?>
-                        </label>
-                    <?php endif ?>
+    <div class="row wt-fact-content py-1">
+        <div class="col-sm-auto">
+            <input id="show-associate-facts" class="form-check-input" type="checkbox"
+                data-bs-toggle="collapse"
+                data-bs-target=".wt-associate-fact"
+                data-wt-persist="associates"
+                autocomplete="off"
+                <?= !$has_associate_facts ? 'disabled="disabled"' : '' ?>
+            >
+            <label class="form-check-label" for="show-associate-facts">
+                <?= I18N::translate('Associated events') ?>
+            </label>
+        </div>
+        <div class="col-sm-auto">
+            <input id="show-relatives-facts" class="form-check-input" type="checkbox"
+                data-bs-toggle="collapse"
+                data-bs-target=".wt-relation-fact"
+                data-wt-persist="relatives"
+                autocomplete="off"
+                <?= !$has_relative_facts ? 'disabled="disabled"' : '' ?>
+            >
+            <label class="form-check-label" for="show-relatives-facts">
+                <?= I18N::translate('Events of close relatives') ?>
+            </label>
+        </div>
+        <div class="col-sm-auto">
+            <input id="show-historical-facts" class="form-check-input" type="checkbox"
+                data-bs-toggle="collapse"
+                data-bs-target=".wt-historic-fact"
+                data-wt-persist="historic-facts"
+                autocomplete="off"
+                <?= !$has_historic_facts ? 'disabled="disabled"' : '' ?>
+            >
+            <label class="form-check-label" for="show-historical-facts">
+                <?= I18N::translate('Historic events') ?>
+            </label>
+        </div>
+    </div>
 
-                    <?php if ($has_historic_facts) : ?>
-                        <label>
-                            <input id="show-historical-facts" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-historic-fact" data-wt-persist="historic-facts" autocomplete="off">
-                            <?= I18N::translate('Historic events') ?>
-                        </label>
-                    <?php endif ?>
-                </td>
-            </tr>
+    <?php foreach ($facts as $fact) : ?>
+        <?= view('fact', ['fact' => $fact, 'record' => $individual]) ?>
+    <?php endforeach ?>
 
-            <?php foreach ($facts as $fact) : ?>
-                <?= view('fact', ['fact' => $fact, 'record' => $individual]) ?>
-            <?php endforeach ?>
+    <?php if (!$has_individual_facts) : ?>
+        <div class="row wt-fact-content my-3">
+            <div class="col-sm-auto py-2">
+                <?= I18N::translate('There are no facts for this individual.') ?>
+            </div>
+        </div>
+    <?php endif ?>
 
-            <?php if (!$has_individual_facts) : ?>
-                <tr>
-                    <td colspan="2">
-                        <?= I18N::translate('There are no facts for this individual.') ?>
-                    </td>
-                </tr>
-            <?php endif ?>
-
-            <?php if ($individual->canEdit()) : ?>
-                <?= view('fact-add-new', ['record' => $individual]) ?>
-            <?php endif ?>
-        </tbody>
-    </table>
+    <?php if ($individual->canEdit()) : ?>
+        <?= view('fact-add-new', ['record' => $individual]) ?>
+    <?php endif ?>
 </div>

--- a/resources/views/modules/personal_facts/tab.phtml
+++ b/resources/views/modules/personal_facts/tab.phtml
@@ -14,6 +14,7 @@ use Illuminate\Support\Collection;
  * @var bool                 $has_associate_facts
  * @var bool                 $has_historic_facts
  * @var bool                 $has_relative_facts
+ * @var bool                 $has_individual_facts
  * @var Individual           $individual
  */
 
@@ -55,7 +56,7 @@ use Illuminate\Support\Collection;
                 <?= view('fact', ['fact' => $fact, 'record' => $individual]) ?>
             <?php endforeach ?>
 
-            <?php if ($facts->isEmpty()) : ?>
+            <?php if (!$has_individual_facts) : ?>
                 <tr>
                     <td colspan="2">
                         <?= I18N::translate('There are no facts for this individual.') ?>

--- a/resources/views/modules/relatives/family.phtml
+++ b/resources/views/modules/relatives/family.phtml
@@ -24,219 +24,224 @@ use Fisharebest\Webtrees\Services\RelationshipService;
 
 ?>
 
-<table class="table table-sm wt-facts-table">
-    <caption>
+<div class="row py-2">
+    <div class="col-sm-auto">
         <a href="<?= e($family->url()) ?>"><?= $label ?></a>
-    </caption>
+    </div>
+</div>
 
-    <tbody>
+<?php
+$found = false;
+foreach ($family->facts(['HUSB'], false, $fam_access_level) as $fact) {
+    $found |= !$fact->isPendingDeletion();
+    $person = $fact->target();
+    if ($person instanceof Individual) {
+        $row_class = 'wt-sex-' . strtolower($person->sex());
+        if ($fact->isPendingAddition()) {
+            $row_class .= ' wt-new';
+        } elseif ($fact->isPendingDeletion()) {
+            $row_class .= ' wt-old';
+        }
+?>
+        <div class="row mt-1 <?= $row_class ?>">
+            <div class="col-sm-2 pe-1 ps-0">
+                <div class="wt-fact-controls h-100">
+                    <?= $individual === $person ? '<i class="icon-selected"></i>' : '' ?>
+                    <?= Registry::container()->get(RelationshipService::class)->getCloseRelationshipName($individual, $person) ?>
+                </div>
+            </div>
+            <div class="col-sm-10 border-0 p-0">
+                <?= view('chart-box', ['individual' => $person]) ?>
+            </div>
+        </div>
+    <?php
+    }
+}
+if (!$found && $family->canEdit()) {
+    ?>
+    <div class="row">
+        <div class="col-sm-2 p-3 wt-fact-controls"></div>
+        <div class="col-sm-10">
+            <a href="<?= e(route(AddSpouseToFamilyPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'sex' => 'M', 'url' => $individual->url() . '#tab-relatives'])) ?>">
+                <?= I18N::translate('Add a husband') ?>
+            </a>
+        </div>
+    </div>
+    <?php
+}
+
+$found = false;
+foreach ($family->facts(['WIFE'], false, $fam_access_level) as $fact) {
+    $person = $fact->target();
+    if ($person instanceof Individual) {
+        $found |= !$fact->isPendingDeletion();
+        $row_class = 'wt-sex-' . strtolower($person->sex());
+        if ($fact->isPendingAddition()) {
+            $row_class .= ' wt-new';
+        } elseif ($fact->isPendingDeletion()) {
+            $row_class .= ' wt-old';
+        }
+    ?>
+
+        <div class="row mt-1 <?= $row_class ?>">
+            <div class="col-sm-2 pe-1 ps-0">
+                <div class="wt-fact-controls h-100">
+                <?= $individual === $person ? '<i class="icon-selected"></i>' : '' ?>
+                <?= Registry::container()->get(RelationshipService::class)->getCloseRelationshipName($individual, $person) ?>
+                </div>
+            </div>
+            <div class="col-sm-10 border-0 p-0">
+                <?= view('chart-box', ['individual' => $person]) ?>
+            </div>
+        </div>
+    <?php
+    }
+}
+if (!$found && $family->canEdit()) { ?>
+    <div class="row">
+        <div class="col-sm-2 p-3 wt-fact-controls">
+            <div class="col-sm-10>
+                    <a href=" <?= e(route(AddSpouseToFamilyPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'sex' => 'F', 'url' => $individual->url() . '#tab-relatives'])) ?>">
+                <?= I18N::translate('Add a wife') ?>
+                </a>
+            </div>
+        </div>
+
+    <?php } ?>
+
+    <?php
+    ///// MARR /////
+    $found = false;
+    $prev  = new Date('');
+    foreach ($family->facts(array_merge(Gedcom::MARRIAGE_EVENTS, Gedcom::DIVORCE_EVENTS), true) as $fact) {
+        $found |= !$fact->isPendingDeletion();
+        if ($fact->isPendingAddition()) {
+            $row_class = 'wt-new';
+        } elseif ($fact->isPendingDeletion()) {
+            $row_class = 'wt-old';
+        } else {
+            $row_class = '';
+        }
+    ?>
+
+    <div class="row mt-1 <?= $row_class ?>">
+        <div class="col-sm-2 ps-0 px-1">
+            <div class="wt-fact-controls h-100 pt-1">
+                <span class="visually-hidden"><?= $fact->label() ?></span>
+            </div>
+        </div>
+        <div class="col-sm-10 wt-fact-content py-1">
+                <span class="label"><?= $fact->label() ?></span>
+            —
+            <span class="field"><?= $fact->date()->display() ?> — <?= $fact->place()->fullName() ?></span>
+        </div>
+    </div>
+
         <?php
-        $found = false;
-        foreach ($family->facts(['HUSB'], false, $fam_access_level) as $fact) {
-            $found |= !$fact->isPendingDeletion();
-            $person = $fact->target();
-            if ($person instanceof Individual) {
-                $row_class = 'wt-sex-' . strtolower($person->sex());
-                if ($fact->isPendingAddition()) {
-                    $row_class .= ' wt-new';
-                } elseif ($fact->isPendingDeletion()) {
-                    $row_class .= ' wt-old';
-                }
-                ?>
-                <tr class="<?= $row_class ?>">
-                    <th scope="row">
-                        <?= $individual === $person ? '<i class="icon-selected"></i>' : '' ?>
-                        <?= Registry::container()->get(RelationshipService::class)->getCloseRelationshipName($individual, $person) ?>
-                    </th>
-                    <td class="border-0 p-0">
-                        <?= view('chart-box', ['individual' => $person]) ?>
-                    </td>
-                </tr>
-                <?php
-            }
+        if (!$prev->isOK() && $fact->date()->isOK()) {
+            $prev = $fact->date();
         }
-        if (!$found && $family->canEdit()) {
-            ?>
-            <tr>
-                <th scope="row"></th>
-                <td>
-                    <a href="<?= e(route(AddSpouseToFamilyPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'sex' => 'M', 'url' => $individual->url() . '#tab-relatives'])) ?>">
-                        <?= I18N::translate('Add a husband') ?>
-                    </a>
-                </td>
-            </tr>
-            <?php
-        }
+    }
 
-        $found = false;
-        foreach ($family->facts(['WIFE'], false, $fam_access_level) as $fact) {
-            $person = $fact->target();
-            if ($person instanceof Individual) {
-                $found |= !$fact->isPendingDeletion();
-                $row_class = 'wt-sex-' . strtolower($person->sex());
-                if ($fact->isPendingAddition()) {
-                    $row_class .= ' wt-new';
-                } elseif ($fact->isPendingDeletion()) {
-                    $row_class .= ' wt-old';
-                }
-                ?>
+    if (!$found && $family->canShow() && $family->canEdit()) {
+        ?>
+        <div class="row py-1">
+            <div class="col-sm-2 pe-1 ps-0 wt-fact-controls">
+                <span class="visually-hidden"><?= I18N::translate('Marriage') ?></span>
+            </div>
 
-                <tr class="<?= $row_class ?>">
-                    <th scope="row">
-                        <?= $individual === $person ? '<i class="icon-selected"></i>' : '' ?>
-                        <?= Registry::container()->get(RelationshipService::class)->getCloseRelationshipName($individual, $person) ?>
-                    </th>
-                    <td class="border-0 p-0">
-                        <?= view('chart-box', ['individual' => $person]) ?>
-                    </td>
-                </tr>
-                <?php
-            }
-        }
-        if (!$found && $family->canEdit()) { ?>
-            <tr>
-                <th scope="row"></th>
-                <td>
-                    <a href="<?= e(route(AddSpouseToFamilyPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'sex' => 'F', 'url' => $individual->url() . '#tab-relatives'])) ?>">
-                        <?= I18N::translate('Add a wife') ?>
-                    </a>
-                </td>
-            </tr>
-
-        <?php } ?>
-
+            <div class="col-sm-10 wt-fact-content py-1">
+                <a href="<?= e(route(AddNewFact::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'fact' => 'MARR'])) ?>">
+                    <?= I18N::translate('Add marriage details') ?>
+                </a>
+            </div>
+        </div>
         <?php
-        ///// MARR /////
-        $found = false;
-        $prev  = new Date('');
-        foreach ($family->facts(array_merge(Gedcom::MARRIAGE_EVENTS, Gedcom::DIVORCE_EVENTS), true) as $fact) {
-            $found |= !$fact->isPendingDeletion();
+    }
+
+    ///// CHIL /////
+    $child_number = 0;
+    foreach ($family->facts(['CHIL'], false, $fam_access_level) as $fact) {
+        $person = $fact->target();
+        if ($person instanceof Individual) {
+            $row_class = 'wt-sex-' . strtolower($person->sex());
             if ($fact->isPendingAddition()) {
-                $row_class = 'wt-new';
+                $child_number++;
+                $row_class .= ' new';
             } elseif ($fact->isPendingDeletion()) {
-                $row_class = 'wt-old';
+                $row_class .= ' old';
             } else {
-                $row_class = '';
+                $child_number++;
             }
-            ?>
-
-            <tr class="<?= $row_class ?>">
-                <th scope="row">
-                    <span class="visually-hidden"><?= $fact->label() ?></span>
-                </th>
-
-                <td>
-                    <span class="label"><?= $fact->label() ?></span>
-                    —
-                    <span class="field"><?= $fact->date()->display() ?> — <?= $fact->place()->fullName() ?></span>
-                </td>
-            </tr>
-
-            <?php
-            if (!$prev->isOK() && $fact->date()->isOK()) {
-                $prev = $fact->date();
-            }
-        }
-
-        if (!$found && $family->canShow() && $family->canEdit()) {
-            ?>
-            <tr>
-                <th scope="row">
-                    <span class="visually-hidden"><?= I18N::translate('Marriage') ?></span>
-                </th>
-
-                <td>
-                    <a href="<?= e(route(AddNewFact::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'fact' => 'MARR'])) ?>">
-                        <?= I18N::translate('Add marriage details') ?>
-                    </a>
-                </td>
-            </tr>
-            <?php
-        }
-
-        ///// CHIL /////
-        $child_number = 0;
-        foreach ($family->facts(['CHIL'], false, $fam_access_level) as $fact) {
-            $person = $fact->target();
-            if ($person instanceof Individual) {
-                $row_class = 'wt-sex-' . strtolower($person->sex());
-                if ($fact->isPendingAddition()) {
-                    $child_number++;
-                    $row_class .= ' new';
-                } elseif ($fact->isPendingDeletion()) {
-                    $row_class .= ' old';
-                } else {
-                    $child_number++;
+            $next = new Date('');
+            foreach ($person->facts(Gedcom::BIRTH_EVENTS, true) as $bfact) {
+                if ($bfact->date()->isOK()) {
+                    $next = $bfact->date();
+                    break;
                 }
-                $next = new Date('');
-                foreach ($person->facts(Gedcom::BIRTH_EVENTS, true) as $bfact) {
-                    if ($bfact->date()->isOK()) {
-                        $next = $bfact->date();
-                        break;
-                    }
-                }
-                ?>
-
-                <tr class="<?= $row_class ?>">
-                    <th scope="row">
-                        <?php if ($individual === $person) : ?>
-                            <i class="icon-selected"></i>
-                        <?php endif ?>
-
-                        <?php if ($prev->isOK() && $next->isOK()) : ?>
-                            <div class="wt-date-difference collapse small">
-                                <?php $days = $next->maximumJulianDay() - $prev->minimumJulianDay(); ?>
-                                <?php if ($days < 0 || $child_number > 1 && $days > 1 && $days < 240) : ?>
-                                    <?= view('icons/warning') ?>
-                                <?php endif ?>
-
-                                <?php $months = intdiv($days + 15, 30); ?>
-                                <?php if (abs($months) === 12 || abs($months) >= 24) : ?>
-                                    <?= I18N::plural('%s year', '%s years', intdiv($months, 12), I18N::number(round($months / 12))) ?>
-                                <?php elseif ($months !== 0) : ?>
-                                    <?= I18N::plural('%s month', '%s months', $months, I18N::number($months)) ?>
-                                <?php endif ?>
-                            </div>
-                        <?php endif ?>
-
-                        <?= Registry::container()->get(RelationshipService::class)->getCloseRelationshipName($individual, $person) ?>
-                    </th>
-                    <td class="border-0 p-0">
-                        <?= view('chart-box', ['individual' => $person]) ?>
-                    </td>
-                </tr>
-                <?php
-                $prev = $next;
             }
-        } ?>
+        ?>
 
-        <?php if ($family->canEdit()) : ?>
-            <tr>
-                <th scope="row">
+        <div class="row mt-1">
+            <div class="col-sm-2 ps-0 px-1">
+                <div class="wt-fact-controls h-100 pt-1">
+                    <?php if ($prev->isOK() && $next->isOK()) : ?>
+                        <div class="wt-date-difference collapse small">
+                            <?php $days = $next->maximumJulianDay() - $prev->minimumJulianDay(); ?>
+                            <?php if ($days < 0 || $child_number > 1 && $days > 1 && $days < 240) : ?>
+                                <?= view('icons/warning') ?>
+                            <?php endif ?>
+
+                            <?php $months = intdiv($days + 15, 30); ?>
+                            <?php if (abs($months) === 12 || abs($months) >= 24) : ?>
+                                <?= I18N::plural('%s year', '%s years', intdiv($months, 12), I18N::number(round($months / 12))) ?>
+                            <?php elseif ($months !== 0) : ?>
+                                <?= I18N::plural('%s month', '%s months', $months, I18N::number($months)) ?>
+                            <?php endif ?>
+                        </div>
+                    <?php endif ?>
+                    <?php if ($individual === $person) : ?>
+                        <i class="icon-selected"></i>
+                    <?php endif ?>
+                    <?= Registry::container()->get(RelationshipService::class)->getCloseRelationshipName($individual, $person) ?>
+                </div>
+            </div>
+
+            <div class="col-sm-10 border-0 p-0">
+                <?= view('chart-box', ['individual' => $person]) ?>
+            </div>
+        </div>
+    <?php
+            $prev = $next;
+        }
+    } ?>
+
+    <?php if ($family->canEdit()) : ?>
+        <div class="row mt-1">
+            <div class="col-sm-2 ps-0 px-1">
+                <div class="wt-fact-controls h-100 pt-1">
                     <span class="visually-hidden"><?= I18N::translate('Children') ?></span>
-                </th>
+                </div>
+            </div>
+            <div class="col-sm-10 wt-fact-content p-1 ps-2">
+                <a href="<?= e(route(AddChildToFamilyPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'sex' => 'M', 'url' => $individual->url() . '#tab-relatives'])) ?>">
+                    <?= $type === 'FAMS' ? I18N::translate('Add a son') : I18N::translate('Add a brother') ?>
+                </a>
+                |
+                <a href="<?= e(route(AddChildToFamilyPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'sex' => 'F', 'url' => $individual->url() . '#tab-relatives'])) ?>">
+                    <?= $type === 'FAMS' ? I18N::translate('Add a daughter') : I18N::translate('Add a sister') ?>
+                </a>
+                |
+                <a href="<?= e(route(AddChildToFamilyPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'sex' => 'U', 'url' => $individual->url() . '#tab-relatives'])) ?>">
+                    <?= $type === 'FAMS' ? I18N::translate('Add a child') : I18N::translate('Add a sibling') ?>
+                </a>
 
-                <td>
-                    <a href="<?= e(route(AddChildToFamilyPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'sex' => 'M', 'url' => $individual->url() . '#tab-relatives'])) ?>">
-                        <?= $type === 'FAMS' ? I18N::translate('Add a son') : I18N::translate('Add a brother') ?>
+                <?php if ($family->children()->count() > 1) : ?>
+                    <br>
+                    <a href="<?= e(route(ReorderChildrenPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'url' => $individual->url() . '#tab-relatives'])) ?>">
+                        <?= I18N::translate('Re-order children') ?>
                     </a>
-                    |
-                    <a href="<?= e(route(AddChildToFamilyPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'sex' => 'F', 'url' => $individual->url() . '#tab-relatives'])) ?>">
-                        <?= $type === 'FAMS' ? I18N::translate('Add a daughter') : I18N::translate('Add a sister') ?>
-                    </a>
-                    |
-                    <a href="<?= e(route(AddChildToFamilyPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'sex' => 'U', 'url' => $individual->url() . '#tab-relatives'])) ?>">
-                        <?= $type === 'FAMS' ? I18N::translate('Add a child') : I18N::translate('Add a sibling') ?>
-                    </a>
-
-                    <?php if ($family->children()->count() > 1) : ?>
-                        <br>
-                        <a href="<?= e(route(ReorderChildrenPage::class, ['tree' => $family->tree()->name(), 'xref' => $family->xref(), 'url' => $individual->url() . '#tab-relatives'])) ?>">
-                            <?= I18N::translate('Re-order children') ?>
-                        </a>
-                    <?php endif; ?>
-                </td>
-            </tr>
-        <?php endif ?>
-    </tbody>
-</table>
+                <?php endif; ?>
+            </div>
+        </div>
+    <?php endif ?>

--- a/resources/views/modules/relatives/family.phtml
+++ b/resources/views/modules/relatives/family.phtml
@@ -125,7 +125,7 @@ if (!$found && $family->canEdit()) { ?>
     ?>
 
     <div class="row mt-1 <?= $row_class ?>">
-        <div class="col-sm-2 ps-0 px-1">
+        <div class="col-sm-2 ps-0 pe-1">
             <div class="wt-fact-controls h-100 pt-1">
                 <span class="visually-hidden"><?= $fact->label() ?></span>
             </div>
@@ -183,7 +183,7 @@ if (!$found && $family->canEdit()) { ?>
         ?>
 
         <div class="row mt-1">
-            <div class="col-sm-2 ps-0 px-1">
+            <div class="col-sm-2 ps-0 pe-1">
                 <div class="wt-fact-controls h-100 pt-1">
                     <?php if ($prev->isOK() && $next->isOK()) : ?>
                         <div class="wt-date-difference collapse small">
@@ -218,7 +218,7 @@ if (!$found && $family->canEdit()) { ?>
 
     <?php if ($family->canEdit()) : ?>
         <div class="row mt-1">
-            <div class="col-sm-2 ps-0 px-1">
+            <div class="col-sm-2 ps-0 pe-1">
                 <div class="wt-fact-controls h-100 pt-1">
                     <span class="visually-hidden"><?= I18N::translate('Children') ?></span>
                 </div>

--- a/resources/views/modules/relatives/family.phtml
+++ b/resources/views/modules/relatives/family.phtml
@@ -45,8 +45,8 @@ foreach ($family->facts(['HUSB'], false, $fam_access_level) as $fact) {
 ?>
         <div class="row mt-1 <?= $row_class ?>">
             <div class="col-sm-2 pe-1 ps-0">
-                <div class="wt-fact-controls h-100">
-                    <?= $individual === $person ? '<i class="icon-selected"></i>' : '' ?>
+                <div class="wt-fact-controls h-100 pt-1">
+                    <?= $individual === $person ? '<i class="icon-selected"> </i>' : '' ?>
                     <?= Registry::container()->get(RelationshipService::class)->getCloseRelationshipName($individual, $person) ?>
                 </div>
             </div>
@@ -85,8 +85,8 @@ foreach ($family->facts(['WIFE'], false, $fam_access_level) as $fact) {
 
         <div class="row mt-1 <?= $row_class ?>">
             <div class="col-sm-2 pe-1 ps-0">
-                <div class="wt-fact-controls h-100">
-                <?= $individual === $person ? '<i class="icon-selected"></i>' : '' ?>
+                <div class="wt-fact-controls h-100 pt-1">
+                <?= $individual === $person ? '<i class="icon-selected"> </i>' : '' ?>
                 <?= Registry::container()->get(RelationshipService::class)->getCloseRelationshipName($individual, $person) ?>
                 </div>
             </div>
@@ -201,7 +201,7 @@ if (!$found && $family->canEdit()) { ?>
                         </div>
                     <?php endif ?>
                     <?php if ($individual === $person) : ?>
-                        <i class="icon-selected"></i>
+                        <i class="icon-selected"> </i>
                     <?php endif ?>
                     <?= Registry::container()->get(RelationshipService::class)->getCloseRelationshipName($individual, $person) ?>
                 </div>

--- a/resources/views/modules/relatives/tab.phtml
+++ b/resources/views/modules/relatives/tab.phtml
@@ -27,19 +27,22 @@ use Illuminate\Support\Collection;
 <?php
 ?>
 
-<div class="wt-tab-relatives py-4">
-    <table class="table table-sm wt-facts-table" role="presentation">
-    <tbody>
-        <tr>
-            <td>
-                <label>
-                    <input id="show-date-differences" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-date-difference" data-wt-persist="date-differences" autocomplete="off">
-                    <?= I18N::translate('Date differences') ?>
-                </label>
-            </td>
-        </tr>
-    </tbody>
-</table>
+<div class="container py-1">
+
+    <div class="row wt-fact-content py-1 mb-2">
+        <div class="col-sm-auto">
+            <input id="show-date-differences" type="checkbox" class="form-check-input"
+                data-bs-toggle="collapse"
+                data-bs-target=".wt-date-difference"
+                data-wt-persist="date-differences"
+                autocomplete="off"
+            >
+            <label class="form-check-label" for="show-date-differences">
+                <?= I18N::translate('Date differences') ?>
+            </label>
+        </div>
+    </div>
+
 
 <!-- Parents -->
 <?php foreach ($parent_families as $family) : ?>
@@ -86,47 +89,44 @@ use Illuminate\Support\Collection;
 <?php endforeach ?>
 
 <?php if ($can_edit) : ?>
-    <br>
-    <table class="table table-sm wt-facts-table" role="presentation">
-        <tbody>
             <?php if ($spouse_families->count() > 1) : ?>
-                <tr>
-                    <td>
+                <div class="row mt-2">
+                    <div class="col-sm-12 wt-fact-content py-1">
                         <a href="<?= e(route(ReorderFamiliesPage::class, ['tree' => $individual->tree()->name(), 'xref' => $individual->xref()])) ?>">
                             <?= view('icons/reorder') ?>
                             <?= I18N::translate('Re-order families') ?>
                         </a>
-                    </td>
-                </tr>
+                    </div>
+                </div>
             <?php endif ?>
 
             <?php if ($parent_families->isEmpty()) : ?>
-                <tr>
-                    <td>
+                <div class="row mt-1">
+                    <div class="col-sm-12 wt-fact-content py-1">
                         <a href="<?= e(route(AddParentToIndividualPage::class, ['tree' => $individual->tree()->name(), 'xref' => $individual->xref(), 'sex' => 'M', 'url' => $individual->url() . '#tab-relatives'])) ?>">
                             <?= I18N::translate('Add a father') ?>
                         </a>
-                    </td>
-                </tr>
-                <tr>
-                    <td>
+                    </div>
+                </div>
+                <div class="row mt-1">
+                    <div class="col-sm-12 wt-fact-content py-1">
                         <a href="<?= e(route(AddParentToIndividualPage::class, ['tree' => $individual->tree()->name(), 'xref' => $individual->xref(), 'sex' => 'F', 'url' => $individual->url() . '#tab-relatives'])) ?>">
                             <?= I18N::translate('Add a mother') ?>
                         </a>
-                    </td>
-                </tr>
+                    </div>
+                </div>
             <?php endif ?>
 
-            <tr>
-                <td>
+            <div class="row mt-1">
+                    <div class="col-sm-12 wt-fact-content py-1">
                     <a href="<?= e(route(LinkChildToFamilyPage::class, ['tree' => $individual->tree()->name(), 'xref' => $individual->xref()])) ?>">
                         <?= I18N::translate('Link this individual to an existing family as a child') ?>
                     </a>
-                </td>
-            </tr>
+                    </div>
+                </div>
 
-            <tr>
-                <td>
+            <div class="row mt-1">
+                    <div class="col-sm-12 wt-fact-content py-1">
                     <a href="<?= e(route(AddSpouseToIndividualPage::class, ['tree' => $individual->tree()->name(), 'xref' => $individual->xref(), 'url' => $individual->url() . '#tab-relatives'])) ?>">
                         <?php if ($individual->sex() !== 'F') : ?>
                             <?= I18N::translate('Add a wife') ?>
@@ -134,11 +134,11 @@ use Illuminate\Support\Collection;
                             <?= I18N::translate('Add a husband') ?>
                         <?php endif ?>
                     </a>
-                </td>
-            </tr>
+                    </div>
+                </div>
 
-            <tr>
-                <td>
+                <div class="row mt-1">
+                    <div class="col-sm-12 wt-fact-content py-1">
                     <a href="<?= e(route(LinkSpouseToIndividualPage::class, ['tree' => $individual->tree()->name(), 'xref' => $individual->xref()])) ?>">
                         <?php if ($individual->sex() !== 'F') : ?>
                             <?= I18N::translate('Add a wife using an existing individual') ?>
@@ -146,17 +146,16 @@ use Illuminate\Support\Collection;
                             <?= I18N::translate('Add a husband using an existing individual') ?>
                         <?php endif ?>
                     </a>
-                </td>
-            </tr>
+                    </div>
+                </div>
 
-            <tr>
-                <td>
+            <div class="row mt-1">
+                    <div class="col-sm-12 wt-fact-content py-1">
                     <a href="<?= e(route(AddChildToIndividualPage::class, ['tree' => $individual->tree()->name(), 'xref' => $individual->xref(), 'sex' => 'U'])) ?>">
                         <?= I18N::translate('Add a child to create a one-parent family') ?>
                     </a>
-                </td>
-            </tr>
-        </tbody>
-    </table>
+                    </div>
+                </div>
+
 <?php endif ?>
 </div>

--- a/resources/views/modules/relatives/tab.phtml
+++ b/resources/views/modules/relatives/tab.phtml
@@ -36,6 +36,12 @@ use Illuminate\Support\Collection;
                 data-bs-target=".wt-date-difference"
                 data-wt-persist="date-differences"
                 autocomplete="off"
+                <?= $parent_families ->isEmpty() &&
+                    $spouse_families->isEmpty() &&
+                    $step_child_families->isEmpty() &&
+                    $step_parent_families->isEmpty() ?
+                    'disabled="disabled"' : ''
+                ?>
             >
             <label class="form-check-label" for="show-date-differences">
                 <?= I18N::translate('Date differences') ?>

--- a/resources/views/modules/sources_tab/tab.phtml
+++ b/resources/views/modules/sources_tab/tab.phtml
@@ -49,7 +49,7 @@ use Illuminate\Support\Collection;
             ?>
 
         <div class="row mt-1 wt-level-two-source collapse">
-            <div class="col-sm-2 ps-0 px-1 rela <?= $styleadd ?>">
+            <div class="col-sm-2 ps-0 pe-1 <?= $styleadd ?>">
                 <div class="wt-fact-controls h-100 pt-1">
                     <?= $fact->label() ?>
                     <?= view('fact-edit-links', ['fact' => $fact, 'url' => $fact->record()->url() . '#tab-sources']) ?>
@@ -76,7 +76,7 @@ use Illuminate\Support\Collection;
 
 <?php if ($can_edit) : ?>
     <div class="row mt-1">
-        <div class="col-2 ps-0 px-1">
+        <div class="col-2 ps-0 pe-1">
             <div class="wt-fact-controls h-100 pt-1">
                 <?= I18N::translate('Source') ?>
             </div>

--- a/resources/views/modules/sources_tab/tab.phtml
+++ b/resources/views/modules/sources_tab/tab.phtml
@@ -17,67 +17,76 @@ use Illuminate\Support\Collection;
 
 ?>
 
-<div class="wt-tab-sources py-4">
-    <table class="table wt-facts-table">
-        <tr>
-            <td colspan="2">
-                <label>
-                    <input id="show-level-2-sources" type="checkbox" data-bs-toggle="collapse" data-bs-target=".wt-level-two-source" data-wt-persist="level-two-sources" autocomplete="off">
-                    <?= I18N::translate('Show all sources') ?>
-                </label>
-            </td>
-        </tr>
+<div class="container py-4 wt-facts-table">
 
-        <?php foreach ($facts as $fact) : ?>
-            <?php if (str_ends_with($fact->tag(), ':SOUR')) : ?>
-                <?= view('fact', ['fact' => $fact, 'record' => $individual]) ?>
-            <?php else : ?>
-                <?php
-                if ($fact->isPendingAddition()) {
-                    $styleadd = 'wt-new ';
-                } elseif ($fact->isPendingDeletion()) {
-                    $styleadd = 'wt-old ';
-                } else {
-                    $styleadd = '';
-                }
-                ?>
+    <div class="row wt-fact-content py-1">
+        <div class="col-sm-auto">
+            <input id="show-level-2-sources" class="form-check-input" type="checkbox"
+                data-bs-toggle="collapse"
+                data-bs-target=".wt-level-two-source"
+                data-wt-persist="level-two-sources"
+                autocomplete="off"
+                <?= $facts->isEmpty() ? 'disabled="disabled"' : '' ?>
+            >
+            <label class="form-check-label" for="show-level-2-notes">
+                <?= I18N::translate('Show all sources') ?>
+            </label>
+        </div>
+    </div>
 
-                <tr class="wt-level-two-source collapse">
-                    <th scope="row" class="rela <?= $styleadd ?>">
-                        <?= $fact->label() ?>
-                        <?= view('fact-edit-links', ['fact' => $fact, 'url' => $fact->record()->url() . '#tab-sources']) ?>
-                    </th>
+    <?php foreach ($facts as $fact) : ?>
+        <?php if (str_ends_with($fact->tag(), ':SOUR')) : ?>
+            <?= view('fact', ['fact' => $fact, 'record' => $individual]) ?>
+        <?php else : ?>
+            <?php
+            if ($fact->isPendingAddition()) {
+                $styleadd = 'wt-new ';
+            } elseif ($fact->isPendingDeletion()) {
+                $styleadd = 'wt-old ';
+            } else {
+                $styleadd = '';
+            }
+            ?>
 
-                    <td class="<?= $styleadd ?>">
-                        <?php if (preg_match_all('/\n(2 SOUR\b.*(?:\n[^2].*)*)/', $fact->gedcom(), $matches, PREG_SET_ORDER) > 0) : ?>
-                            <?php foreach ($matches as $match) : ?>
-                                <?= view('fact-gedcom-fields', ['gedcom' => $match[1], 'parent' => $fact->tag(), 'tree' => $fact->record()->tree()]) ?>
-                            <?php endforeach ?>
-                        <?php endif ?>
-                    </td>
-                </tr>
-            <?php endif ?>
-        <?php endforeach ?>
-
-        <?php if ($facts->isEmpty()) : ?>
-            <tr>
-                <td colspan="2">
-                    <?= I18N::translate('There are no source citations for this individual.') ?>
-                </td>
-            </tr>
+        <div class="row mt-1 wt-level-two-source collapse">
+            <div class="col-sm-2 ps-0 px-1 rela <?= $styleadd ?>">
+                <div class="wt-fact-controls h-100 pt-1">
+                    <?= $fact->label() ?>
+                    <?= view('fact-edit-links', ['fact' => $fact, 'url' => $fact->record()->url() . '#tab-sources']) ?>
+                </div>
+            </div>
+            <div class="col-sm-10 wt-fact-content pt-1 <?= $styleadd ?>">
+                <?php if (preg_match_all('/\n(2 SOUR\b.*(?:\n[^2].*)*)/', $fact->gedcom(), $matches, PREG_SET_ORDER) > 0) : ?>
+                    <?php foreach ($matches as $match) : ?>
+                        <?= view('fact-gedcom-fields', ['gedcom' => $match[1], 'parent' => $fact->tag(), 'tree' => $fact->record()->tree()]) ?>
+                    <?php endforeach ?>
+                <?php endif ?>
+            </div>
+        </div>
         <?php endif ?>
+    <?php endforeach ?>
 
-        <?php if ($can_edit) : ?>
-            <tr>
-                <th scope="row">
-                    <?= I18N::translate('Source') ?>
-                </th>
-                <td>
-                    <a href="<?= e(route(AddNewFact::class, ['tree' => $individual->tree()->name(), 'xref' => $individual->xref(), 'fact' => 'SOUR'])) ?>">
-                        <?= I18N::translate('Add a source citation') ?>
-                    </a>
-                </td>
-            </tr>
-        <?php endif ?>
-    </table>
+    <?php if ($facts->isEmpty()) : ?>
+    <div class="row wt-fact-content my-3">
+        <div class="col-sm-auto py-2">
+            <?= I18N::translate('There are no source citations for this individual.') ?>
+        </div>
+    </div>
+<?php endif ?>
+
+<?php if ($can_edit) : ?>
+    <div class="row mt-1">
+        <div class="col-2 ps-0 px-1">
+            <div class="wt-fact-controls h-100 pt-1">
+                <?= I18N::translate('Source') ?>
+            </div>
+        </div>
+        <div class="col-10 wt-fact-content p-1">
+            <a href="<?= e(route(AddNewFact::class, ['tree' => $individual->tree()->name(), 'xref' => $individual->xref(), 'fact' => 'SOUR'])) ?>">
+                <?= I18N::translate('Add a source citation') ?>
+            </a>
+        </div>
+    </div>
+<?php endif ?>
+
 </div>


### PR DESCRIPTION
Replaced the containing table with a bootstrap grid. This fixes all the problems with content overflowing the right margin and even looks reasonable when the browser width is reduced such that the columns fold.

Requires two new webtrees classes for theming, everthing else is pure bootstrap.