### PR TITLE
fixed #5207: memory_limit = -1 means unlimited

### DIFF
--- a/app/Http/RequestHandlers/SetupWizard.php
+++ b/app/Http/RequestHandlers/SetupWizard.php
@@ -136,7 +136,7 @@ class SetupWizard implements RequestHandlerInterface
 
         $data['cpu_limit']    = $this->php_service->maxExecutionTime();
         $data['locales']      = $locales;
-        $memory_limit         = $this->php_service->memoryLimit();
+        $data['memory_limit'] = $this->php_service->memoryLimit();
 
         // Only show database errors after the user has chosen a driver.
         if ($step >= 4) {

--- a/app/Http/RequestHandlers/SetupWizard.php
+++ b/app/Http/RequestHandlers/SetupWizard.php
@@ -136,11 +136,7 @@ class SetupWizard implements RequestHandlerInterface
 
         $data['cpu_limit']    = $this->php_service->maxExecutionTime();
         $data['locales']      = $locales;
-        $memoryLimit = $this->php_service->memoryLimit();
-        if ($memoryLimit != -1) {
-            $memoryLimit = intdiv($memoryLimit, 1024*1024);
-        }
-        $data['memory_limit'] = $memoryLimit;
+        $memory_limit         = $this->php_service->memoryLimit();
 
         // Only show database errors after the user has chosen a driver.
         if ($step >= 4) {

--- a/app/Http/RequestHandlers/SetupWizard.php
+++ b/app/Http/RequestHandlers/SetupWizard.php
@@ -136,7 +136,11 @@ class SetupWizard implements RequestHandlerInterface
 
         $data['cpu_limit']    = $this->php_service->maxExecutionTime();
         $data['locales']      = $locales;
-        $data['memory_limit'] = intdiv($this->php_service->memoryLimit(), 1024*1024);
+        $memoryLimit = $this->php_service->memoryLimit();
+        if ($memoryLimit != -1) {
+            $memoryLimit = intdiv($memoryLimit, 1024*1024);
+        }
+        $data['memory_limit'] = $memoryLimit;
 
         // Only show database errors after the user has chosen a driver.
         if ($step >= 4) {

--- a/resources/views/setup/step-2-server-checks.phtml
+++ b/resources/views/setup/step-2-server-checks.phtml
@@ -75,7 +75,7 @@ use Illuminate\Support\Collection;
     </p>
 
     <p class="alert alert-<?= $memory_limit > 0 && $memory_limit < 33554432 || $cpu_limit > 0 && $cpu_limit < 20 ? 'danger' : 'success' ?>">
-        <?= I18N::translate('This server’s memory limit is %s MB and its CPU time limit is %s seconds.', $memory_limit <= 0 ? '∞' : I18N::number(intdiv($memory_limit, 1048576)), I18N::number($cpu_limit)) ?>
+        <?= I18N::translate('This server’s memory limit is %s MB and its CPU time limit is %s seconds.', $memory_limit <= 0 ? I18N::translate('unlimited') : I18N::number(intdiv($memory_limit, 1048576)), I18N::number($cpu_limit)) ?>
     </p>
 
     <p>

--- a/resources/views/setup/step-2-server-checks.phtml
+++ b/resources/views/setup/step-2-server-checks.phtml
@@ -74,8 +74,8 @@ use Illuminate\Support\Collection;
         <?= I18N::translate('Large systems (50,000 individuals): 64–128 MB, 40–80 seconds') ?>
     </p>
 
-    <p class="alert alert-<?= $memory_limit < 32 || $cpu_limit > 0 && $cpu_limit < 20 ? 'danger' : 'success' ?>">
-        <?= I18N::translate('This server’s memory limit is %s MB and its CPU time limit is %s seconds.', I18N::number($memory_limit), I18N::number($cpu_limit)) ?>
+    <p class="alert alert-<?= $memory_limit != -1 && $memory_limit < 32 || $cpu_limit > 0 && $cpu_limit < 20 ? 'danger' : 'success' ?>">
+        <?= I18N::translate('This server’s memory limit is %s MB and its CPU time limit is %s seconds.', ($memory_limit == -1 ? I18N::translate('unlimited') : I18N::number($memory_limit)), I18N::number($cpu_limit)) ?>
     </p>
 
     <p>

--- a/resources/views/setup/step-2-server-checks.phtml
+++ b/resources/views/setup/step-2-server-checks.phtml
@@ -74,8 +74,8 @@ use Illuminate\Support\Collection;
         <?= I18N::translate('Large systems (50,000 individuals): 64–128 MB, 40–80 seconds') ?>
     </p>
 
-    <p class="alert alert-<?= $memory_limit != -1 && $memory_limit < 32 || $cpu_limit > 0 && $cpu_limit < 20 ? 'danger' : 'success' ?>">
-        <?= I18N::translate('This server’s memory limit is %s MB and its CPU time limit is %s seconds.', ($memory_limit == -1 ? I18N::translate('unlimited') : I18N::number($memory_limit)), I18N::number($cpu_limit)) ?>
+    <p class="alert alert-<?= $memory_limit > 0 && $memory_limit < 32 || $cpu_limit > 0 && $cpu_limit < 20 ? 'danger' : 'success' ?>">
+        <?= I18N::translate('This server’s memory limit is %s MB and its CPU time limit is %s seconds.', ($memory_limit <= 0 ? '∞' : I18N::number(intdiv($memory_limit, 1048576)), I18N::number($cpu_limit)) ?>
     </p>
 
     <p>

--- a/resources/views/setup/step-2-server-checks.phtml
+++ b/resources/views/setup/step-2-server-checks.phtml
@@ -74,7 +74,7 @@ use Illuminate\Support\Collection;
         <?= I18N::translate('Large systems (50,000 individuals): 64–128 MB, 40–80 seconds') ?>
     </p>
 
-    <p class="alert alert-<?= $memory_limit > 0 && $memory_limit < 32 || $cpu_limit > 0 && $cpu_limit < 20 ? 'danger' : 'success' ?>">
+    <p class="alert alert-<?= $memory_limit > 0 && $memory_limit < 33554432 || $cpu_limit > 0 && $cpu_limit < 20 ? 'danger' : 'success' ?>">
         <?= I18N::translate('This server’s memory limit is %s MB and its CPU time limit is %s seconds.', ($memory_limit <= 0 ? '∞' : I18N::number(intdiv($memory_limit, 1048576)), I18N::number($cpu_limit)) ?>
     </p>
 

--- a/resources/views/setup/step-2-server-checks.phtml
+++ b/resources/views/setup/step-2-server-checks.phtml
@@ -75,7 +75,7 @@ use Illuminate\Support\Collection;
     </p>
 
     <p class="alert alert-<?= $memory_limit > 0 && $memory_limit < 33554432 || $cpu_limit > 0 && $cpu_limit < 20 ? 'danger' : 'success' ?>">
-        <?= I18N::translate('This server’s memory limit is %s MB and its CPU time limit is %s seconds.', ($memory_limit <= 0 ? '∞' : I18N::number(intdiv($memory_limit, 1048576)), I18N::number($cpu_limit)) ?>
+        <?= I18N::translate('This server’s memory limit is %s MB and its CPU time limit is %s seconds.', $memory_limit <= 0 ? '∞' : I18N::number(intdiv($memory_limit, 1048576)), I18N::number($cpu_limit)) ?>
     </p>
 
     <p>


### PR DESCRIPTION
Prevent an error or warning is displayed in setup wizard when memory_limit = -1.
See https://www.php.net/manual/en/ini.core.php#ini.sect.resource-limits

Reused the word "unlimited" which already had a translation.
The text is not perfect then, but it's already better than showing "-1" 