### PR TITLE
Timestamp class needed local input and UTC output modes.

### DIFF
--- a/app/Contracts/TimestampFactoryInterface.php
+++ b/app/Contracts/TimestampFactoryInterface.php
@@ -33,6 +33,8 @@ interface TimestampFactoryInterface
     public function make(int $timestamp, UserInterface $user = null): TimestampInterface;
 
     /**
+     * Constructs a Timestamp using UTC input only.
+     *
      * @param string|null        $string YYYY-MM-DD HH:MM:SS (as provided by SQL).
      * @param string             $format
      * @param UserInterface|null $user
@@ -40,6 +42,29 @@ interface TimestampFactoryInterface
      * @return TimestampInterface
      */
     public function fromString(?string $string, string $format = 'Y-m-d H:i:s', UserInterface $user = null): TimestampInterface;
+
+    /**
+     * Constructs a Timestamp using local datetime input according to user's timezone setting.
+     *
+     * @param string             $string YYYY-MM-DD HH:MM:SS (as provided by SQL).
+     * @param string             $format
+     * @param UserInterface|null $user
+     *
+     * @return TimestampInterface
+     */
+    public function fromLocalString(string $string, string $format = 'Y-m-d H:i:s', UserInterface $user = null): TimestampInterface;
+
+    /**
+     * Constructs a Timestamp using local datetime input according to the specified timezone.
+     *
+     * @param DateTimeZone       $timezone
+     * @param string             $string YYYY-MM-DD HH:MM:SS (as provided by SQL).
+     * @param string             $format
+     * @param UserInterface|null $user
+     *
+     * @return TimestampInterface
+     */
+    public function fromZoneString(DateTimeZone $timezone, string $string, string $format, UserInterface $user = null): TimestampInterface;
 
     /**
      * @param UserInterface|null $user

--- a/app/Contracts/TimestampFactoryInterface.php
+++ b/app/Contracts/TimestampFactoryInterface.php
@@ -19,6 +19,8 @@ declare(strict_types=1);
 
 namespace Fisharebest\Webtrees\Contracts;
 
+use DateTimeZone;
+
 /**
  * Create a timestamp object.
  */

--- a/app/Contracts/TimestampInterface.php
+++ b/app/Contracts/TimestampInterface.php
@@ -61,6 +61,13 @@ interface TimestampInterface
     public function toDateTimeString(): string;
 
     /**
+     * Use UTC instead of the saved timezone.
+     *
+     * @return string
+     */
+    public function toUTCDateTimeString(): string;
+
+    /**
      * @param TimestampInterface $datetime
      *
      * @return int

--- a/app/Services/PendingChangesService.php
+++ b/app/Services/PendingChangesService.php
@@ -289,12 +289,12 @@ class PendingChangesService
             ->where('gedcom_name', '=', $tree);
 
         if ($from !== '') {
-            $query->where('change_time', '>=', Registry::timestampFactory()->fromString($from, 'Y-m-d')->toDateString());
+            $query->where('change_time', '>=', Registry::timestampFactory()->fromLocalString("$from 00:00:00")->toUTCDateTimeString());
         }
 
         if ($to !== '') {
             // before end of the day
-            $query->where('change_time', '<', Registry::timestampFactory()->fromString($to, 'Y-m-d')->addDays(1)->toDateString());
+            $query->where('change_time', '<', Registry::timestampFactory()->fromLocalString("$to 00:00:00")->addDays(1)->toUTCDateTimeString());
         }
 
         if ($type !== '') {

--- a/app/Services/SiteLogsService.php
+++ b/app/Services/SiteLogsService.php
@@ -56,12 +56,12 @@ class SiteLogsService
             ->select(['log.*', new Expression("COALESCE(user_name, '<none>') AS user_name"), new Expression("COALESCE(gedcom_name, '<none>') AS gedcom_name")]);
 
         if ($from !== '') {
-            $query->where('log_time', '>=', Registry::timestampFactory()->fromString($from, 'Y-m-d')->toDateString());
+            $query->where('log_time', '>=', Registry::timestampFactory()->fromLocalString("$from 00:00:00")->toUTCDateTimeString());
         }
 
         if ($to !== '') {
             // before end of the day
-            $query->where('log_time', '<', Registry::timestampFactory()->fromString($to, 'Y-m-d')->addDays(1)->toDateString());
+            $query->where('log_time', '<', Registry::timestampFactory()->fromLocalString("$to 00:00:00")->addDays(1)->toUTCDateTimeString());
         }
 
         if ($type !== '') {

--- a/app/Timestamp.php
+++ b/app/Timestamp.php
@@ -100,6 +100,16 @@ class Timestamp implements TimestampInterface
     }
 
     /**
+     * Use UTC instead of the saved timezone.
+     *
+     * @return string
+     */
+    public function toUTCDateTimeString(): string
+    {
+        return Carbon::createFromTimestampUTC($this->carbon->getTimestamp())->format('Y-m-d H:i:s');
+    }
+
+    /**
      * @param TimestampInterface $datetime
      *
      * @return int


### PR DESCRIPTION
Fixes #4549 

Clarifies the existing fromString() factory is only appropriate for UTC input.

Provides the fromLocalString() factory for user input, such as log filters.

Provides fromZoneString() factory for de-duplication and abstraction of the other two factories.

Provides Timestamp::toUTCDateTimeString() for SQL output, so timestamps won't be converted to local time and compared to stored UTC values.

Updates the PendingChangesService and SiteLogsService to use the correct times and timezones.