### PR TITLE
fix issue #5196: skip BURI in chartbox when DEAT is present

### DIFF
--- a/resources/views/chart-box.phtml
+++ b/resources/views/chart-box.phtml
@@ -183,6 +183,7 @@ $id = Registry::idFactory()->id();
 
                 if ($event instanceof Fact) {
                     echo $event->summary();
+                    break;
                 }
             }
             ?>


### PR DESCRIPTION
The easiest 'fix' is adding the missing `break` statement.
More complex logic can be added when requested.