### PR TITLE
fix end of file check for tree-import cli command

### DIFF
--- a/app/Cli/Commands/TreeImport.php
+++ b/app/Cli/Commands/TreeImport.php
@@ -164,7 +164,7 @@ final class TreeImport extends AbstractCommand
             while ($bytes_loaded < $total_bytes) {
                 $tmp = fread($fp, 8192);
                 $buffer .= $tmp;
-                $bytes_loaded += strlen($buffer);
+                $bytes_loaded += strlen($tmp);
 
                 $records = preg_split('/[\r\n]+(?=0)/', $buffer);
                 $buffer = array_pop($records);


### PR DESCRIPTION
When the tree-importer cli command is checking if it has finished reading in the gedcom file, it is adding the size of the entire buffer on every read, instead of just the new bytes read. This makes it think it has already read more of the file than it actually has.  Mostly, the command will work normally since the leftover bytes in the buffer aren't enough to affect the next buffer read.  But, if the gedcom file is very large and/or has large records, the leftover bytes will accumulate past the 8192 buffer size and the command won't read in the complete gedcom file.