### PR TITLE
Tint timeline background colors

### DIFF
--- a/resources/css/_chart-timeline.css
+++ b/resources/css/_chart-timeline.css
@@ -24,34 +24,39 @@
     left: 0;
 }
 
+.person0, .person1, .person2, .person3,
+.person4, .person5, .person6, .person7 {
+    --person-bg-alpha: 30%;
+}
+
 .person0 {
-    background-color: #ffb3ba;
+    background-color: color-mix(in srgb, var(--bs-red) var(--person-bg-alpha), transparent);
 }
 
 .person1 {
-    background-color: #ffd8ba;
+    background-color: color-mix(in srgb, var(--bs-orange) var(--person-bg-alpha), transparent);
 }
 
 .person2 {
-    background-color: #fff3ba;
+    background-color: color-mix(in srgb, var(--bs-yellow) var(--person-bg-alpha), transparent);
 }
 
 .person3 {
-    background-color: #d4ffba;
+    background-color: color-mix(in srgb, var(--bs-green) var(--person-bg-alpha), transparent);
 }
 
 .person4 {
-    background-color: #baffc9;
+    background-color: color-mix(in srgb, var(--bs-teal) var(--person-bg-alpha), transparent);
 }
 
 .person5 {
-    background-color: #bae1ff;
+    background-color: color-mix(in srgb, var(--bs-cyan) var(--person-bg-alpha), transparent);
 }
 
 .person6 {
-    background-color: #e2baff;
+    background-color: color-mix(in srgb, var(--bs-purple) var(--person-bg-alpha), transparent);
 }
 
 .person7 {
-    background-color: #ffbaf3;
+    background-color: color-mix(in srgb, var(--bs-pink) var(--person-bg-alpha), transparent);
 }

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -582,7 +582,7 @@ div.faq_body {
     bottom: 20px;
 }
 
-.person0, .person1, .person2, .person3, .person4, .person5 {
+.person0, .person1, .person2, .person3, .person4, .person5, .person6, .person7 {
     border: outset var(--bs-border-color) var(--bs-border-width);
     vertical-align: top;
 }


### PR DESCRIPTION
Use strong colors and tint them with the background. This makes timeline usable with the dark mode.

Also apply the same border style for person6 and person7 classes.

Before:
<img width="1127" height="679" alt="image" src="https://github.com/user-attachments/assets/f4ada894-c194-4433-aa51-f3d697328b96" />

After (dark):
<img width="1125" height="652" alt="image" src="https://github.com/user-attachments/assets/e1a79b23-e2f8-4ae7-9804-cef56223aefe" />

After (light):
<img width="1129" height="661" alt="image" src="https://github.com/user-attachments/assets/c1a3664f-6654-4bcf-a562-b3204026dc54" />
