### PR TITLE
fix #4511 & #5137: when adding a child to a family, put it between older and younger children

### DIFF
--- a/app/Http/RequestHandlers/AddChildToFamilyAction.php
+++ b/app/Http/RequestHandlers/AddChildToFamilyAction.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 namespace Fisharebest\Webtrees\Http\RequestHandlers;
 
 use Fisharebest\Webtrees\Auth;
+use Fisharebest\Webtrees\Date;
+use Fisharebest\Webtrees\Fact;
 use Fisharebest\Webtrees\Family;
 use Fisharebest\Webtrees\Individual;
 use Fisharebest\Webtrees\Registry;
@@ -59,7 +61,7 @@ class AddChildToFamilyAction implements RequestHandlerInterface
         $child  = $tree->createIndividual("0 @@ INDI\n1 FAMC @" . $xref . '@' . $gedcom);
 
         // Link the child to the family
-        $before_id = $this->factIdOfYoungerSibling($family, $child);
+        $before_id = $this->childFactOfYoungerSibling($family, $child)?->id() ?? '';
         $family->createFact('1 CHIL @' . $child->xref() . '@', true, $before_id);
 
         $url = Validator::parsedBody($request)->isLocalUrl()->string('url', $child->url());
@@ -67,15 +69,15 @@ class AddChildToFamilyAction implements RequestHandlerInterface
         return redirect($url);
     }
 
-    private function factIdOfYoungerSibling(Family $family, Individual $child): string
+    private function childFactOfYoungerSibling(Family $family, Individual $child): Fact | null
     {
-        $child_birth_day = $child->getBirthDate()->julianDay();
-        foreach ($family->facts(['CHIL'], false, Auth::PRIV_HIDE, true) as $fact) {
-            if ($child_birth_day < $fact->target()->getBirthDate()->julianDay()) {
-                return $fact->id();
-            }
-        }
-        return '';
+        $filter = function (Fact $fact) use ($child): bool {
+            return $fact->target() instanceof Individual &&
+                Date::compare($child->getBirthDate(), $fact->target()->getBirthDate()) < 0;
+        };
+        return $family
+            ->facts(['CHIL'], false, Auth::PRIV_HIDE, true)
+            ->first($filter);
     }
 
 }

--- a/app/Http/RequestHandlers/AddSpouseToIndividualAction.php
+++ b/app/Http/RequestHandlers/AddSpouseToIndividualAction.php
@@ -20,6 +20,8 @@ declare(strict_types=1);
 namespace Fisharebest\Webtrees\Http\RequestHandlers;
 
 use Fisharebest\Webtrees\Auth;
+use Fisharebest\Webtrees\Date;
+use Fisharebest\Webtrees\Fact;
 use Fisharebest\Webtrees\Family;
 use Fisharebest\Webtrees\Individual;
 use Fisharebest\Webtrees\Registry;
@@ -67,11 +69,11 @@ class AddSpouseToIndividualAction implements RequestHandlerInterface
         $family = $tree->createFamily('0 @@ FAM' . $gedcom . $i_link . $s_link);
 
         // Link the individual to the family
-        $before_id = $this->factIdOfLaterMarriage($individual, $family);
+        $before_id = $this->famsFactOfLaterMarriage($individual, $family)?->id() ?? '';
         $individual->createFact('1 FAMS @' . $family->xref() . '@', false, $before_id);
 
         // Link the spouse to the family
-        $before_id = $this->factIdOfLaterMarriage($spouse, $family);
+        $before_id = $this->famsFactOfLaterMarriage($spouse, $family)?->id();
         $spouse->createFact('1 FAMS @' . $family->xref() . '@', false, $before_id);
 
         $url = Validator::parsedBody($request)->isLocalUrl()->string('url', $spouse->url());
@@ -79,15 +81,15 @@ class AddSpouseToIndividualAction implements RequestHandlerInterface
         return redirect($url);
     }
 
-    private function factIdOfLaterMarriage(Individual $partner, Family $family): string
+    private function famsFactOfLaterMarriage(Individual $partner, Family $family): Fact | null
     {
-        $family_marriage_date = $family->getMarriageDate()->julianDay();
-        foreach ($partner->facts(['FAMS'], false, Auth::PRIV_HIDE, true) as $fact) {
-            if ($family_marriage_date < $fact->target()->getMarriageDate()->julianDay()) {
-                return $fact->id();
-            }
-        }
-        return '';
+        $filter = function (Fact $fact) use ($family): bool {
+            return $fact->target() instanceof Family &&
+                Date::compare($family->getMarriageDate(), $fact->target()->getMarriageDate()) < 0;
+        };
+        return $partner
+            ->facts(['FAMS'], false, Auth::PRIV_HIDE, true)
+            ->first($filter);
     }
 
 }

--- a/app/Http/RequestHandlers/LinkSpouseToIndividualAction.php
+++ b/app/Http/RequestHandlers/LinkSpouseToIndividualAction.php
@@ -71,11 +71,11 @@ class LinkSpouseToIndividualAction implements RequestHandlerInterface
 
         // Link the individual to the family
         $before_id = $this->factIdOfLaterMarriage($individual, $family);
-        $individual->createFact('1 FAMS @' . $family->xref() . '@', false, $before_id);
+        $individual->createFact('1 FAMS @' . $family->xref() . '@', true, $before_id);
 
         // Link the spouse to the family
         $before_id = $this->factIdOfLaterMarriage($spouse, $family);
-        $spouse->createFact('1 FAMS @' . $family->xref() . '@', false, $before_id);
+        $spouse->createFact('1 FAMS @' . $family->xref() . '@', true, $before_id);
 
         return redirect($family->url());
     }


### PR DESCRIPTION
Inspired on the algorithm of the 1.7 branch: put a new child after older children, just before the first child which is younger.

This saves the user from having to reorder or sort children after a child is added.

I did try to make some actual tests, avoid mocking everything, but alas got stuck on tree authorisations when creating a family or child.