### PR TITLE
UID References in notes

### DIFF
--- a/app/CommonMark/UidExtension.php
+++ b/app/CommonMark/UidExtension.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2025 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Fisharebest\Webtrees\CommonMark;
+
+use Fisharebest\Webtrees\Tree;
+use League\CommonMark\Environment\EnvironmentBuilderInterface;
+use League\CommonMark\Extension\ExtensionInterface;
+
+/**
+ * Convert UIDs within markdown text to links
+ */
+class UidExtension implements ExtensionInterface
+{
+    private Tree $tree;
+
+    /**
+     * @param Tree $tree Match UIDs in this tree
+     */
+    public function __construct(Tree $tree)
+    {
+        $this->tree = $tree;
+    }
+
+    /**
+     * @param EnvironmentBuilderInterface $environment
+     */
+    public function register(EnvironmentBuilderInterface $environment): void
+    {
+        $environment
+            ->addInlineParser(new UidParser($this->tree))
+            ->addRenderer(UidNode::class, new UidRenderer());
+    }
+}

--- a/app/CommonMark/UidNode.php
+++ b/app/CommonMark/UidNode.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2025 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Fisharebest\Webtrees\CommonMark;
+
+use Fisharebest\Webtrees\GedcomRecord;
+use League\CommonMark\Node\Node;
+
+/**
+ * Convert UIDs within markdown text to links
+ */
+class UidNode extends Node
+{
+    private GedcomRecord $record;
+    private String $linkText;
+
+    /**
+     * @param GedcomRecord $record
+     */
+    public function __construct(GedcomRecord $record, String $linkText)
+    {
+        parent::__construct();
+
+        $this->record = $record;
+        $this->linkText = $linkText;
+    }
+
+    /**
+     * @return GedcomRecord
+     */
+    public function record(): GedcomRecord
+    {
+        return $this->record;
+    }
+
+    /**
+     * @return linkTxt
+     */
+    public function linkText(): String
+    {
+        return $this->linkText;
+    }
+}

