### PR TITLE
Adjust base CSSs and minimal theme to use Bootstrap variables

### DIFF
--- a/resources/css/_base.css
+++ b/resources/css/_base.css
@@ -159,7 +159,7 @@ a:hover, .btn-link:hover, .nav-link:hover {
 }
 
 .wt-icon-spinner {
-    color: lightgrey;
+    color: var(--bs-body-color);
     opacity: 0;
     animation: spinner-fade-in 0.5s ease-in forwards;
     animation-delay: 1s;

--- a/resources/css/_base.css
+++ b/resources/css/_base.css
@@ -159,7 +159,7 @@ a:hover, .btn-link:hover, .nav-link:hover {
 }
 
 .wt-icon-spinner {
-    color: var(--bs-body-color);
+    color: var(--bs-secondary-color);
     opacity: 0;
     animation: spinner-fade-in 0.5s ease-in forwards;
     animation-delay: 1s;

--- a/resources/css/_base.css
+++ b/resources/css/_base.css
@@ -87,7 +87,7 @@ a:hover {
 /* Accordions */
 .accordion-button,
 .accordion-button:not(.collapsed) {
-    background-color: rgba(0,0,0,.03);
+    background-color: var(--bs-tertiary-bg);
     color: currentcolor;
 }
 

--- a/resources/css/_base.css
+++ b/resources/css/_base.css
@@ -125,7 +125,7 @@ a:hover, .btn-link:hover, .nav-link:hover {
 .wt-nested-edit-fields {
     padding-left: 1rem;
     margin-left: 1rem;
-    border-left: solid 4px grey;
+    border-left: solid 4px var(--bs-border-color);
 }
 
 .wt-text-overflow-elipsis {

--- a/resources/css/_chart-interactive.css
+++ b/resources/css/_chart-interactive.css
@@ -22,13 +22,13 @@
 .tv_out {
     position: relative;
     overflow: hidden;
-    border: thin solid #CCCCCC; /* customizable */
+    border: thin solid var(--bs-border-color); /* customizable */
     /* The chart height can be adjusted to fill the pag */
     height: 50vh;
     resize: vertical;
     min-height: 25vh;
     max-height: 95vh;
-    background: #E6E6E6; /* customizable */
+    background: var(--bs-secondary-bg); /* customizable */
     display: -webkit-box;
     display: -moz-box;
     display: flex;
@@ -159,8 +159,8 @@ table#tvTreeBorder td,
 
 /* Person or couple(s) box style */
 #tv_tree div.tv_box {
-    border: thin outset #81A9CB; /* customizable */
-    background: #fffdfd; /* customizable */
+    border: thin outset var(--bs-tertiary-color); /* customizable */
+    background: transparent; /* customizable */
     margin-top: 2px;
     margin-bottom: 2px;
     padding: 0;
@@ -168,30 +168,16 @@ table#tvTreeBorder td,
     cursor: help; /* customizable */
     border-collapse: collapse; /* required */
     border-radius: 4px; /* customizable */
-    box-shadow: 1px 1px 2px #cfcfdf; /* customizable */
+    box-shadow: var(--bs-box-shadow-sm); /* customizable */
 }
 #tv_tree div.boxExpanded {
     width: 250px; /* customizable:initial expanded box width */
-}
-#tv_tree div.tv_box div.tvM {
-    background: #f5fdff; /* customizable */
-    color: #220000; /* customizable */
-}
-#tv_tree div.tv_box div.tvF {
-    background: #fff8f5; /* customizable */
-    color: #000022; /* customizable */
 }
 #tv_tree div.tv_box span.tvSexSymbol {
     font-weight: bold;
     font-family: x-large, serif; /*Arial Unicode MS, monospace; /* customizable, BUT test required for ALL browsers */
     vertical-align: top;
     margin: 1px;
-}
-#tv_tree div.tv_box span.tvM {
-    color: #8f8fdf; /* customizable */
-}
-#tv_tree div.tv_box span.tvF {
-    color: #df8f8f; /* customizable */
 }
 
 #tv_tree div.tv_box div.tvM,
