### PR TITLE
Divert to setup wizard's admin step when config.ini.php is pre-written

### DIFF
--- a/app/Http/Middleware/BootstrapAdminWizard.php
+++ b/app/Http/Middleware/BootstrapAdminWizard.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2026 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Fisharebest\Webtrees\Http\Middleware;
+
+use Fisharebest\Webtrees\Contracts\UserInterface;
+use Fisharebest\Webtrees\DB;
+use Fisharebest\Webtrees\Http\RequestHandlers\SetupWizard;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Throwable;
+
+/**
+ * When a deployment ships a pre-written config.ini.php (e.g. a container image
+ * that injects DB credentials from environment variables) but has not yet
+ * created an administrator account, the normal request pipeline can only
+ * respond with 404: every route assumes at least one user exists. This
+ * middleware diverts such requests to the setup wizard's administrator step,
+ * carrying the already-known database settings forward so the operator only
+ * has to fill in the admin account.
+ *
+ * Requires the schema migration to have run (the user table must exist); the
+ * surrounding pipeline guarantees this — UpdateDatabaseSchema runs before us.
+ */
+class BootstrapAdminWizard implements MiddlewareInterface
+{
+    public function __construct(
+        private readonly SetupWizard $setup_wizard,
+    ) {
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        // Only intervene when ReadConfigIni populated the request from
+        // config.ini.php — otherwise we are in a fresh install where the
+        // setup wizard is already the active handler.
+        if ($request->getAttribute('dbhost') === null) {
+            return $handler->handle($request);
+        }
+
+        if ($this->administratorExists()) {
+            return $handler->handle($request);
+        }
+
+        // Jump straight to the admin step. Pre-existing config.ini.php values
+        // travel as request attributes; SetupWizard::userData() picks them up
+        // as defaults so the hidden DB fields in step-5 are correctly seeded.
+        $body          = $request->getParsedBody();
+        $body          = is_array($body) ? $body : [];
+        $body['step']  = 5;
+
+        return $this->setup_wizard->handle($request->withParsedBody($body));
+    }
+
+    /**
+     * Returns true when at least one administrator account exists. Any
+     * database error (missing tables, lost connection) is treated as "yes" so
+     * the regular pipeline can surface the real failure instead of silently
+     * routing to the wizard.
+     */
+    private function administratorExists(): bool
+    {
+        try {
+            return DB::table('user_setting')
+                ->where('setting_name', '=', UserInterface::PREF_IS_ADMINISTRATOR)
+                ->where('setting_value', '=', '1')
+                ->exists();
+        } catch (Throwable) {
+            return true;
+        }
+    }
+}

--- a/app/Http/RequestHandlers/SetupWizard.php
+++ b/app/Http/RequestHandlers/SetupWizard.php
@@ -55,7 +55,7 @@ use function touch;
 use function unlink;
 use function view;
 
