### PR TITLE
Ignore Visual Studio cache folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@
 /tests/clover.xml
 /tests/coverage
 /vendor/
+
+.vs/


### PR DESCRIPTION
For people using VS, this folder gets created anytime the folder is opened in the editor, would be convenient to ignore it in Git.