### PR TITLE
fix #5340: before merging gather only xrefs of changes with status pending on originating tree

### DIFF
--- a/app/Services/AdminService.php
+++ b/app/Services/AdminService.php
@@ -64,6 +64,7 @@ class AdminService
     {
         $subquery1 = DB::table('change')
             ->where('gedcom_id', '=', $tree1->id())
+            ->where('status', '=', 'pending')
             ->select(['xref AS xref1'])
             ->union(DB::table('individuals')
                 ->where('i_file', '=', $tree1->id())


### PR DESCRIPTION
fixes #5340 

XREFs of changes with status accepted or rejected in the originating tree should not be queried for prior to a tree merge.
The merge itself does nothing with pending changes in the originating tree.

XREFs of pending changes could be useful to gather though. If these overlap, then the merge will ask to first execute renumbering this tree. Then renumbering won't execute while there are still pending changes:
https://github.com/fisharebest/webtrees/blob/main/app/Http/RequestHandlers/RenumberTreeAction.php#L59-L68

> You need to accept or reject all pending changes before proceeding.

With all changes being accepted or rejected, renumbering will take care of any colliding XREFs and there should be no issue with merging. 