-final class SetupWizard implements RequestHandlerInterface
+class SetupWizard implements RequestHandlerInterface
 {
     use ViewResponseTrait;
 
@@ -79,6 +79,15 @@ final class SetupWizard implements RequestHandlerInterface
         'wtuser'   => '',
         'wtpass'   => '',
         'wtemail'  => '',
+    ];
+
+    /**
+     * Map form field names to config.ini.php key names where the two differ.
+     * The wizard's form uses `baseurl`; config.ini.php uses `base_url`. All
+     * other DB-related keys (dbhost, dbport, dbuser, …) share the same name.
+     */
+    private const array CONFIG_INI_KEYS = [
+        'baseurl' => 'base_url',
     ];
 
     private const array DEFAULT_PORTS = [
@@ -177,7 +186,15 @@ final class SetupWizard implements RequestHandlerInterface
         $data = [];
 
         foreach (self::DEFAULT_DATA as $key => $default) {
-            $data[$key] = Validator::parsedBody($request)->string($key, $default);
+            // Request attributes carry values from config.ini.php (set by the
+            // ReadConfigIni middleware). They act as fallback defaults when
+            // the POST body does not supply the same field — so an install
+            // diverted to the wizard from a pre-written config.ini.php
+            // arrives at step 5 with the DB fields already filled in.
+            $attribute = $request->getAttribute(self::CONFIG_INI_KEYS[$key] ?? $key);
+            $fallback  = is_string($attribute) ? $attribute : $default;
+
+            $data[$key] = Validator::parsedBody($request)->string($key, $fallback);
         }
 
         return $data;

--- a/app/Webtrees.php
+++ b/app/Webtrees.php
@@ -52,6 +52,7 @@ use Fisharebest\Webtrees\Http\Dispatcher;
 use Fisharebest\Webtrees\Http\Middleware\BadBotBlocker;
 use Fisharebest\Webtrees\Http\Middleware\BaseUrl;
 use Fisharebest\Webtrees\Http\Middleware\BootModules;
+use Fisharebest\Webtrees\Http\Middleware\BootstrapAdminWizard;
 use Fisharebest\Webtrees\Http\Middleware\CheckForMaintenanceMode;
 use Fisharebest\Webtrees\Http\Middleware\CheckForNewVersion;
 use Fisharebest\Webtrees\Http\Middleware\ClientIp;
@@ -162,6 +163,7 @@ class Webtrees
         UseDatabase::class,
         DebugLogger::class,
         UpdateDatabaseSchema::class,
+        BootstrapAdminWizard::class,
         UseSession::class,
         UseLanguage::class,
         CheckForMaintenanceMode::class,

--- a/tests/app/Http/Middleware/BootstrapAdminWizardTest.php
+++ b/tests/app/Http/Middleware/BootstrapAdminWizardTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/**
+ * webtrees: online genealogy
+ * Copyright (C) 2026 webtrees development team
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Fisharebest\Webtrees\Http\Middleware;
+
+use Fisharebest\Webtrees\Contracts\UserInterface;
+use Fisharebest\Webtrees\Http\RequestHandlers\SetupWizard;
+use Fisharebest\Webtrees\Services\UserService;
+use Fisharebest\Webtrees\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+use function response;
+
+#[CoversClass(BootstrapAdminWizard::class)]
+class BootstrapAdminWizardTest extends TestCase
+{
+    protected static bool $uses_database = true;
+
+    /**
+     * Without a dbhost request attribute the middleware must not intervene.
+     * That attribute is set by the ReadConfigIni middleware only when
+     * config.ini.php exists; its absence means we are in a fresh install
+     * where the setup wizard is already routed by ReadConfigIni itself.
+     */
+    public function testPassThroughWhenNoConfigIniLoaded(): void
+    {
+        $expected = response('handler ran');
+        $handler  = self::createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($expected);
+
+        $request    = self::createRequest();
+        $wizard     = self::createStub(SetupWizard::class);
+        $middleware = new BootstrapAdminWizard($wizard);
+
+        $response = $middleware->process($request, $handler);
+
+        self::assertSame('handler ran', (string) $response->getBody());
+    }
+
+    /**
+     * config.ini.php is present and an administrator already exists — the
+     * regular handler stack must run unchanged.
+     */
+    public function testPassThroughWhenAdministratorExists(): void
+    {
+        (new UserService())
+            ->create('admin', 'Admin', 'admin@example.test', 'secret')
+            ->setPreference(UserInterface::PREF_IS_ADMINISTRATOR, '1');
+
+        $expected = response('handler ran');
+        $handler  = self::createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($expected);
+
+        $request    = self::createRequest()->withAttribute('dbhost', 'localhost');
+        $wizard     = self::createStub(SetupWizard::class);
+        $middleware = new BootstrapAdminWizard($wizard);
+
+        $response = $middleware->process($request, $handler);
+
+        self::assertSame('handler ran', (string) $response->getBody());
+    }
+
+    /**
+     * config.ini.php is present but the user table is empty — the middleware
+     * must hand the request to the setup wizard so the operator can finish
+     * the install by filling in only the admin account.
+     */
+    public function testDivertToSetupWizardWhenAdministratorMissing(): void
+    {
+        $expected = response('wizard ran');
+        $wizard   = self::createMock(SetupWizard::class);
+        $wizard->expects(self::once())
+            ->method('handle')
+            ->willReturnCallback(function ($request) use ($expected): ResponseInterface {
+                $body = $request->getParsedBody();
+
+                self::assertIsArray($body);
+                self::assertSame(5, $body['step']);
+
+                return $expected;
+            });
+
+        $handler = self::createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn(response('handler ran'));
+
+        $request    = self::createRequest()->withAttribute('dbhost', 'localhost');
+        $middleware = new BootstrapAdminWizard($wizard);
+
+        $response = $middleware->process($request, $handler);
+
+        self::assertSame('wizard ran', (string) $response->getBody());
+    }
+
+    /**
+     * A non-administrator user (e.g. a moderator left behind after deleting
+     * the admin account) must not count: the middleware still diverts to the
+     * wizard so the install completes cleanly.
+     */
+    public function testDivertWhenOnlyNonAdministratorsExist(): void
+    {
+        (new UserService())
+            ->create('user', 'User', 'user@example.test', 'secret');
+        // No PREF_IS_ADMINISTRATOR preference set.
+
+        $expected = response('wizard ran');
+        $wizard   = self::createStub(SetupWizard::class);
+        $wizard->method('handle')->willReturn($expected);
+
+        $handler = self::createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn(response('handler ran'));
+
+        $request    = self::createRequest()->withAttribute('dbhost', 'localhost');
+        $middleware = new BootstrapAdminWizard($wizard);
+
+        $response = $middleware->process($request, $handler);
+
+        self::assertSame('wizard ran', (string) $response->getBody());
+    }
+}

