### PR TITLE
Wrap long urls inside Fact notes and Shared notes

### DIFF
--- a/app/Elements/NoteStructure.php
+++ b/app/Elements/NoteStructure.php
@@ -138,7 +138,7 @@ class NoteStructure extends SubmitterText
                 '</button> ' .
                 '<span class="label">' . $label . ':</span> ' . $first_line .
                 '</div>' .
-                '<div id="' . e($id) . '" class="ps-4 collapse ' . ($expanded ? 'show' : '') . '">' .
+                '<div id="' . e($id) . '" class="ps-4 collapse ut' . ($expanded ? 'show' : '') . '">' .
                 $html .
                 '</div>';
         }

--- a/app/Elements/NoteStructure.php
+++ b/app/Elements/NoteStructure.php
@@ -165,7 +165,7 @@ class NoteStructure extends SubmitterText
             '</button> ' .
             I18N::translate('%1$s: %2$s', $label, $value) .
             '</div>' .
-            '<div class="ps-4 collapse ' . ($expanded ? 'show' : '') . ' ' . e($id) . '">' .
+            '<div class="ps-4 collapse ut ' . ($expanded ? 'show' : '') . ' ' . e($id) . '">' .
             $html .
             '</div>';
     }


### PR DESCRIPTION
I added "ut" class to the divs containing the Fact Note and Shared.
This change will prevent overflow of the long urls out of the note divs in exp[anded state.
![original beheviour](https://github.com/user-attachments/assets/dbde4bcb-164a-458f-99ef-9dc2ebd8f3b3)
![updated behaviour](https://github.com/user-attachments/assets/45dfb5ed-a107-4b0d-8b64-b94c5ad7074c)
