### PR TITLE
Switch to one column at medium width instead of small on individual page

### DIFF
--- a/resources/views/individual-page.phtml
+++ b/resources/views/individual-page.phtml
@@ -48,7 +48,7 @@ use Illuminate\Support\Collection;
     <?= view('individual-page-tabs', ['record' => $record, 'tabs' => $tabs]) ?>
 <?php else : ?>
     <div class="row">
-        <div class="col-sm-8">
+        <div class="col-md-8">
             <div class="row mb-4">
                 <?= view('individual-page-images', ['can_upload_media' => $can_upload_media, 'individual_media' => $individual_media, 'record' => $record, 'tree' => $tree]) ?>
 
@@ -58,7 +58,7 @@ use Illuminate\Support\Collection;
             <?= view('individual-page-tabs', ['record' => $record, 'tabs' => $tabs]) ?>
         </div>
 
-        <div class="col-sm-4">
+        <div class="col-md-4">
             <?= view('individual-page-sidebars', ['record' => $record, 'sidebars' => $sidebars]) ?>
         </div>
     </div>


### PR DESCRIPTION
I think it gets a bit "crowdy" with two columns on such thin widths. This change alters the threshold for when to switch between one and two columns.

Smallest width with two columns before change:
<img width="579" height="1106" alt="image" src="https://github.com/user-attachments/assets/afb53127-ca5b-49f2-8a93-2c0203e3f072" />

Smallest width with two columns after change:
<img width="772" height="1096" alt="image" src="https://github.com/user-attachments/assets/f54ce9bb-be64-420d-b87a-68d3be69647f" />