--- a/tests/app/Http/RequestHandlers/SetupWizardTest.php
+++ b/tests/app/Http/RequestHandlers/SetupWizardTest.php
@@ -19,8 +19,14 @@ declare(strict_types=1);
 
 namespace Fisharebest\Webtrees\Http\RequestHandlers;
 
+use Fisharebest\Webtrees\Services\MigrationService;
+use Fisharebest\Webtrees\Services\ModuleService;
+use Fisharebest\Webtrees\Services\PhpService;
+use Fisharebest\Webtrees\Services\ServerCheckService;
+use Fisharebest\Webtrees\Services\UserService;
 use Fisharebest\Webtrees\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use ReflectionMethod;
 
 #[CoversClass(SetupWizard::class)]
 class SetupWizardTest extends TestCase
@@ -28,5 +34,45 @@ class SetupWizardTest extends TestCase
     public function testClass(): void
     {
         self::assertTrue(class_exists(SetupWizard::class));
+    }
+
+    /**
+     * userData() must prefer the POST body, then fall back to request
+     * attributes (carrying values that ReadConfigIni loaded from
+     * config.ini.php), then to the hard-coded defaults. The form field
+     * `baseurl` reads from the config.ini.php key `base_url`; all other DB
+     * keys share the same name in both representations.
+     */
+    public function testUserDataPrefersBodyThenAttributesThenDefaults(): void
+    {
+        $wizard = new SetupWizard(
+            self::createStub(MigrationService::class),
+            self::createStub(ModuleService::class),
+            self::createStub(PhpService::class),
+            self::createStub(ServerCheckService::class),
+            self::createStub(UserService::class),
+        );
+
+        $request = self::createRequest(
+            params: [
+                'dbhost' => 'body-host',
+            ],
+        )
+            ->withAttribute('dbhost', 'attr-host')
+            ->withAttribute('dbuser', 'attr-user')
+            ->withAttribute('base_url', 'https://example.test');
+
+        $method = new ReflectionMethod($wizard, 'userData');
+        $data   = $method->invoke($wizard, $request);
+
+        // POST body wins.
+        self::assertSame('body-host', $data['dbhost']);
+        // Attribute fills in where the body is silent.
+        self::assertSame('attr-user', $data['dbuser']);
+        // baseurl form field maps to base_url config.ini.php key.
+        self::assertSame('https://example.test', $data['baseurl']);
+        // Untouched fields fall back to the hard-coded defaults.
+        self::assertSame('', $data['dbpass']);
+        self::assertSame('wt_', $data['tblpfx']);
     }
 }


### PR DESCRIPTION
## Problem

Headless and containerised installs (Docker images that inject DB credentials via environment variables, for example) typically ship a pre-written `config.ini.php`. With `config.ini.php` in place, the existing `ReadConfigIni` middleware bypasses the setup wizard entirely, so an install that has not yet created an administrator account responds `404` to every route — there is no admin to authenticate, no tree to show, and the wizard is unreachable because the config file already exists.

The operator has no way out short of deleting `config.ini.php` and retyping the DB credentials they already provided through the environment.

## Change

A new `BootstrapAdminWizard` middleware runs immediately after `UpdateDatabaseSchema`. When `config.ini.php` was loaded (a `dbhost` attribute is present on the request) and the `user` table contains no administrator, it diverts the request to the wizard's administrator step (step 5).

`SetupWizard::userData()` now also reads request attributes as fallback defaults, so the hidden DB fields in step 5 are seeded from `config.ini.php` and step 6 can finish the install without asking the operator to retype credentials they already provided through the environment.

`SetupWizard` is unsealed (`final` → open) so the new middleware test can substitute it with a stub. Routing pipelines keep working unchanged otherwise:

- Fresh install, no `config.ini.php` → routed to step 1 by `ReadConfigIni` (unchanged).
- Install with populated user table → no behaviour change.
- Install with `config.ini.php` but no admin → now routes to step 5 instead of a blanket `404`.

## Tests

- `BootstrapAdminWizardTest`: four behavioural cases (pass-through without `dbhost` attribute, pass-through when admin exists, divert to wizard when admin missing, divert when only non-admin users exist).
- `SetupWizardTest`: covers the new `userData()` fallback precedence (body → request attribute → hard-coded default).

Targeted `tests/app/Http/` run: 478 / 478 green.

## Compatibility

No schema changes, no config file changes, no removed APIs. The only API-shape change is `SetupWizard` losing its `final` modifier; downstream subclassing is not encouraged but the existing surface stays identical.