### PR TITLE
Update .htaccess for Apache >= 2.4

### DIFF
--- a/data/.htaccess
+++ b/data/.htaccess
@@ -1,2 +1,14 @@
-order allow,deny
-deny from all
+# Apache >= 2.4
+<IfModule mod_authz_core.c>
+    Require all denied
+</IfModule>
+
+# Apache <= 2.2
+<IfModule !mod_authz_core.c>
+  <IfModule !mod_access_compat.c>
+    <IfModule mod_authz_host.c>
+      Order Allow,Deny
+      Deny from all
+    </IfModule>
+  </IfModule>
+</IfModule>


### PR DESCRIPTION
Support for Apache 2.4 authz_host module new syntax.

As said in https://httpd.apache.org/docs/2.4/en/upgrading.html#run-time, the access control module has changed and is now based on a generic module authz_core with a new and .
A new module called access_compat allow Apache 2.4 to read old authz_host directives, but is transitionary.
This PR intend to make this .htaccess works with Apache2 old and new, and the .htaccess configuration parsing to not crash, even without the access_compat module.