### PR TITLE
fix issue #4309: first week misaligned on calendarWidget when 1st of month is a Sunday

### DIFF
--- a/resources/js/webtrees.js
+++ b/resources/js/webtrees.js
@@ -452,8 +452,7 @@
     content += '</tr>';
 
     let tdate = new Date(date.getFullYear(), date.getMonth(), 1);
-    let day = tdate.getDay();
-    day = day - weekStart;
+    let day = (7 + tdate.getDay() - weekStart) % 7;
     let daymilli = 1000 * 60 * 60 * 24;
     tdate = tdate.getTime() - (day * daymilli) + (daymilli / 2);
     tdate = new Date(tdate);


### PR DESCRIPTION
Fixing issue: when the first day of the month is on a Sunday (eg 01 JUN 2025 is a Sunday) then the Calendar Widget starts displaying data at Monday the 2nd. There's no need to go back to 1775 (as originally reported) because this happens regulary.

Cause: weekStart is usually a Monday (value 1). When subtracted from Sunday (value 0) the outcome is negative, while a number between 0 and 6 was expected.

Note that % operator (modulo) on negative numbers yield negative results, so add 7 to counter-act that.

Useful test cases:
* 01 MAR 2025 = Saturday
* 01 JUN 2025 = Sunday
* 01 JUL 2024 = Monday