### PR TITLE
fix issue #5352: use Fact::sortFactTags to order the 'quick' fact buttons

### DIFF
--- a/resources/views/fact-add-new.phtml
+++ b/resources/views/fact-add-new.phtml
@@ -3,12 +3,14 @@
 declare(strict_types=1);
 
 use Fisharebest\Webtrees\Auth;
+use Fisharebest\Webtrees\Fact;
 use Fisharebest\Webtrees\Family;
 use Fisharebest\Webtrees\GedcomRecord;
 use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\Individual;
 use Fisharebest\Webtrees\Registry;
 use Fisharebest\Webtrees\Services\GedcomEditService;
+use Illuminate\Support\Collection;
 
 /**
  * @var GedcomRecord $record
@@ -23,6 +25,7 @@ $add_facts = (new GedcomEditService())->factsToAdd($record, false);
 switch ($record->tag()) {
     case Individual::RECORD_TYPE:
         $quick_facts  = array_filter(explode(',', $record->tree()->getPreference('INDI_FACTS_QUICK')));
+        $quick_facts = Fact::sortFactTags(Collection::make($quick_facts))->all();
         $unique_facts = [
             'ADOP',
             'AFN',
@@ -62,6 +65,7 @@ switch ($record->tag()) {
 
     case Family::RECORD_TYPE:
         $quick_facts  = array_filter(explode(',', $record->tree()->getPreference('FAM_FACTS_QUICK')));
+        $quick_facts = Fact::sortFactTags(Collection::make($quick_facts))->all();
         $unique_facts = [
             'DIV',
             'DIVF',


### PR DESCRIPTION
fixes #5352
Use the orphaned sorting function for the ordering of facts again.