### PR TITLE
Fix & minor code improvement on Timeline chart

### DIFF
--- a/resources/views/modules/timeline-chart/chart.phtml
+++ b/resources/views/modules/timeline-chart/chart.phtml
@@ -38,9 +38,6 @@ use Fisharebest\Webtrees\Individual;
     let bheight = <?= json_encode($bheight, JSON_THROW_ON_ERROR) ?>;
     let scale = <?= json_encode($scale, JSON_THROW_ON_ERROR) ?>;
 
-    timeline_chart_div = document.getElementById("timeline_chart");
-    timeline_chart_div.style.height = '<?= json_encode(0 + ($topyear - $baseyear) * $scale * 1.1, JSON_THROW_ON_ERROR) ?>px';
-
     /**
      * Find the position of an event, relative to an element.
      *
@@ -252,7 +249,7 @@ use Fisharebest\Webtrees\Individual;
     }
 </script>
 
-<div id="timeline_chart">
+<div id="timeline_chart" style="height:<?= 0 + ($topyear - $baseyear) * $scale * 1.1 ?>px">
     <!-- print the timeline line image -->
     <div id="line" style="position:absolute; <?= I18N::direction() === 'ltr' ? 'left:22px;' : 'right:22px;' ?> top:0;">
         <img src="<?= e(asset('css/images/vline.png')) ?>" width="3"

--- a/resources/views/modules/timeline-chart/chart.phtml
+++ b/resources/views/modules/timeline-chart/chart.phtml
@@ -337,7 +337,7 @@ use Fisharebest\Webtrees\Individual;
         } else {
             $col = array_search($event->record(), $individuals, true);
         }
-        $col %= 6;
+        $col %= 8;
         echo '</td><td class="person' . $col . '">';
         if (count($individuals) > 6) {
             // We only have six colours, so show names if more than this number


### PR DESCRIPTION
There are actually 2 parts to this PR, and feel free to apply only the fix if you want:

- First a small bug in the Timeline chart whereby the events are not coloured based on the new 8 rotating colours, but still on the old 6 ones, creating a discrepancy between the colour of the person at the top, and the associated events when there are more than 6 persons.  See for instance [this example on the stable brach](https://dev.webtrees.net/demo-stable/index.php?route=%2Fdemo-stable%2Ftree%2Fdemo%2Ftimeline-10&xrefs%5B0%5D=i1&xrefs%5B1%5D=I10030&xrefs%5B2%5D=I10084&xrefs%5B3%5D=I10090&xrefs%5B4%5D=I10107&xrefs%5B5%5D=I10089&xrefs%5B6%5D=I10127&xrefs%5B7%5D=I10132) with King George V and Mary of Teck misaligned.

- The second one is the code improvement(?): whilst I was investigating an issue with the height in the timeline chart, eventually due to the issue fixed in 4f8c0f4, I have noticed that the height of the global chart is set in JS. Looks like a legacy implementation, as that height is not dependent on anything retrieved in JS, and fully determined by the PHP template variables, so I suggest to move it directly inline in HTML. It appears clearer to me, and would avoid any side effect from JS execution issues.