@@ -246,10 +232,10 @@ table#tvTreeBorder td,
     padding: 0;
     margin: 0; /* required */
     z-index: 90; /* should be < 100 because 100 is the z-index of WT menus */
-    background-color: #efefef; /* customizable */
-    border: 1px outset #dfdfdf; /* customizable */
-    border-radius: 4px; /* customizable */
-    box-shadow: 1px 1px 2px #cfcfdf; /* customizable */
+    background-color: var(--bs-tertiary-bg); /* customizable */
+    border: var(--bs-border-width) outset var(--bs-border-color); /* customizable */
+    border-radius: var(--bs-border-radius-sm); /* customizable */
+    box-shadow: var(--bs-box-shadow-sm ); /* customizable */
 }
 
 /* styles submenu */
@@ -274,9 +260,8 @@ table#tvTreeBorder td,
     height: 24px;
     text-align: center;
     vertical-align: middle;
-    border: thin solid #efefef; /* customizable */
-    background-color: #efefef; /* customizable */
-    border-radius: 4px;
+    border: thin solid var(--bs-border-color); /* customizable */
+    border-radius: var(--bs-border-radius-sm);
 }
 #tvStylesSubmenu li.tv_button {
     float : none;
@@ -286,11 +271,11 @@ table#tvTreeBorder td,
     display: block;
 }
 #tv_tools li.tv_button:hover {
-    border: thin outset #fdfffd; /* customizable */
+    border: thin outset var(--bs-border-color); /* customizable */
     cursor: pointer;
 }
 #tv_tools li.tvPressed {
-    border: thin inset #ffffff; /* customizable */
+    border: thin inset var(--bs-border-color); /* customizable */
 }
 #tv_tools ul li img {
     border: none;
@@ -314,26 +299,26 @@ table#tvTreeBorder td,
     cursor: move;
     height: 22px;
     width: 2px;
-    border: thin inset #f6f6f6; /* customizable */
+    border: thin inset var(--bs-border-color); /* customizable */
     margin: 2px;
     overflow: hidden; /* required for IE */
 }
 
 #tvToolsHandler:hover {
-    border: thin outset #f6f6f6; /* customizable */
+    border: thin outset var(--bs-border-color); /* customizable */
 }
 
 
 #tv_tree div.tv_box div.tvM,
 #tv_tree div.tv_box div.tvF {
     background: none;
-    color: #000;
+    color: var(--bs-body-color);
     border: 0;
     margin: 0;
     padding: 0 4px;
 }
 
-.tvM {background-color: #DDF !important;}
-.tvF {background-color: #FDD !important;}
+.tvM {background-color: var(--bs-primary-bg-subtle) !important;}
+.tvF {background-color: var(--bs-danger-bg-subtle) !important;}
 
-.dashed {border-top: thin dashed #81A9CB !important;}
+.dashed {border-top: thin dashed var(--bs-secondary-color) !important;}

--- a/resources/css/_colorbox.css
+++ b/resources/css/_colorbox.css
@@ -65,15 +65,15 @@
 
 #cboxContent,
 #cboxOverlay {
-    background: #fff;
+    background: var(--bs-body-bg);
 }
 
 #cboxContent {
     overflow: hidden;
     position: relative;
     padding: 0.5rem;
-    border: 0.25rem solid #ccc;
-    border-radius: 0.5rem;
+    border: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color);
+    border-radius: var(--bs-border-radius-lg);
     box-sizing: content-box;
 }
 
@@ -93,7 +93,6 @@
 }
 
 #cboxTitle {
-    background: #fff;
     position: absolute;
     bottom: 0.25rem;
     margin: 0 2rem 0 4.5rem;
