### PR TITLE
Add wrapping behaviour to the fact note.

### DIFF
--- a/app/Elements/NoteStructure.php
+++ b/app/Elements/NoteStructure.php
@@ -165,7 +165,7 @@ class NoteStructure extends SubmitterText
             '</button> ' .
             I18N::translate('%1$s: %2$s', $label, $value) .
             '</div>' .
-            '<div class="ps-4 collapse ' . ($expanded ? 'show' : '') . ' ' . e($id) . '">' .
+            '<div class="ut ps-4 collapse ' . ($expanded ? 'show' : '') . ' ' . e($id) . '">' .
             $html .
             '</div>';
     }

--- a/resources/css/webtrees.css
+++ b/resources/css/webtrees.css
@@ -655,10 +655,6 @@ div.fact_SHARED_NOTE {
     border: 1px solid #81a9cb;
 }
 
-.wt-facts-table td .wt-fact-notes p {
-    overflow-wrap: break-word;
-}
-
 .wt-facts-table .wt-sex-f > td {
     background-color: var(--sex-f-bg);
     border: solid #81a9cb thin;

--- a/resources/css/webtrees.css
+++ b/resources/css/webtrees.css
@@ -655,6 +655,10 @@ div.fact_SHARED_NOTE {
     border: 1px solid #81a9cb;
 }
 
+.wt-facts-table td .wt-fact-notes p {
+    overflow-wrap: break-word;
+}
+
 .wt-facts-table .wt-sex-f > td {
     background-color: var(--sex-f-bg);
     border: solid #81a9cb thin;


### PR DESCRIPTION
Issue: When you add long url to the fact note it overflows the container.
I resolved it by adding overflow-wrap: break-word to the .wt-facts-table td .wt-fact-notes p