### PR TITLE
phpinfo() not always returns a proper body

### DIFF
--- a/app/Http/RequestHandlers/PhpInformation.php
+++ b/app/Http/RequestHandlers/PhpInformation.php
@@ -48,6 +48,7 @@ final class PhpInformation implements RequestHandlerInterface
         if (preg_match('%<body>(.*)</body>%s', $phpinfo, $matches)) {
             $phpinfo = $matches[1];
         } else {
+            // Some web hosts use custom PHP builds with a non-standard phpinfo()
             $phpinfo = '<pre>' . $phpinfo . '</pre>';
         }
 

--- a/app/Http/RequestHandlers/PhpInformation.php
+++ b/app/Http/RequestHandlers/PhpInformation.php
@@ -45,8 +45,11 @@ final class PhpInformation implements RequestHandlerInterface
         ob_start();
         phpinfo(INFO_ALL & ~INFO_CREDITS & ~INFO_LICENSE);
         $phpinfo = ob_get_clean();
-        preg_match('%<body>(.*)</body>%s', $phpinfo, $matches);
-        $phpinfo = $matches[1];
+        if (preg_match('%<body>(.*)</body>%s', $phpinfo, $matches)) {
+            $phpinfo = $matches[1];
+        } else {
+            $phpinfo = '<pre>' . $phpinfo . '</pre>';
+        }
 
         return $this->viewResponse('admin/server-information', [
             'title'   => I18N::translate('Server information'),


### PR DESCRIPTION
As [reported on the forum](https://www.webtrees.net/index.php/forum/webtrees-help-and-support/40529-server-information-returns-undefined-array-key-1#115441) the captured output of `phpinfo()` not always contains a body.
Then display the available output (tagged pre-formatted) instead of throwing error `Undefined array key 1`.