--- a/app/CommonMark/UidParser.php
+++ b/app/CommonMark/UidParser.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2025 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Fisharebest\Webtrees\CommonMark;
+
+use Fisharebest\Webtrees\Auth;
+use Fisharebest\Webtrees\Gedcom;
+use Fisharebest\Webtrees\GedcomRecord;
+use Fisharebest\Webtrees\Registry;
+use Fisharebest\Webtrees\Tree;
+use Fisharebest\Webtrees\Services\GedcomImportService;
+use Fisharebest\Webtrees\Services\TreeService;
+use Fisharebest\Webtrees\Services\SearchService;
+use League\CommonMark\Parser\Inline\InlineParserInterface;
+use League\CommonMark\Parser\Inline\InlineParserMatch;
+use League\CommonMark\Parser\InlineParserContext;
+use Illuminate\Support\Collection;
+
+/**
+ * Convert UIDs within markdown text to links
+ */
+class UidParser implements InlineParserInterface
+{
+    private Tree $tree;
+    private SearchService $search_service;
+
+    /**
+     * @param Tree $tree Match UIDs in this tree
+     */
+    public function __construct(Tree $tree)
+    {
+        $this->tree = $tree;
+        $this->search_service = new SearchService(new TreeService(new GedcomImportService($this->tree)));
+    }
+
+    /**
+     * We are only interested in text that begins with '@'.
+     *
+     * @return InlineParserMatch
+     */
+    public function getMatchDefinition(): InlineParserMatch
+    {
+        return InlineParserMatch::regex('#(' . Gedcom::REGEX_UID . ')(:.*)?#');
+    }
+
+    private function firstMatchingUid(String $pUid, Collection $pCollection)
+    {
+        foreach ($pCollection as $recTmp) {
+            if (preg_match('/\n1 _?UID ' . $pUid . '$/', $recTmp->gedcom())) {
+                return $recTmp;
+                break;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @param InlineParserContext $inlineContext
+     *
+     * @return bool
+     */
+    public function parse(InlineParserContext $inlineContext): bool
+    {
+        $cursor = $inlineContext->getCursor();
+        $subm = $inlineContext->getSubMatches();
+        #[$uid, $linkText] = $inlineContext->getSubMatches();
+        #$uid = [$subm[0], 'UID ' . $subm[0]];
+        $uid = [$subm[0]];
+        $firstFoundRecord = null;
+        if (isset($subm[1])) {
+            #Remove the initial colon
+            $linkText = substr($subm[1], 1);
+        } else {
+            $linkText = '';
+        }
+
+        // Do the search
+        $result = new Collection();
+
+        // Log search requests for visitors
+        if (Auth::id() === null) {
+            Log::addSearchLog('General: ' . $query, $search_trees->all());
+        }
+
+        $result = $this->search_service->searchIndividuals([$this->tree], $uid);
+        $firstFoundRecord = $this->firstMatchingUid($uid[0], $result);
+
+        if ($firstFoundRecord === null) {
+            $result = $this->search_service->searchFamilies([$this->tree], $uid);
+            $firstFoundRecord = $this->firstMatchingUid($uid[0], $result);
+
+            if ($firstFoundRecord === null) {
+                $result = $this->search_service->searchFamilyNames([$this->tree], $uid);
+                $firstFoundRecord = $this->firstMatchingUid($uid[0], $result);
+
+                if ($firstFoundRecord === null) {
+                    $result = $this->search_service->searchRepositories([$this->tree], $uid);
+                    $firstFoundRecord = $this->firstMatchingUid($uid[0], $result);
+
+                    if ($firstFoundRecord === null) {
+                        $result = $this->search_service->searchSources([$this->tree], $uid);
+                        $firstFoundRecord = $this->firstMatchingUid($uid[0], $result);
+
+                        if ($firstFoundRecord === null) {
+                            $result = $this->search_service->searchNotes([$this->tree], $uid);
+                            $firstFoundRecord = $this->firstMatchingUid($uid[0], $result);
+
+                            if ($firstFoundRecord === null) {
+                                $result = $this->search_service->searchLocations([$this->tree], $uid);
+                                $firstFoundRecord = $this->firstMatchingUid($uid[0], $result);
+
+                                if ($firstFoundRecord === null) {
+                                    $result = $this->search_service->searchMedia([$this->tree], $uid);
+                                    $firstFoundRecord = $this->firstMatchingUid($uid[0], $result);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+
+        if ($firstFoundRecord === null) {
+            return false;
+        } else {
+
+            $record = $firstFoundRecord;
+    
+            if ($record instanceof GedcomRecord) {
+                $cursor->advanceBy($inlineContext->getFullMatchLength());
+
+            $inlineContext->getContainer()->appendChild(new XrefNode($record));
+
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/app/CommonMark/UidRenderer.php
+++ b/app/CommonMark/UidRenderer.php
@@ -47,26 +47,26 @@ class UidRenderer implements NodeRendererInterface
             $html = $node->record()->fullName();
         } elseif ($node->linkText === "FULLNAME") {
             $html = $node->record()->fullName();
-#TODO Needs to be checked if the record has the fact asked for
-#TODO Needs take the date format defined acording to the language shown.
-#TODO         } elseif ($node->linkText === "BIRT:DATE") {
-#TODO             $html = $node->record()->fullName();
-#TODO                         $tmp   = new Date($value);
-#TODO                         $dfmt = "%j %F %Y";
-#TODO                         $value = strip_tags($tmp->display(null, $dfmt));
-#TODO         } elseif ($node->linkText === "BIRT:PLAC") {
-#TODO             $html = $node->record()->fullName();
-#TODO                         $tmp   = new Place($value, $this->tree);
-#TODO                         $value = $tmp->shortName();
-#TODO         } elseif ($node->linkText === "DEAT:DATE") {
-#TODO             $html = $node->record()->fullName();
-#TODO                         $tmp   = new Date($value);
-#TODO                         $dfmt = "%j %F %Y";
-#TODO                         $value = strip_tags($tmp->display(null, $dfmt));
-#TODO         } elseif ($node->linkText === "DEAT:PLAC") {
-#TODO             $html = $node->record()->fullName();
-#TODO                         $tmp   = new Place($value, $this->tree);
-#TODO                         $value = $tmp->shortName();
+        #TODO Needs to be checked if the record has the fact asked for
+        #TODO Needs take the date format defined acording to the language shown.
+        #TODO } elseif ($node->linkText === "BIRT:DATE") {
+        #TODO     $html = $node->record()->fullName();
+        #TODO                 $tmp   = new Date($value);
+        #TODO                 $dfmt = "%j %F %Y";
+        #TODO                 $value = strip_tags($tmp->display(null, $dfmt));
+        #TODO } elseif ($node->linkText === "BIRT:PLAC") {
+        #TODO     $html = $node->record()->fullName();
+        #TODO                 $tmp   = new Place($value, $this->tree);
+        #TODO                 $value = $tmp->shortName();
+        #TODO } elseif ($node->linkText === "DEAT:DATE") {
+        #TODO     $html = $node->record()->fullName();
+        #TODO                 $tmp   = new Date($value);
+        #TODO                 $dfmt = "%j %F %Y";
+        #TODO                 $value = strip_tags($tmp->display(null, $dfmt));
+        #TODO } elseif ($node->linkText === "DEAT:PLAC") {
+        #TODO     $html = $node->record()->fullName();
+        #TODO                 $tmp   = new Place($value, $this->tree);
+        #TODO                 $value = $tmp->shortName();
         } else {
             $html = $node->linkText();
         }

--- a/app/CommonMark/UidRenderer.php
+++ b/app/CommonMark/UidRenderer.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2025 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Fisharebest\Webtrees\CommonMark;
+
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\ChildNodeRendererInterface;
+use League\CommonMark\Renderer\NodeRendererInterface;
+use League\CommonMark\Util\HtmlElement;
+use Stringable;
+
+/**
+ * Convert XREFs within markdown text to links
+ */
+class UidRenderer implements NodeRendererInterface
+{
+    /**
+     * @param Node                       $node
+     * @param ChildNodeRendererInterface $childRenderer
+     *
+     * @return Stringable
+     */
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer): Stringable
+    {
+        UidNode::assertInstanceOf($node);
+
+        /** @var UidNode $node */
+        $href = $node->record()->url();
+
+        if (empty($node->linkText())) {
+            $html = $node->record()->fullName();
+        } elseif ($node->linkText === "FULLNAME") {
+            $html = $node->record()->fullName();
+#TODO Needs to be checked if the record has the fact asked for
+#TODO Needs take the date format defined acording to the language shown.
+#TODO         } elseif ($node->linkText === "BIRT:DATE") {
+#TODO             $html = $node->record()->fullName();
+#TODO                         $tmp   = new Date($value);
+#TODO                         $dfmt = "%j %F %Y";
+#TODO                         $value = strip_tags($tmp->display(null, $dfmt));
+#TODO         } elseif ($node->linkText === "BIRT:PLAC") {
+#TODO             $html = $node->record()->fullName();
+#TODO                         $tmp   = new Place($value, $this->tree);
+#TODO                         $value = $tmp->shortName();
+#TODO         } elseif ($node->linkText === "DEAT:DATE") {
+#TODO             $html = $node->record()->fullName();
+#TODO                         $tmp   = new Date($value);
+#TODO                         $dfmt = "%j %F %Y";
+#TODO                         $value = strip_tags($tmp->display(null, $dfmt));
+#TODO         } elseif ($node->linkText === "DEAT:PLAC") {
+#TODO             $html = $node->record()->fullName();
+#TODO                         $tmp   = new Place($value, $this->tree);
+#TODO                         $value = $tmp->shortName();
+        } else {
+            $html = $node->linkText();
+        }
+
+        return new HtmlElement('a', ['href' => $href], $html);
+    }
+}

--- a/app/Factories/MarkdownFactory.php
+++ b/app/Factories/MarkdownFactory.php
@@ -21,6 +21,7 @@ namespace Fisharebest\Webtrees\Factories;
 
 use Fisharebest\Webtrees\CommonMark\CensusTableExtension;
 use Fisharebest\Webtrees\CommonMark\XrefExtension;
+use Fisharebest\Webtrees\CommonMark\UidExtension;
 use Fisharebest\Webtrees\Contracts\MarkdownFactoryInterface;
 use Fisharebest\Webtrees\Tree;
 use League\CommonMark\Environment\Environment;
@@ -98,6 +99,7 @@ class MarkdownFactory implements MarkdownFactoryInterface
         // Optionally create links to other records.
         if ($tree instanceof Tree) {
             $environment->addExtension(new XrefExtension($tree));
+            $environment->addExtension(new UidExtension($tree));
         }
 
         $converter = new MarkDownConverter($environment);
@@ -129,6 +131,7 @@ class MarkdownFactory implements MarkdownFactoryInterface
         // Optionally create links to other records.
         if ($tree instanceof Tree) {
             $environment->addExtension(new XrefExtension($tree));
+            $environment->addExtension(new UidExtension($tree));
         }
 
         $converter = new MarkDownConverter($environment);

--- a/app/Gedcom.php
+++ b/app/Gedcom.php
@@ -242,6 +242,9 @@ class Gedcom
     // Regular expression to match a GEDCOM XREF.
     public const string REGEX_XREF = '[A-Za-z0-9:_.-]{1,20}';
 
+    // Regular expression to match a GEDCOM UID or _UID.
+    public const string REGEX_UID = '[0-9a-fA-F]{8}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{4}-?[0-9a-fA-F]{12}|[0-9a-fA-F]{36}|[0-9a-fA-F]{38}';
+
     // Regular expression to match a GEDCOM fact/event for editing raw GEDCOM.
     private const string REGEX_VALUE   = '( .+)?';
     private const string REGEX_LEVEL_9 = '\n9 ' . self::REGEX_TAG . self::REGEX_VALUE;


### PR DESCRIPTION
Added an option to add _UID|UID references with options for different text on links.

It puts the full name if not specified options.
It lets put any text as the link text, if added after a colon.

Are commented options for BIRT:DATE, BIRT:PLAC, DEAT:DATE, DEAT:PLAC as text for the link. Needs more work

It works for UID's on Individualas, Families, Media, Sources.

Examples showing the full name:
```
Note's text before #FE7C45EE57AD4C4DA6675AFED8B59B8F966987# and after the reference.
```
```
Note's text before #FE7C45EE57AD4C4DA6675AFED8B59B8F966987:FULLNAME# and after the reference.
```

Example showing an arbitrary text as the link text:
```
Note's text before #FE7C45EE57AD4C4DA6675AFED8B59B8F966987: this guy was also there# and after the reference.
```

These options are commented/not implemented in the code
```
Note's text before #FE7C45EE57AD4C4DA6675AFED8B59B8F966987:BIRT:DATE# and after the reference.
Note's text before #FE7C45EE57AD4C4DA6675AFED8B59B8F966987:BIRT:PLAC# and after the reference.
Note's text before #FE7C45EE57AD4C4DA6675AFED8B59B8F966987:DEAT:DATE# and after the reference.
Note's text before #FE7C45EE57AD4C4DA6675AFED8B59B8F966987:DEAT:PLAC# and after the reference.
```

Hope you get the idea with this.

Ely