### PR TITLE
Add support for MySQL/MariaDB UNIX socket connection

### DIFF
--- a/app/Http/Middleware/UseDatabase.php
+++ b/app/Http/Middleware/UseDatabase.php
@@ -94,6 +94,7 @@ class UseDatabase implements MiddlewareInterface
             // For MySQL
             'charset'                 => $charset,
             'collation'               => $collation,
+            'unix_socket'             => Validator::attributes($request)->string('dbsocket'),
             'timezone'                => '+00:00',
             'engine'                  => 'InnoDB',
             'modes'                   => [

--- a/app/Http/RequestHandlers/SetupWizard.php
+++ b/app/Http/RequestHandlers/SetupWizard.php
@@ -65,19 +65,20 @@ class SetupWizard implements RequestHandlerInterface
     private const DEFAULT_DBTYPE = 'mysql';
     private const DEFAULT_PREFIX = 'wt_';
     private const DEFAULT_DATA   = [
-        'baseurl' => '',
-        'lang'    => '',
-        'dbtype'  => self::DEFAULT_DBTYPE,
-        'dbhost'  => '',
-        'dbport'  => '',
-        'dbuser'  => '',
-        'dbpass'  => '',
-        'dbname'  => '',
-        'tblpfx'  => self::DEFAULT_PREFIX,
-        'wtname'  => '',
-        'wtuser'  => '',
-        'wtpass'  => '',
-        'wtemail' => '',
+        'baseurl'  => '',
+        'lang'     => '',
+        'dbtype'   => self::DEFAULT_DBTYPE,
+        'dbhost'   => '',
+        'dbport'   => '',
+        'dbuser'   => '',
+        'dbpass'   => '',
+        'dbname'   => '',
+        'dbsocket' => '',
+        'tblpfx'   => self::DEFAULT_PREFIX,
+        'wtname'   => '',
+        'wtuser'   => '',
+        'wtpass'   => '',
+        'wtemail'  => '',
     ];
 
     private const DEFAULT_PORTS = [
@@ -451,6 +452,7 @@ class SetupWizard implements RequestHandlerInterface
                     'database'                => '',
                     'username'                => $data['dbuser'],
                     'password'                => $data['dbpass'],
+                    'unix_socket'             => $data['dbsocket'],
                 ], 'temp');
                 $capsule->getConnection('temp')->statement('CREATE DATABASE IF NOT EXISTS `' . $data['dbname'] . '` COLLATE utf8_unicode_ci');
                 break;
@@ -469,6 +471,7 @@ class SetupWizard implements RequestHandlerInterface
             // For MySQL
             'charset'                 => 'utf8',
             'collation'               => 'utf8_unicode_ci',
