### PR TITLE
Update league/commonmark from 2.8.0 to 2.8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "illuminate/database": "12.50.0",
         "illuminate/support": "12.50.0",
         "intervention/image": "3.11.6",
-        "league/commonmark": "2.8.0",
+        "league/commonmark": "2.8.2",
         "league/flysystem": "3.31.0",
         "league/flysystem-path-prefixing": "3.31.0",
         "league/flysystem-ziparchive": "3.31.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b32a4d43ca7fb9a712e6bf007f5dd47c",
+    "content-hash": "24328b3131ab174230c527df66587fb6",
     "packages": [
         {
             "name": "aura/router",
@@ -1792,16 +1792,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.0",
+            "version": "2.8.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "4efa10c1e56488e658d10adf7b7b7dcd19940bfb"
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/4efa10c1e56488e658d10adf7b7b7dcd19940bfb",
-                "reference": "4efa10c1e56488e658d10adf7b7b7dcd19940bfb",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
+                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
                 "shasum": ""
             },
             "require": {
@@ -1826,9 +1826,9 @@
                 "phpstan/phpstan": "^1.8.2",
                 "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
                 "scrutinizer/ocular": "^1.8.1",
-                "symfony/finder": "^5.3 | ^6.0 | ^7.0",
-                "symfony/process": "^5.4 | ^6.0 | ^7.0",
-                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0",
+                "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
+                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0 || ^8.0",
                 "unleashedtech/php-coding-standard": "^3.1.1",
                 "vimeo/psalm": "^4.24.0 || ^5.0.0 || ^6.0.0"
             },
@@ -1895,7 +1895,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-26T21:48:24+00:00"
+            "time": "2026-03-19T13:16:38+00:00"
         },
         {
             "name": "league/config",


### PR DESCRIPTION
## Summary

- Update `league/commonmark` from 2.8.0 to 2.8.2 to resolve security advisories
- Version 2.8.0 is affected by advisories `PKSA-21fb-n1x5-5nf7` and `PKSA-2cx9-ynrq-qdk3`
- Composer >= 2.7 blocks installation by default due to the `block-insecure` audit setting, making it impossible to install any webtrees 2.2.x version without manually overriding security checks
- Version 2.8.2 is a compatible patch release that resolves all advisories

## Problem

Since Composer 2.7, the default `audit.block-insecure` setting prevents installing packages with known security advisories. Because webtrees pins `league/commonmark` to exact versions, and all pinned versions (2.5.3, 2.7.1, 2.8.0) are affected, no version of webtrees 2.2.x can currently be installed with default Composer settings.

## Test plan

- [x] `composer update league/commonmark` succeeds
- [x] `composer audit` reports no security vulnerability advisories