### PR TITLE
fixed bug: Setup wizard reported memory_limit as zero

### DIFF
--- a/app/Http/RequestHandlers/SetupWizard.php
+++ b/app/Http/RequestHandlers/SetupWizard.php
@@ -136,7 +136,7 @@ class SetupWizard implements RequestHandlerInterface
 
         $data['cpu_limit']    = $this->php_service->maxExecutionTime();
         $data['locales']      = $locales;
-        $data['memory_limit'] = intdiv($this->php_service->maxExecutionTime(), 1048576);
+        $data['memory_limit'] = intdiv($this->php_service->memoryLimit(), 1024*1024);
 
         // Only show database errors after the user has chosen a driver.
         if ($step >= 4) {


### PR DESCRIPTION
Also made the magic division number a bit less magic.
Please also review the advised memory sizes here:
https://github.com/fisharebest/webtrees/blob/main/resources/views/setup/step-2-server-checks.phtml#L70-L74
This guide dates from over a decade ago, webtrees needs a lot more memory these days.