### PR TITLE
Fix error when non-admins save tree preferences

### DIFF
--- a/resources/views/admin/trees-preferences.phtml
+++ b/resources/views/admin/trees-preferences.phtml
@@ -87,6 +87,8 @@ use Illuminate\Support\Collection;
                 </div>
             </div>
         </div>
+    <?php else : ?>
+        <input type="hidden" name="gedcom" value="<?= e($tree->name()) ?>">
     <?php endif ?>
 
     <!-- PEDIGREE_ROOT_ID -->


### PR DESCRIPTION
Managers can edit most of the tree preferences but the "gedcom" parameter isn't submitted unless the user is an admin resulting in the error message:
```
The parameter “gedcom” is missing.
```
Add a hidden field with the missing "gedcom" parameter.