@@ -105,9 +104,10 @@
 }
 
 #cboxPrevious, #cboxNext, #cboxSlideshow, #cboxClose {
-    background: #eee;
+    background-color: transparent;
     border: 0;
-    border-radius: 0.5rem;
+    border-radius: var(--bs-border-radius);
+    color: var(--bs-emphasis-color);
     overflow: visible;
     padding: 0 0.5rem;
     position: absolute;

--- a/resources/css/_list-individuals.css
+++ b/resources/css/_list-individuals.css
@@ -46,6 +46,5 @@
 }
 
 .wt-initial.active {
-    color: #f00;
     font-weight: bold;
 }

--- a/resources/css/_on-screen-keyboard.css
+++ b/resources/css/_on-screen-keyboard.css
@@ -24,7 +24,6 @@
 }
 
 .wt-osk-keys {
-    background: #eee;
     padding: 0.25rem;
     font-size: larger;
 }
@@ -36,21 +35,22 @@
 }
 
 .wt-osk-key {
-    background: #ddd;
+    background: var(--bs-secondary-bg);
     border-radius: .25rem;
+    color: var(--bs-emphasis-color);
     padding: 0.25rem;
     cursor: pointer;
 }
 
 .wt-osk-key-shift {
-    color: #aaa;
+    color: var(--bs-secondary-color);
     font-size: smaller;
 }
 
 .wt-osk-keys.shifted .wt-osk-key {
-    color: #aaa;
+    color: var(--bs-secondary-color);
 }
 
 .wt-osk-keys.shifted .wt-osk-key-shift {
-    color: #555;
+    color: var(--bs-tertiary-color);
 }

