### PR TITLE
pending change might not point to a GedcomRecord

### DIFF
--- a/app/Module/ReviewChangesModule.php
+++ b/app/Module/ReviewChangesModule.php
@@ -22,6 +22,7 @@ namespace Fisharebest\Webtrees\Module;
 use Fisharebest\Webtrees\Auth;
 use Fisharebest\Webtrees\Contracts\UserInterface;
 use Fisharebest\Webtrees\DB;
+use Fisharebest\Webtrees\GedcomRecord;
 use Fisharebest\Webtrees\Http\RequestHandlers\PendingChanges;
 use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\Registry;
@@ -163,7 +164,7 @@ class ReviewChangesModule extends AbstractModule implements ModuleBlockInterface
 
             foreach ($changes as $change) {
                 $record = Registry::gedcomRecordFactory()->make($change->xref, $tree, $change->new_gedcom ?: $change->old_gedcom);
-                if ($record->canShow()) {
+                if ($record instanceof GedcomRecord && $record->canShow()) {
                     $content .= '<li><a href="' . e($record->url()) . '">' . $record->fullName() . '</a></li>';
                 }
             }


### PR DESCRIPTION
fix #5090: on the [forum](https://www.webtrees.net/index.php/forum/help-for-release-2-2-x/40498-error-on-my-page) it was reported that accepting or rejecting pending changes makes the error in the home/my page block go away. Thus these cases where `$record == null` can be safely ignored.