### PR TITLE
Fixes: #4948 - Update ckeditor-js.phtml extraAllowedContent

### DIFF
--- a/resources/views/modules/ckeditor/ckeditor-js.phtml
+++ b/resources/views/modules/ckeditor/ckeditor-js.phtml
@@ -25,7 +25,7 @@ declare(strict_types=1);
         // Disable toolbars
         CKEDITOR.config.language = <?= json_encode(strtolower($language), JSON_THROW_ON_ERROR) ?>;
         CKEDITOR.config.removePlugins = 'forms,newpage,preview,print,save,templates,flash,iframe';
-        CKEDITOR.config.extraAllowedContent = 'area[shape,coords,href,target,alt,title];map[name];img[usemap];*[class,style]';
+        CKEDITOR.config.extraAllowedContent = 'area[shape,coords,href,target,alt,title];map[name];img[usemap];*[class,style];*(*);';
 
         // Do not convert é to &eacute; in the editor
         CKEDITOR.config.entities = false;

--- a/resources/views/modules/ckeditor/ckeditor-js.phtml
+++ b/resources/views/modules/ckeditor/ckeditor-js.phtml
@@ -25,7 +25,7 @@ declare(strict_types=1);
         // Disable toolbars
         CKEDITOR.config.language = <?= json_encode(strtolower($language), JSON_THROW_ON_ERROR) ?>;
         CKEDITOR.config.removePlugins = 'forms,newpage,preview,print,save,templates,flash,iframe';
-        CKEDITOR.config.extraAllowedContent = 'area[shape,coords,href,target,alt,title];map[name];img[usemap];*[class,style];*(*);';
+        CKEDITOR.config.extraAllowedContent = 'area[shape,coords,href,target,alt,title];map[name];img[usemap];*{*}(*)';
 
         // Do not convert é to &eacute; in the editor
         CKEDITOR.config.entities = false;


### PR DESCRIPTION
Allow CKEditor to accept all element classes.
The current webtrees `ckeditor-js.phtml CKEDITOR.config.extraAllowedContent ='*[class,style];' `appears intended to do this but is not working consistently. See issue #4948 CKEditor strips some bootstrap and other classes. 
This also facilitates using classes added in the CSS and JS  module.