+            'unix_socket'             => $data['dbsocket'],
             'timezone'                => '+00:00',
             'engine'                  => 'InnoDB',
             'modes'                   => [

--- a/resources/views/setup/config.ini.phtml
+++ b/resources/views/setup/config.ini.phtml
@@ -10,6 +10,7 @@ declare(strict_types=1);
  * @var string $dbpass
  * @var string $dbport
  * @var string $dbtype
+ * @var string $dbsocket
  * @var string $tblpfx
  */
 
@@ -21,6 +22,7 @@ dbport="<?= addcslashes($dbport, '"') ?>"
 dbuser="<?= addcslashes($dbuser, '"') ?>"
 dbpass="<?= addcslashes($dbpass, '"') ?>"
 dbname="<?= addcslashes($dbname, '"') ?>"
+dbsocket="<?= addcslashes($dbsocket, '"') ?>"
 tblpfx="<?= addcslashes($tblpfx, '"') ?>"
 base_url="<?= addcslashes($baseurl, '"') ?>"
 rewrite_urls="0"

--- a/resources/views/setup/step-1-language.phtml
+++ b/resources/views/setup/step-1-language.phtml
@@ -13,6 +13,7 @@ use Illuminate\Support\Collection;
  * @var string                          $dbport
  * @var string                          $dbtype
  * @var string                          $dbuser
+ * @var string                          $dbsocket
  * @var Collection<int,string>          $errors
  * @var string                          $lang
  * @var Collection<int,LocaleInterface> $locales
@@ -33,6 +34,7 @@ use Illuminate\Support\Collection;
     <input name="dbuser" type="hidden" value="<?= e($dbuser) ?>">
     <input name="dbpass" type="hidden" value="<?= e($dbpass) ?>">
     <input name="dbname" type="hidden" value="<?= e($dbname) ?>">
+    <input name="dbsocket" type="hidden" value="<?= e($dbsocket) ?>">
     <input name="tblpfx" type="hidden" value="<?= e($tblpfx) ?>">
     <input name="wtname" type="hidden" value="<?= e($wtname) ?>">
     <input name="wtuser" type="hidden" value="<?= e($wtuser) ?>">

--- a/resources/views/setup/step-2-server-checks.phtml
+++ b/resources/views/setup/step-2-server-checks.phtml
@@ -13,6 +13,7 @@ use Illuminate\Support\Collection;
  * @var string                 $dbport
  * @var string                 $dbtype
  * @var string                 $dbuser
+ * @var string                 $dbsocket
  * @var Collection<int,string> $errors
  * @var string                 $lang
  * @var int                    $memory_limit
@@ -34,6 +35,7 @@ use Illuminate\Support\Collection;
     <input name="dbuser" type="hidden" value="<?= e($dbuser) ?>">
     <input name="dbpass" type="hidden" value="<?= e($dbpass) ?>">
     <input name="dbname" type="hidden" value="<?= e($dbname) ?>">
+    <input name="dbsocket" type="hidden" value="<?= e($dbsocket) ?>">
     <input name="tblpfx" type="hidden" value="<?= e($tblpfx) ?>">
     <input name="wtname" type="hidden" value="<?= e($wtname) ?>">
     <input name="wtuser" type="hidden" value="<?= e($wtuser) ?>">

--- a/resources/views/setup/step-3-database-type.phtml
+++ b/resources/views/setup/step-3-database-type.phtml
@@ -12,6 +12,7 @@ use Illuminate\Support\Collection;
  * @var string                 $dbport
  * @var string                 $dbtype
  * @var string                 $dbuser
+ * @var string                 $dbsocket
  * @var Collection<int,string> $errors
  * @var string                 $lang
  * @var string                 $tblpfx

--- a/resources/views/setup/step-4-database-mysql.phtml
+++ b/resources/views/setup/step-4-database-mysql.phtml
@@ -12,6 +12,7 @@ use Illuminate\Support\Collection;
  * @var string                 $dbport
  * @var string                 $dbtype
  * @var string                 $dbuser
+ * @var string                 $dbsocket
  * @var Collection<int,string> $errors
  * @var string                 $lang
  * @var string                 $tblpfx
@@ -55,12 +56,6 @@ use Illuminate\Support\Collection;
             <div class="form-text">
                 <?= I18N::translate('Most sites are configured to use localhost. This means that your database runs on the same computer as your web server.') ?>
             </div>
-
-            <!--
-            <div class="form-text">
-                <?= I18N::translate('If you connect to the database using a UNIX socket, enter the path here and leave the port number empty.') ?>
-            </div>
-            -->
         </div>
     </div>
 
@@ -74,6 +69,20 @@ use Illuminate\Support\Collection;
 
             <div class="form-text">
                 <?= I18N::translate('Most sites are configured to use the default value of 3306.') ?>
+            </div>
+        </div>
+    </div>
+
+    <div class="row mb-3">
+        <label class="col-form-label col-sm-3" for="dbsocket">
+            <?= I18N::translate('UNIX Socket path') ?>
+        </label>
+
+        <div class="col-sm-9">
+            <input class="form-control" id="dbsocket" name="dbsocket" type="text" value="<?= e($dbsocket) ?>" dir="ltr">
+
+            <div class="form-text">
+                <?= I18N::translate('If you connect to the database using a UNIX socket, enter the path here.') ?>
             </div>
         </div>
     </div>

--- a/resources/views/setup/step-5-administrator.phtml
+++ b/resources/views/setup/step-5-administrator.phtml
@@ -12,6 +12,7 @@ use Illuminate\Support\Collection;
  * @var string                 $dbport
  * @var string                 $dbtype
  * @var string                 $dbuser
+ * @var string                 $dbsocket
  * @var Collection<int,string> $errors
  * @var string                 $lang
  * @var string                 $tblpfx
@@ -32,6 +33,7 @@ use Illuminate\Support\Collection;
     <input name="dbuser" type="hidden" value="<?= e($dbuser) ?>">
     <input name="dbpass" type="hidden" value="<?= e($dbpass) ?>">
     <input name="dbname" type="hidden" value="<?= e($dbname) ?>">
+    <input name="dbsocket" type="hidden" value="<?= e($dbsocket) ?>">
     <input name="tblpfx" type="hidden" value="<?= e($tblpfx) ?>">
     <input name="baseurl" type="hidden" value="">
 


### PR DESCRIPTION
This changes enable the configuration of UNIX socket connections for MySQL/MariaDB.
It adds an additional configuration field for the socket path.

The change has been tested locally and on a running Webtrees instance using Webtrees 2.1.17.