### PR TITLE
when logging out the homepage is fetched twice

### DIFF
--- a/app/Http/RequestHandlers/Logout.php
+++ b/app/Http/RequestHandlers/Logout.php
@@ -29,8 +29,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-use function redirect;
-use function route;
+use function response;
 
 /**
  * Perform a logout.
@@ -52,6 +51,6 @@ class Logout implements RequestHandlerInterface
             FlashMessages::addMessage(I18N::translate('You have signed out.'));
         }
 
-        return redirect(route(HomePage::class));
+        return response();
     }
 }

--- a/app/Http/RequestHandlers/Logout.php
+++ b/app/Http/RequestHandlers/Logout.php
@@ -29,7 +29,9 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+use function redirect;
 use function response;
+use function route;
 
 /**
  * Perform a logout.
@@ -51,6 +53,12 @@ class Logout implements RequestHandlerInterface
             FlashMessages::addMessage(I18N::translate('You have signed out.'));
         }
 
-        return response();
+        if ($request->getHeaderLine('X-Requested-With') !== '') {
+            // Ajax request - send empty response
+            return response();
+        } else {
+            // Form submission - redirect to home page
+            return redirect(route(HomePage::class));
+        }
     }
 }


### PR DESCRIPTION
fix #5153

The logout request handler may respond with a simple 204-NoContent. The originating view already contains redirection. As reported on the [forum](https://www.webtrees.net/index.php/forum/help-for-release-2-2-x/40009-forbidden-403-error-on-logout?start=0), some servers don't cope well.

Affected user reported back this patch does the trick: logout goes smoothly.