### PR TITLE
fix issue #5019: forward from old branch list url

### DIFF
--- a/app/Module/BranchesListModule.php
+++ b/app/Module/BranchesListModule.php
@@ -167,7 +167,7 @@ class BranchesListModule extends AbstractModule implements ModuleListInterface, 
         return redirect($this->listUrl($tree, [
             'soundex_dm'  => Validator::queryParams($request)->boolean('soundex_dm'),
             'soundex_std' => Validator::queryParams($request)->boolean('soundex_std'),
-            'surname'     => 'x' . Validator::queryParams($request)->string('surname'),
+            'surname'     => Validator::queryParams($request)->string('surname'),
         ]));
     }
 


### PR DESCRIPTION
I've removed the part 
````
'x' .
````
which caused the issue. No idea how that creeped in.