### PR TITLE
Fix: tree CLI command cannot find existing trees

### DIFF
--- a/app/Cli/Commands/TreeEdit.php
+++ b/app/Cli/Commands/TreeEdit.php
@@ -73,7 +73,7 @@ final class TreeEdit extends AbstractCommand
             return Command::INVALID;
         }
 
-        $tree = $this->tree_service->all()->get('name');
+        $tree = $this->tree_service->all()->get($name);
 
         if ($create) {
             if ($tree instanceof Tree) {


### PR DESCRIPTION
## Problem

The `tree` CLI command's `--delete` and `--title` paths always fail with `[ERROR] Tree '<name>' does not exist.`, even for trees that demonstrably exist (visible in `tree-list`).

Cause: in `app/Cli/Commands/TreeEdit.php:76`, the tree is looked up using the literal string `'name'` as the collection key instead of the `$name` argument value:

```php
$tree = $this->tree_service->all()->get('name');
```

`$tree_service->all()` returns a Collection keyed by tree name, so `->get('name')` only matches a tree literally named `name` — for everyone else the lookup returns `null` and the command bails out.

## Fix

One-character change: use the variable.

```diff
-        $tree = $this->tree_service->all()->get('name');
+        $tree = $this->tree_service->all()->get($name);
```

## Reproduce on `main`

```sh
php index.php tree --create --title=Demo demo
php index.php tree-list                       # → demo is listed
php index.php tree --delete demo              # → [ERROR] Tree 'demo' does not exist.
php index.php tree --title="New title" demo   # → same error
```

After the fix both `--delete` and `--title` work as documented.

## Notes

- `tree --create` was unaffected because its happy path doesn't depend on the lookup result (it only checks that the lookup returns `null`, which it always did).
- Bug introduced in 37845cc210 ("Add CLI commands to create/edit/delete users and trees") — has been latent since the CLI tree-edit command was first added.