### PR TITLE
fix #5287: extra newline in family gedcom for new spouse triggered validation error

### DIFF
--- a/app/Http/RequestHandlers/AddSpouseToFamilyAction.php
+++ b/app/Http/RequestHandlers/AddSpouseToFamilyAction.php
@@ -76,7 +76,7 @@ final class AddSpouseToFamilyAction implements RequestHandlerInterface
         $levels = Validator::parsedBody($request)->array('flevels');
         $tags   = Validator::parsedBody($request)->array('ftags');
         $values = Validator::parsedBody($request)->array('fvalues');
-        $gedcom = $this->gedcom_edit_service->editLinesToGedcom(Family::RECORD_TYPE, $levels, $tags, $values);
+        $gedcom = $this->gedcom_edit_service->editLinesToGedcom(Family::RECORD_TYPE, $levels, $tags, $values, false);
 
         if ($gedcom !== '') {
             $family->createFact($gedcom, false);


### PR DESCRIPTION
The GedcomEditService function should be called with append flag = false