### PR TITLE
Fix Datatables error in Media Manager

### DIFF
--- a/app/Http/RequestHandlers/ManageMediaData.php
+++ b/app/Http/RequestHandlers/ManageMediaData.php
@@ -215,7 +215,11 @@ final class ManageMediaData implements RequestHandlerInterface
                     ->map(static fn (string $file): array => (array) $file);
 
                 $search_columns = [0];
-                $sort_columns   = [0 => 0];
+                $sort_columns   = [
+                    0 => 0,
+                    1 => 0,
+                    2 => 0,
+                ];
 
                 $callback = function (array $row) use ($data_filesystem, $media_trees): array {
                     try {

--- a/app/Services/DatatablesService.php
+++ b/app/Services/DatatablesService.php
@@ -76,6 +76,10 @@ class DatatablesService
         if ($order !== []) {
             $collection = $collection->sort(static function (array $row1, array $row2) use ($order, $sort_columns): int {
                 foreach ($order as $column) {
+                    if (!isset($sort_columns[$column['column']])) {
+                        continue;
+                    }
+
                     $key = $sort_columns[$column['column']];
                     $dir = $column['dir'];
 


### PR DESCRIPTION
Fix Datatables error "Undefined array key 2" when using the "Manage media" utility.

To reproduce the error:
- open "Manage media" for Local or External files
- sort by the third column "Media object"
- switch to "Unused files"
- user sees a pop-up "DataTables warning: table id=wt-datatables-admin-media - Invalid JSON response. For more information about this error, please see https://datatables.net/tn/1"
- instead of the JSON the backend returns "Undefined array key 2 …/app/Services/DatatablesService.php:79"