### PR TITLE
Update checkbox.phtml

### DIFF
--- a/resources/views/components/checkbox.phtml
+++ b/resources/views/components/checkbox.phtml
@@ -9,11 +9,13 @@ declare(strict_types=1);
  * @var string      $label
  * @var string      $name
  * @var string|null $value
+ * @var string      $unchecked
  */
 
 ?>
 
 <div class="form-check">
+    <input type="hidden" value="<?= e($unchecked) ?>" name="<?= e($name) ?>">
     <input type="checkbox" class="form-check-input"
         name="<?= e($name) ?>"
         id="<?= e($id ?? $name . '-' . ($value ?? '1')) ?>"


### PR DESCRIPTION
Currently the Checkbox component cannot be properly used to save empty (unchecked status) settings. A hidden element is missing here, which is assigned the unchecked value.