### PR TITLE
Cache of places lacked tree id

### DIFF
--- a/app/Place.php
+++ b/app/Place.php
@@ -113,7 +113,7 @@ class Place
      */
     public function id(): int
     {
-        return Registry::cache()->array()->remember('place-' . $this->place_name, function (): int {
+        return Registry::cache()->array()->remember('place-' . $this->place_name . '@' . $this->tree->id(), function (): int {
             // The "top-level" place won't exist in the database.
             if ($this->parts->isEmpty()) {
                 return 0;


### PR DESCRIPTION
While researching [something else](https://github.com/fisharebest/webtrees/issues/2728) I discovered that the in-memory cache of places lacked the id of the tree in the key. Better put it there for safety.

This might have been the cause of (just a handful) records I found with links to similar places belonging to another tree.

```sql
select place.p_place as place_name,
       place.p_file as tree,
       parent.p_file as parent_tree
  from wt_places place
  join wt_places parent on parent.p_id = place.p_parent_id
 where place.p_parent_id > 0
   and place.p_file != parent.p_file;

select link.pl_gid as link_xref,
       link.pl_file as link_tree,
       place.p_file as place_tree,
       place.p_place as place_name
  from wt_placelinks link
  join wt_places place on link.pl_p_id = place.p_id
 where link.pl_file != place.p_file;
```