### PR TITLE
Add support for WMS maps

### DIFF
--- a/resources/js/webtrees.js
+++ b/resources/js/webtrees.js
@@ -723,6 +723,8 @@
       for (let [, child] of Object.entries(provider.children)) {
         if ('bingMapsKey' in child) {
           child.layer = L.tileLayer.bing(child);
+        } else if ('wmsOptions' in child) {
+            child.layer = L.tileLayer.wms(child.url, child.wmsOptions);
         } else {
           child.layer = L.tileLayer(child.url, child);
         }

--- a/resources/js/webtrees.js
+++ b/resources/js/webtrees.js
@@ -723,9 +723,15 @@
       for (let [, child] of Object.entries(provider.children)) {
         if ('bingMapsKey' in child) {
           child.layer = L.tileLayer.bing(child);
-        } else if ('wmsOptions' in child) {
-            child.layer = L.tileLayer.wms(child.url, child.wmsOptions);
+        } else if ('options' in child) {
+          // TileLayer options in separate variable
+          if ('layers' in child.options) {
+            child.layer = L.tileLayer.wms(child.url, child.options);
+          } else {
+            child.layer = L.tileLayer(child.url, child.options);
+          }
         } else {
+          // TileLayer options mixed with other variables, for backwards compatibility
           child.layer = L.tileLayer(child.url, child);
         }
         if (provider.default && child.default) {


### PR DESCRIPTION
Will detect that it is an WMS map by looking for `layers` in `options`.

I decided to put all tile layer options in a separate variable because of [this](https://leafletjs.com/reference.html#tilelayer-wms):
> If any custom options not documented here are used, they will be sent to the WMS server as extra parameters in each request URL.

This means that for example _url_ will be appended as parameter in the request if they are mixed with the tile layer options.

Here are samples of WMTS and WMS maps:
```
    public function leafletJsTileLayers(): array
    {
        return [
            (object) [
                'default'     => true,
                'label'       => 'WMTS map',
                'url'         => 'https://minkarta.lantmateriet.se/map/topowebbcache?layer=topowebb&tilematrixset=3857&Service=WMTS&Request=GetTile&TileMatrix={z}&TileCol={x}&TileRow={y}',
                'options'  => 
                    (object) [
                        'attribution' => '<a href="https://www.lantmateriet.se">Lantmäteriet</a>',
                        'maxZoom'     => 17,
                        'minZoom'     => 2,
                    ],
            ],
            (object) [
                'label'       => 'WMS map',
                'url'         => 'https://minkarta.lantmateriet.se/map/ortofoto',
                'options'  => 
                    (object) [
                        'attribution' => '<a href="https://www.lantmateriet.se">Lantmäteriet</a>',
                        'layers'      => 'Ortofoto_0.5,Ortofoto_0.4,Ortofoto_0.25,Ortofoto_0.16',
                        'maxZoom'     => 19,
                        'minZoom'     => 2,
                        'service'     => 'WMS',
                    ],
            ],
        ];
    }
```