### PR TITLE
Media download fix

### DIFF
--- a/app/Services/GedcomExportService.php
+++ b/app/Services/GedcomExportService.php
@@ -251,7 +251,7 @@ class GedcomExportService
                         $datum->m_gedcom ??
                         $datum->o_gedcom;
                 }
-                
+
                 if ($media_path !== null && $zip_filesystem !== null && preg_match('/0 @' . Gedcom::REGEX_XREF . '@ OBJE/', $gedcom) === 1) {
                     preg_match_all('/\n1 FILE (.+)/', $gedcom, $matches, PREG_SET_ORDER);
 


### PR DESCRIPTION
A proposal to fix download issues (gateway timeout and DB timeout) of ZIP archives including media files on shared servers with low performance and no control on DB time out values.

The fix idea is to use PHP zip extension as a primary solution to add media files to the archive, and use Flysystem streams if the extension is not available or if the zip creation throws an error.
