### PR TITLE
vscode devcontainer support via xdebug

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+FROM mcr.microsoft.com/devcontainers/php:1-8.3-bookworm
+
+# Install MariaDB client and network debug tools
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get install -y mariadb-client libpng-dev libicu-dev libzip-dev inetutils-ping netcat-openbsd tcpdump\ 
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# Install necessary PHP extensions
+RUN docker-php-ext-install mysqli pdo pdo_mysql gd intl zip
+
+# [Optional] Uncomment this section to install additional OS packages.
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/php-mariadb
+{
+	"name": "Webtrees PHP",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/opencodeco/devcontainers/install-php-extensions:latest": {},
+		"ghcr.io/devcontainers-extra/features/composer:1": {}
+	},
+
+	"forwardPorts": [
+		8080,
+		3306		
+	],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": ".devcontainer/postinstall.sh"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.8'
+
+services: 
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+
+    volumes:
+      - ../..:/workspaces:cached
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+      
+
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally. 
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+  db:
+    image: mariadb:10.4
+    restart: unless-stopped
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: mariadb
+      MYSQL_DATABASE: mariadb
+      MYSQL_USER: mariadb
+      MYSQL_PASSWORD: mariadb
+
+    # Add "forwardPorts": ["3306"] to **devcontainer.json** to forward MariaDB locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+  
+volumes:
+  mariadb-data:
+

--- a/.devcontainer/postinstall.sh
+++ b/.devcontainer/postinstall.sh
@@ -1,0 +1,6 @@
+sudo cp .devcontainer/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
+composer update 
+composer install 
+sudo chmod a+x $(pwd)
+sudo rm -rf /var/www/html
+sudo ln -s $(pwd) /var/www/html

--- a/.devcontainer/xdebug.ini
+++ b/.devcontainer/xdebug.ini
@@ -1,0 +1,7 @@
+[xdebug]
+zend_extension=xdebug
+xdebug.mode=develop,debug
+xdebug.start_with_request = yes
+xdebug.client_port = "9003"
+xdebug.idekey="vsc"
+xdebug.log=/tmp/xdebug_remote.log

--- a/.vscode/.gitignore
+++ b/.vscode/.gitignore
@@ -1,0 +1,1 @@
+launch.json

--- a/.vscode/launch.json-devcontainer-dist
+++ b/.vscode/launch.json-devcontainer-dist
@@ -1,0 +1,28 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug server",
+            "type": "php",
+            "request": "launch",
+            "runtimeArgs": [
+                "-dxdebug.mode=debug",
+                "-dxdebug.start_with_request=yes",
+                "-S",
+                "0.0.0.0:8080"
+            ],
+            "program": "",
+            "cwd": "${workspaceRoot}",
+            /* This is the debugger port on your dev machine that the container will connect to, xdebug.ini uses it*/
+            "port": 9003,
+            "serverReadyAction": {
+                "pattern": "Development Server \\(http://\w:([0-9]+)\\) started",
+                "uriFormat": "http://localhost:%s",
+                "action": "openExternally"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This enables debugging (using xdebug) in vscode

- Make sure PHP debugger and devcontainer extensions are installed
- Install docker on your system
- In .vscode, copy `launch.json-devcontainer-dist` to `launch.json` or use its contents for an existing launch.json file
- Build the devcontainer and switch the workspace to devcontainer

When you run the debug server launch configuration, a PHP webserver inside the devcontainer will start and you will be able to use the vscode debugger: place breakpoints, use watches, catch exceptions, step over etc.

Note that xdebug server runs on your machine and listens on its port 9003. The xdebug client is a php extension that runs _in_ the devcontainer and will connect back to your host, which is why vscode should have port 9003 listed in forwarded ports and it should be green when the web server is running.