### PR TITLE
Enhancement: installed custom modules statistics, include installed modules in the latest-version check

### DIFF
--- a/app/Services/UpgradeService.php
+++ b/app/Services/UpgradeService.php
@@ -80,6 +80,7 @@ class UpgradeService
 
     public function __construct(
         private readonly TimeoutService $timeout_service,
+        private readonly ModuleService $module_service,
     ) {
     }
 
@@ -356,6 +357,7 @@ class UpgradeService
             'p' => PHP_VERSION,
             's' => $site_uuid,
             'd' => DB::driverName(),
+            'm' => $this->module_service->all()->map(static fn ($module) => $module->name())->implode(','),
         ];
     }
 }

--- a/tests/app/Http/RequestHandlers/ControlPanelControllerTest.php
+++ b/tests/app/Http/RequestHandlers/ControlPanelControllerTest.php
@@ -50,7 +50,7 @@ class ControlPanelControllerTest extends TestCase
         $timeout_service       = new TimeoutService(php_service: new PhpService());
         $gedcom_import_service = new GedcomImportService();
         $tree_service          = new TreeService($gedcom_import_service);
-        $upgrade_service       = new UpgradeService($timeout_service);
+        $upgrade_service       = new UpgradeService($timeout_service, $module_service);
         $user_service          = new UserService();
         $handler               = new ControlPanel(
             $admin_service,

--- a/tests/app/Http/RequestHandlers/UpgradeWizardPageTest.php
+++ b/tests/app/Http/RequestHandlers/UpgradeWizardPageTest.php
@@ -21,6 +21,7 @@ namespace Fisharebest\Webtrees\Http\RequestHandlers;
 
 use Fig\Http\Message\StatusCodeInterface;
 use Fisharebest\Webtrees\Services\GedcomImportService;
+use Fisharebest\Webtrees\Services\ModuleService;
 use Fisharebest\Webtrees\Services\PhpService;
 use Fisharebest\Webtrees\Services\TimeoutService;
 use Fisharebest\Webtrees\Services\TreeService;
@@ -36,9 +37,10 @@ class UpgradeWizardPageTest extends TestCase
     public function testWizard(): void
     {
         $timeout_service       = new TimeoutService(php_service: new PhpService());
+        $module_service        = new ModuleService();
         $gedcom_import_service = new GedcomImportService();
         $tree_service          = new TreeService($gedcom_import_service);
-        $upgrade_service       = new UpgradeService($timeout_service);
+        $upgrade_service       = new UpgradeService($timeout_service, $module_service);
         $handler               = new UpgradeWizardPage($tree_service, $upgrade_service);
         $request               = self::createRequest();
         $response              = $handler->handle($request);

--- a/tests/app/Http/RequestHandlers/UpgradeWizardStepTest.php
+++ b/tests/app/Http/RequestHandlers/UpgradeWizardStepTest.php
@@ -27,6 +27,7 @@ use Fisharebest\Webtrees\Http\Exceptions\HttpServerErrorException;
 use Fisharebest\Webtrees\Services\GedcomExportService;
 use Fisharebest\Webtrees\Services\GedcomImportService;
 use Fisharebest\Webtrees\Services\MaintenanceModeService;
+use Fisharebest\Webtrees\Services\ModuleService;
 use Fisharebest\Webtrees\Services\PendingChangesService;
 use Fisharebest\Webtrees\Services\PhpService;
 use Fisharebest\Webtrees\Services\TimeoutService;
@@ -50,7 +51,7 @@ class UpgradeWizardStepTest extends TestCase
             new MaintenanceModeService(__DIR__ . '/../../../data/'),
             new PendingChangesService(new GedcomImportService()),
             new TreeService(new GedcomImportService()),
-            new UpgradeService(new TimeoutService(php_service: new PhpService())),
+            new UpgradeService(new TimeoutService(php_service: new PhpService()), new ModuleService()),
         );
 
         $request = self::createRequest(RequestMethodInterface::METHOD_POST, ['step' => 'Invalid']);
@@ -121,7 +122,7 @@ class UpgradeWizardStepTest extends TestCase
             new MaintenanceModeService(__DIR__ . '/../../../data/'),
             new PendingChangesService(new GedcomImportService()),
             new TreeService(new GedcomImportService()),
-            new UpgradeService(new TimeoutService(php_service: new PhpService()))
+            new UpgradeService(new TimeoutService(php_service: new PhpService()), new ModuleService())
         );
 
         $request  = self::createRequest(RequestMethodInterface::METHOD_POST, ['step' => 'Prepare']);
@@ -137,7 +138,7 @@ class UpgradeWizardStepTest extends TestCase
             new MaintenanceModeService(__DIR__ . '/../../../data/'),
             new PendingChangesService(new GedcomImportService()),
             new TreeService(new GedcomImportService()),
-            new UpgradeService(new TimeoutService(php_service: new PhpService()))
+            new UpgradeService(new TimeoutService(php_service: new PhpService()), new ModuleService())
         );
 
         $request  = self::createRequest(RequestMethodInterface::METHOD_POST, ['step' => 'Pending']);
@@ -160,7 +161,7 @@ class UpgradeWizardStepTest extends TestCase
             new MaintenanceModeService(__DIR__ . '/../../../data/'),
             new PendingChangesService(new GedcomImportService()),
             new TreeService(new GedcomImportService()),
-            new UpgradeService(new TimeoutService(php_service: new PhpService()))
+            new UpgradeService(new TimeoutService(php_service: new PhpService()), new ModuleService())
         );
 
         $request = self::createRequest(RequestMethodInterface::METHOD_POST, ['step' => 'Pending']);
@@ -181,7 +182,7 @@ class UpgradeWizardStepTest extends TestCase
             new MaintenanceModeService(__DIR__ . '/../../../data/'),
             new PendingChangesService(new GedcomImportService()),
             $tree_service,
-            new UpgradeService(new TimeoutService(php_service: new PhpService()))
+            new UpgradeService(new TimeoutService(php_service: new PhpService()), new ModuleService())
         );
 
         $request  = self::createRequest()->withQueryParams(['step' => 'Export', 'tree' => $tree->name()]);


### PR DESCRIPTION
Currently, the latest-version.txt request for version check transmits basic data for statistics like PHP version, database type, and webtrees version. I propose to include a list of installed modules.

This would help to track the popularity of custom modules-ons and ultimately to improve the understanding of the ecosystem.

This would address and close my enhancement proposal #5377 .