### PR TITLE
Fix Disallow syntax in robots.txt

### DIFF
--- a/resources/views/robots-txt.phtml
+++ b/resources/views/robots-txt.phtml
@@ -29,19 +29,19 @@ Disallow: <?= $base_path ?>/manager
 Disallow: <?= $base_path ?>/editor
 Disallow: <?= $base_path ?>/account
 <?php foreach ($trees as $tree) : ?>
-Disallow <?= $base_path ?>/tree/<?= $tree ?>/ancestors
-Disallow <?= $base_path ?>/tree/<?= $tree ?>/calendar
-Disallow <?= $base_path ?>/tree/<?= $tree ?>/compact
-Disallow <?= $base_path ?>/tree/<?= $tree ?>/descendants
-Disallow <?= $base_path ?>/tree/<?= $tree ?>/family-book
-Disallow <?= $base_path ?>/tree/<?= $tree ?>/family-list
-Disallow <?= $base_path ?>/tree/<?= $tree ?>/fan-chart
-Disallow <?= $base_path ?>/tree/<?= $tree ?>/hourglass
-Disallow <?= $base_path ?>/tree/<?= $tree ?>/individual-list
-Disallow <?= $base_path ?>/tree/<?= $tree ?>/lifespans
-Disallow <?= $base_path ?>/tree/<?= $tree ?>/pedigree
-Disallow <?= $base_path ?>/tree/<?= $tree ?>/report
-Disallow <?= $base_path ?>/tree/<?= $tree ?>/timeline
+Disallow: <?= $base_path ?>/tree/<?= $tree ?>/ancestors
+Disallow: <?= $base_path ?>/tree/<?= $tree ?>/calendar
+Disallow: <?= $base_path ?>/tree/<?= $tree ?>/compact
+Disallow: <?= $base_path ?>/tree/<?= $tree ?>/descendants
+Disallow: <?= $base_path ?>/tree/<?= $tree ?>/family-book
+Disallow: <?= $base_path ?>/tree/<?= $tree ?>/family-list
+Disallow: <?= $base_path ?>/tree/<?= $tree ?>/fan-chart
+Disallow: <?= $base_path ?>/tree/<?= $tree ?>/hourglass
+Disallow: <?= $base_path ?>/tree/<?= $tree ?>/individual-list
+Disallow: <?= $base_path ?>/tree/<?= $tree ?>/lifespans
+Disallow: <?= $base_path ?>/tree/<?= $tree ?>/pedigree
+Disallow: <?= $base_path ?>/tree/<?= $tree ?>/report
+Disallow: <?= $base_path ?>/tree/<?= $tree ?>/timeline
 <?php endforeach ?>
 Crawl-delay: 10
 


### PR DESCRIPTION
There should be a colon after `Disallow` directives in  the Robots.txt.
Google accepts it without, but raises a warning in the Search Console.