### PR TITLE
Update PendingChangesService.php - typo

### DIFF
--- a/app/Services/PendingChangesService.php
+++ b/app/Services/PendingChangesService.php
@@ -307,7 +307,7 @@ class PendingChangesService
 
         if ($to !== '') {
             // before end of the day
-            $to_time = DateTimeImmutable::createFromFormat('!Y-m-d', $from, $tz)
+            $to_time = DateTimeImmutable::createFromFormat('!Y-m-d', $to, $tz)
                 ->add(new DateInterval('P1D'))
                 ->setTimezone($utc)
                 ->format('Y-m-d H:i:s');


### PR DESCRIPTION
To date is incorrect (from+1) instead of $to

possible fix for issue #4976 

In that request I thought there was something special about the last listed tree, but it was just fortuitous that my last tree had changes within one day of the start date