### PR TITLE
fix issue #3648: do not filter out names of type 'marriage' in the Family name

### DIFF
--- a/app/Family.php
+++ b/app/Family.php
@@ -320,9 +320,9 @@ class Family extends GedcomRecord
             // Check the script used by each name, so we can match cyrillic with cyrillic, greek with greek, etc.
             $husb_names = [];
             if ($this->husb instanceof Individual) {
-                $husb_names = array_filter($this->husb->getAllNames(), static fn (array $x): bool => $x['type'] !== '_MARNM');
+                $husb_names = $this->husb->getAllNames();
             }
-            // If the individual only has married names, create a fake birth name.
+            // use Nomen Nescio when no name is known
             if ($husb_names === []) {
                 $husb_names[] = [
                     'type' => 'BIRT',
@@ -336,9 +336,9 @@ class Family extends GedcomRecord
 
             $wife_names = [];
             if ($this->wife instanceof Individual) {
-                $wife_names = array_filter($this->wife->getAllNames(), static fn (array $x): bool => $x['type'] !== '_MARNM');
+                $wife_names = $this->wife->getAllNames();
             }
-            // If the individual only has married names, create a fake birth name.
+            // use Nomen Nescio when no name is known
             if ($wife_names === []) {
                 $wife_names[] = [
                     'type' => 'BIRT',


### PR DESCRIPTION
Users will have put the Marriage name first because that is the preferred name.
Not using it for naming the Family is not consistent and takes them by surprise.