### PR TITLE
fix #4467 support for 4k/5k monitors

### DIFF
--- a/resources/css/_base.css
+++ b/resources/css/_base.css
@@ -63,6 +63,11 @@ a:hover {
     text-decoration: underline;
 }
 
+/* Extend screen width limitation of bootstrap for 4k/5k devices */
+@media (min-width: 1700px) { .container, .container-lg, .container-md, .container-sm, .container-xl, .container-xxl {max-width: 1600px} }
+@media (min-width: 2100px) { .container, .container-lg, .container-md, .container-sm, .container-xl, .container-xxl {max-width: 1980px} }
+@media (min-width: 2500px) { .container, .container-lg, .container-md, .container-sm, .container-xl, .container-xxl {max-width: 2360px} }
+
 /* Scrollbars */
 .wt-global {
     /* Prevent redraws when dynamic content requires a scrollbar. */


### PR DESCRIPTION
 Bootstrap sets usable width to 52% for 5k monitors.

See forum discussion 
https://www.webtrees.net/index.php/forum/help-for-release-2-1-x/39936-diagrams-how-to-set-to-use-the-entire-screen-width 
and bootstrap code https://github.com/twbs/bootstrap/blob/main/site/data/breakpoints.yml