### PR TITLE
Fix rounded left corners on quick-search

### DIFF
--- a/resources/views/layouts/default.phtml
+++ b/resources/views/layouts/default.phtml
@@ -84,9 +84,9 @@ use Psr\Http\Message\ServerRequestInterface;
 
                         <div class="col wt-header-search">
                             <form method="post" action="<?= e(route(SearchQuickAction::class, ['tree' => $tree->name()])) ?>" class="wt-header-search-form" role="search">
-                                <div class="input-group">
-                                    <label class="visually-hidden" for="quick-search"><?= I18N::translate('Search') ?></label>
+                                <label class="visually-hidden" for="quick-search"><?= I18N::translate('Search') ?></label>
 
+                                <div class="input-group">
                                     <input type="search" class="form-control wt-header-search-field" id="quick-search" name="query" size="15" placeholder="<?= I18N::translate('Search') ?>">
 
                                     <button type="submit" class="btn btn-primary wt-header-search-button" aria-label="<?= I18N::translate('Search') ?>">


### PR DESCRIPTION
Move quick-search label outside of the input-group to make the input element the first, which makes sure that the bootstrap CSS corner-radius rule is applied.

Before:
<img width="245" height="43" alt="image" src="https://github.com/user-attachments/assets/438a2347-3950-4b49-acdd-4cb69a63ff2e" />

After:
<img width="250" height="42" alt="image" src="https://github.com/user-attachments/assets/d196eb7c-ea29-4f77-af70-ab0a0e02e962" />