### PR TITLE
Update GedcomImportService.php

### DIFF
--- a/app/Services/GedcomImportService.php
+++ b/app/Services/GedcomImportService.php
@@ -236,6 +236,15 @@ class GedcomImportService
             $gedrec = str_replace('@@', '@', $gedrec);
         }
 
+        if (preg_match('/^0 @([^@]+)@ (_STF|_PTF|_STE|_PTE)/', $gedrec, $match)) {
+            $xref = $match[1];
+
+            $exists = DB::table('other')->where('o_id', '=', $xref)->where('o_file', '=', $tree_id)->exists();
+            if ($exists) {
+                return; // Skip duplicate custom record
+            }
+        }
+
         // Standardise gedcom format
         $gedrec = $this->reformatRecord($gedrec, $tree);
 


### PR DESCRIPTION
Fix for issue #5125

This change addresses an issue when importing GEDCOM files that contain multiple custom records (_PTF, _STF, _STE, _PTE, etc.) with the same cross-reference identifier (XREF), such as @TF0@ or @T0@. These records are inserted into the wt_other table using (o_id, o_file) as a composite primary key.

If two or more records share the same XREF, the import process fails with a SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry error due to a primary key conflict.

To prevent this, the GedcomImportService::importRecord() method has been extended with a pre-insert check. If a record of the same type and XREF already exists in the database, the new record is silently skipped. This avoids import crashes and allows the remaining GEDCOM data to be processed successfully.

This solution targets a common case with Webtrees 2.1+ place templates and source templates introduced in version 11, where reused XREFs are sometimes present by design. Skipping duplicates ensures that user-defined templates or updates from newer GEDCOM files do not cause import errors.

Limitations:

- Only affects _PTF, _STF, _PTE, and _STE records.
- The first occurrence of a given XREF is preserved; subsequent duplicates are ignored.
- Logging or conflict resolution is not included in this patch but could be added in the future.