--- a/resources/css/_vendor-patches.css
+++ b/resources/css/_vendor-patches.css
@@ -56,3 +56,8 @@ table.dataTable {
 table.datatables > thead > tr > th.dt-type-numeric {
     text-align: inherit;
 }
+
+/* Don't hardcode color in tom select control */
+.ts-control, .ts-control input, .ts-dropdown {
+    color: inherit;
+}

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -424,17 +424,11 @@ table {
 
 /* ==== FAQ table styles ===== */
 table.faq {
-    background-color: #ddd;
     margin: 5px 0 50px 5px;
     width: 98%;
 }
 
-table.faq tr:nth-child(odd) td {
-    background-color: #fff;
-}
-
 div.faq_title {
-    background-color: #ddd;
     margin: 1em 0;
     padding: .25em;
     font-weight: bold;

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -605,7 +605,7 @@ div.faq_body {
 }
 
 .optionbox, .descriptionbox {
-    border: solid #000 1px;
+    border: solid var(--bs-border-color) var(--bs-border-width);
     vertical-align: top;
     padding: 3px;
 }
@@ -626,8 +626,8 @@ div.faq_body {
 }
 
 .person0, .person1, .person2, .person3, .person4, .person5 {
-    border:outset #555 1px;
-    vertical-align:top;
+    border: outset var(--bs-border-color) var(--bs-border-width);
+    vertical-align: top;
 }
 .person0{
     background-color:#eee;
@@ -741,7 +741,7 @@ div.faq_body {
 
 .wt-calendar-month .wt-page-options-label,
 .wt-calendar-month .wt-page-options-value {
-    border: solid grey thin;
+    border: solid var(--bs-border-color) var(--bs-border-width);
     padding: 0.2rem;
 }
 

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -183,6 +183,7 @@ table {
 .wt-footer-contact {
 }
 
+/* Is this used? */
 .wt-footer-cookies {
     background: #aaa;
     color: #fff;
@@ -348,6 +349,7 @@ table {
     text-align: center;
 }
 
+/* Is this used? */
 /* ======== Block styles ===== */
 .block {
     background-color: #fff;

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -228,7 +228,7 @@ table {
 
 .wt-block-content .list_table {
     border-spacing: 1px;
-    border: solid #000 1px;
+    border: var(--bs-border-style) var(--bs-border-color) var(--bs-border-width);
     border-right: 0;
 }
 
@@ -281,31 +281,31 @@ table {
     height: 5rem;
     padding: 2px;
     line-height: 1.1;
-    border: solid gray thin;
+    border: var(--bs-border-style) var(--bs-border-color) var(--bs-border-width);
 }
 
 .wt-chart-box-f,
 .wt-chart-box-f .wt-chart-box-dropdown {
     background: var(--sex-f-bg);
-    border: solid var(--sex-f-fg) thin;
+    border: var(--bs-border-style) var(--sex-f-fg) var(--bs-border-width);
 }
 
 .wt-chart-box-m,
 .wt-chart-box-m .wt-chart-box-dropdown {
     background: var(--sex-m-bg);
-    border: solid var(--sex-m-fg) thin;
+    border: var(--bs-border-style) var(--sex-m-fg) var(--bs-border-width);
 }
 
 .wt-chart-box-u,
 .wt-chart-box-u .wt-chart-box-dropdown {
     background: var(--sex-u-bg);
-    border: solid var(--sex-u-fg) thin;
+    border: var(--bs-border-style) var(--sex-u-fg) var(--bs-border-width);
 }
 
 .wt-chart-box-x,
 .wt-chart-box-x .wt-chart-box-dropdown {
     background: var(--sex-x-bg);
-    border: solid var(--sex-x-fg) thin;
+    border: var(--bs-border-style) var(--sex-x-fg) var(--bs-border-width);
 }
 
 /* ---Pending edits--- */
@@ -352,7 +352,7 @@ table {
 .block {
     background-color: #fff;
     color: #555;
-    border: solid #ccc 1px;
+    border: var(--bs-border-style) var(--bs-border-color) var(--bs-border-width);
     padding: 3px;
     vertical-align: top;
 }
@@ -364,7 +364,7 @@ table {
 
 .blockcontent .list_table {
     border-spacing: 0;
-    border: solid #555 1px;
+    border: var(--bs-border-style) #555 1px;
     border-right: 0;
 }
 
@@ -594,7 +594,7 @@ div.faq_body {
 
 .wt-lifespans-summary {
     background: #ffffff;
-    border: thin solid #000;
+    border: thin var(--bs-border-style) #000;
     z-index: 1;
 }
 
@@ -608,7 +608,7 @@ div.faq_body {
 }
 
 .optionbox, .descriptionbox {
-    border: solid var(--bs-border-color) var(--bs-border-width);
+    border: var(--bs-border-style) var(--bs-border-color) var(--bs-border-width);
     vertical-align: top;
     padding: 3px;
 }
@@ -744,7 +744,7 @@ div.faq_body {
 
 .wt-calendar-month .wt-page-options-label,
 .wt-calendar-month .wt-page-options-value {
-    border: solid var(--bs-border-color) var(--bs-border-width);
+    border: var(--bs-border-style) var(--bs-border-color) var(--bs-border-width);
     padding: 0.2rem;
 }
 

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -81,12 +81,6 @@ table {
  *     +---wt-footer wt-footer-xxxxx
  */
 
-::backdrop, .wt-global {
-    /* Avoid extremes of black and white.  It is better for users with dyslexia. */
-    color: #0a0a0a;
-    background-color: #f9f9f9;
-}
-
 .wt-header-wrapper {
 }
 
@@ -148,7 +142,6 @@ table {
     /* Recalculate margins for content */
     margin: 0 calc(50% - 50vw);
     padding: 0 calc(50vw - 50%);
-    border-bottom: 2px solid #aaa;
 }
 
 .wt-genealogy-menu {
@@ -223,11 +216,9 @@ table {
  */
 
 .wt-block {
-    border: solid #000 1px;
 }
 
 .wt-block-header {
-    background-color: #fff;
 }
 
 .wt-block-content {
@@ -410,7 +401,6 @@ table {
 }
 
 .wt-facts-table th {
-    border: 1px solid #000;
     font-weight: normal;
 }
 
@@ -419,7 +409,6 @@ table {
 }
 
 .wt-facts-table td {
-    border: solid #000 1px;
 }
 
 .parentdeath {

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -591,8 +591,8 @@ div.faq_body {
 }
 
 .wt-lifespans-summary {
-    background: #ffffff;
-    border: thin var(--bs-border-style) #000;
+    background: var(--bs-secondary-bg);
+    border: var(--bs-border-style) var(--bs-border-color) var(--bs-border-width);
     z-index: 1;
 }
 

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -743,6 +743,10 @@ div.faq_body {
     padding: 0.2rem;
 }
 
+.wt-page-options-value {
+    padding: 0.2rem;
+}
+
 /* Forms */
 .col-form-label {
     font-weight: bold;

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -552,10 +552,12 @@ div.faq_body {
 
 /*-- Fan chart ---- */
 .fan_chart_menu {
-    background: #fff;
-    position: absolute;
-    display: none;
-    z-index: 100;
+	background: var(--bs-body-bg);
+	border: var(--bs-border-style) var(--bs-border-color) var(--bs-border-width);
+	border-radius: var(--bs-border-radius);
+	position: absolute;
+	display: none;
+	z-index: 100;
 }
 
 #fan_chart ul {

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -235,8 +235,9 @@ table {
 .wt-block-content .list_value,
 .wt-block-content .list_value_wrap {
     border: 0;
-    border-top: solid #000 1px;
-    border-right: solid #000 1px;
+    border-top: var(--bs-border-style) var(--bs-border-color) var(--bs-border-width);
+    border-right: var(--bs-border-style) var(--bs-border-color) var(--bs-border-width);
+    border-radius: var(--bs-border-radius);
 }
 
 /*
@@ -318,7 +319,9 @@ table {
 
 .list_value,
 .list_value_wrap {
-    border: solid #000 1px;
+    background: var(--bs-body-bg);
+    border: var(--bs-border-style) var(--bs-border-color) var(--bs-border-width);
+    border-radius: var(--bs-border-radius);
     vertical-align: top;
     padding: 4px;
 }
@@ -368,8 +371,8 @@ table {
 .blockcontent .list_value,
 .blockcontent .list_value_wrap {
     border: 0;
-    border-top: solid #555 1px;
-    border-right: solid #555 1px;
+    border-top: var(--bs-border-style) var(--bs-border-color) var(--bs-border-width);
+    border-right: var(--bs-border-style) var(--bs-border-color) var(--bs-border-width);
 }
 
 .blockheader {

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -17,20 +17,20 @@
 @import "_base.css";
 
 :root {
-    --chart-line-radius: 1rem;
-    --chart-line: solid gray thin;
-    --link-color-hover: #0a58ca;
-    --link-color: #0d6efd;
-    --link-decoration-hover: underline;
-    --link-decoration: underline;
-    --sex-f-bg: #ffffff;
-    --sex-f-fg: #888888;
-    --sex-m-bg: #ffffff;
-    --sex-m-fg: #888888;
-    --sex-u-bg: #ffffff;
-    --sex-u-fg: #888888;
-    --sex-x-bg: #ffffff;
-    --sex-x-fg: #888888;
+    --chart-line-radius: var(--bs-border-radius-xl);
+    --chart-line: solid var(--bs-dark-border-subtle) var(--bs-border-width);
+    --link-color-hover: var(--bs-link-hover-color);
+    --link-color: var(--bs-link-color);
+    --link-decoration-hover: var(--bs-link-decoration);
+    --link-decoration: var(--bs-link-decoration);
+    --sex-f-bg: var(--bs-body-bg);
+    --sex-f-fg: var(--bs-pink);
+    --sex-m-bg: var(--bs-body-bg);
+    --sex-m-fg: var(--bs-blue);
+    --sex-u-bg: var(--bs-body-bg);
+    --sex-u-fg: var(--bs-gray);
+    --sex-x-bg: var(--bs-body-bg);
+    --sex-x-fg: var(--bs-gray);
 }
 
 /* Override Bootstrap formatting */

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -632,28 +632,29 @@ div.faq_body {
     border: outset var(--bs-border-color) var(--bs-border-width);
     vertical-align: top;
 }
+
 .person0 {
-    background-color: var(--bs-secondary-bg);
+    background-color: var(--bs-primary-bg-subtle);
 }
 
 .person1 {
-    background-color: var(--bs-tertiary-bg);
+    background-color: var(--bs-secondary-bg-subtle);
 }
 
-.person2{
-    background-color:#999;
+.person2 {
+    background-color: var(--bs-success-bg-subtle);
 }
 
-.person3{
-    background-color:#dfdfdf;
+.person3 {
+    background-color: var(--bs-danger-bg-subtle);
 }
 
-.person4{
-    background-color:#eee;
+.person4 {
+    background-color: var(--bs-warning-bg-subtle);
 }
 
-.person5{
-    background-color:#fefefe;
+.person5 {
+    background-color: var(--bs-info-bg-subtle);
 }
 
 /*-- timeline  --*/

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -582,11 +582,9 @@ div.faq_body {
 }
 
 .wt-lifespans-individuals {
-    background: #fafafa;
 }
 
 .wt-lifespans-individual {
-
 }
 
 .wt-lifespans-summary {

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -279,26 +279,22 @@ table {
     border: var(--bs-border-style) var(--bs-border-color) var(--bs-border-width);
 }
 
-.wt-chart-box-f,
-.wt-chart-box-f .wt-chart-box-dropdown {
+.wt-chart-box-f {
     background: var(--sex-f-bg);
     border: var(--bs-border-style) var(--sex-f-fg) var(--bs-border-width);
 }
 
-.wt-chart-box-m,
-.wt-chart-box-m .wt-chart-box-dropdown {
+.wt-chart-box-m {
     background: var(--sex-m-bg);
     border: var(--bs-border-style) var(--sex-m-fg) var(--bs-border-width);
 }
 
-.wt-chart-box-u,
-.wt-chart-box-u .wt-chart-box-dropdown {
+.wt-chart-box-u {
     background: var(--sex-u-bg);
     border: var(--bs-border-style) var(--sex-u-fg) var(--bs-border-width);
 }
 
-.wt-chart-box-x,
-.wt-chart-box-x .wt-chart-box-dropdown {
+.wt-chart-box-x {
     background: var(--sex-x-bg);
     border: var(--bs-border-style) var(--sex-x-fg) var(--bs-border-width);
 }

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -183,13 +183,6 @@ table {
 .wt-footer-contact {
 }
 
-/* Is this used? */
-.wt-footer-cookies {
-    background: #aaa;
-    color: #fff;
-    transition: height 0.5s;
-}
-
 .wt-footer-page-views {
 }
 
@@ -349,40 +342,6 @@ table {
 #place-hierarchy h4 {
     text-align: center;
 }
-
-/* Is this used? */
-/* ======== Block styles ===== */
-.block {
-    background-color: #fff;
-    color: #555;
-    border: var(--bs-border-style) var(--bs-border-color) var(--bs-border-width);
-    padding: 3px;
-    vertical-align: top;
-}
-
-.blockcontent {
-    margin: 5px;
-    overflow: auto;
-}
-
-.blockcontent .list_table {
-    border-spacing: 0;
-    border: var(--bs-border-style) #555 1px;
-    border-right: 0;
-}
-
-.blockcontent .list_value,
-.blockcontent .list_value_wrap {
-    border: 0;
-    border-top: var(--bs-border-style) var(--bs-border-color) var(--bs-border-width);
-    border-right: var(--bs-border-style) var(--bs-border-color) var(--bs-border-width);
-}
-
-.blockheader {
-    font-weight: bold;
-}
-
-/* end Block styles */
 
 .user_welcome_block table,
 .gedcom_block_block table {

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -278,6 +278,7 @@ table {
  * +--- wt-chart-box-facts
  *     +--- wt-chart-box-fact
  */
+
 .wt-chart-box {
     height: 5rem;
     padding: 2px;
@@ -552,12 +553,12 @@ div.faq_body {
 
 /*-- Fan chart ---- */
 .fan_chart_menu {
-	background: var(--bs-body-bg);
-	border: var(--bs-border-style) var(--bs-border-color) var(--bs-border-width);
-	border-radius: var(--bs-border-radius);
-	position: absolute;
-	display: none;
-	z-index: 100;
+    background: var(--bs-body-bg);
+    border: var(--bs-border-style) var(--bs-border-color) var(--bs-border-width);
+    border-radius: var(--bs-border-radius);
+    position: absolute;
+    display: none;
+    z-index: 100;
 }
 
 #fan_chart ul {

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -627,12 +627,12 @@ div.faq_body {
     border: outset var(--bs-border-color) var(--bs-border-width);
     vertical-align: top;
 }
-.person0{
-    background-color:#eee;
+.person0 {
+    background-color: var(--bs-secondary-bg);
 }
 
-.person1{
-    background-color:#bfbfbf;
+.person1 {
+    background-color: var(--bs-tertiary-bg);
 }
 
 .person2{

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -476,10 +476,12 @@ div.faq_body {
 }
 
 .odometer {
-    font-family: courier, monospace;
-    font-weight: bold;
-    background: #000;
-    color: #fff;
+    font-family: var(--bs-font-monospace);
+    font-weight: var(--bs-font-weight-bold);
+    color: var(--bs-emphasis-color);
+    background-color: var(--bs-secondary-bg);
+    padding: 0.1rem 0.25rem;
+    border-radius: var(--bs-border-radius-sm);
 }
 
 .upcoming_events_block button,

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -82,6 +82,7 @@ table {
  */
 
 .wt-header-wrapper {
+    background: var(--bs-primary-bg-subtle);
 }
 
 .wt-header-container {
@@ -103,6 +104,7 @@ table {
     flex: 1 1 auto;
     width: auto;
     font-size: 1.75rem;
+    color: var(--bs-primary-text-emphasis);
 }
 
 .wt-header-search {

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -18,7 +18,7 @@
 
 :root {
     --chart-line-radius: var(--bs-border-radius-xl);
-    --chart-line: solid var(--bs-dark-border-subtle) var(--bs-border-width);
+    --chart-line: solid var(--bs-secondary-color) var(--bs-border-width);
     --link-color-hover: var(--bs-link-hover-color);
     --link-color: var(--bs-link-color);
     --link-decoration-hover: var(--bs-link-decoration);


### PR DESCRIPTION
* Adjust minimal theme (and other base CSS files) to use CSS variables from Bootstrap instead of hardcoded colors, radius, thickness etc.
* This makes the minimal theme usable with both light and dark bootstrap themes, as implemented in #5256
* Next step would be to implement light/dark switching in the minimal theme.
* To test dark mode, add this attribute to the html element: `data-bs-theme="dark"`

<img width="1145" height="1270" alt="light-start" src="https://github.com/user-attachments/assets/6e6990f7-0d17-429f-8234-5aa24d494158" />
<img width="1145" height="1270" alt="dark-start" src="https://github.com/user-attachments/assets/71c63bfb-4df4-442f-9ed0-6cd332ffc70b" />
<img width="1145" height="1270" alt="light-indi" src="https://github.com/user-attachments/assets/e4aebbb5-ae22-4b1c-8e00-00123eb4cc34" />
<img width="1145" height="1270" alt="dark-indi" src="https://github.com/user-attachments/assets/7efb2546-ebc4-4f8f-abb3-24d531db4348" />
