### PR TITLE
access to calendar menu restricted to members by default

### DIFF
--- a/app/Date.php
+++ b/app/Date.php
@@ -21,6 +21,9 @@ namespace Fisharebest\Webtrees;
 
 use Fisharebest\ExtCalendar\GregorianCalendar;
 use Fisharebest\Webtrees\Date\AbstractCalendarDate;
+use Fisharebest\Webtrees\Module\CalendarMenuModule;
+use Fisharebest\Webtrees\Module\ModuleMenuInterface;
+use Fisharebest\Webtrees\Services\ModuleService;
 
 /**
  * A representation of GEDCOM dates and date ranges.
@@ -100,12 +103,17 @@ class Date
      */
     public function display(Tree|null $tree = null, string|null $date_format = null, bool $convert_calendars = false): string
     {
+        $link_to_calendar = false;
         if ($tree instanceof Tree) {
-            $CALENDAR_FORMAT = $tree->getPreference('CALENDAR_FORMAT');
-        } else {
-            $CALENDAR_FORMAT = 'none';
+            $module = Registry::container()->get(ModuleService::class)
+                ->findByComponent(ModuleMenuInterface::class, $tree, Auth::user())
+                ->first(static fn (ModuleMenuInterface $module): bool => $module instanceof CalendarMenuModule);
+            if ($module instanceof CalendarMenuModule) {
+                $link_to_calendar = true;
+            }
         }
 
+        $CALENDAR_FORMAT = ($tree instanceof Tree) ? $tree->getPreference('CALENDAR_FORMAT') : 'none';
         $date_format ??= I18N::dateFormat();
 
         if ($convert_calendars) {
@@ -123,7 +131,7 @@ class Date
         } else {
             $d2 = $this->date2->format($date_format, $this->qual2);
         }
-        // Con vert to other calendars, if requested
+        // Convert to other calendars, if requested
         $conv1 = '';
         $conv2 = '';
         foreach ($calendar_format as $cal_fmt) {
@@ -149,9 +157,9 @@ class Date
                 if ($d1 !== $d1tmp && $d1tmp !== '') {
                     if ($tree instanceof Tree) {
                         if ($CALENDAR_FORMAT !== 'none') {
-                            $conv1 .= ' <span dir="' . I18N::direction() . '">(<a href="' . e($d1conv->calendarUrl($date_format, $tree)) . '" rel="nofollow">' . $d1tmp . '</a>)</span>';
+                            $conv1 .= ' <span dir="' . I18N::direction() . '">(' . $this->renderLink($link_to_calendar, $d1conv, $date_format, $tree, $d1tmp) . ')</span>';
                         } else {
-                            $conv1 .= ' <span dir="' . I18N::direction() . '"><br><a href="' . e($d1conv->calendarUrl($date_format, $tree)) . '" rel="nofollow">' . $d1tmp . '</a></span>';
+                            $conv1 .= ' <span dir="' . I18N::direction() . '"><br>' . $this->renderLink($link_to_calendar, $d1conv, $date_format, $tree, $d1tmp) . '</span>';
                         }
                     } else {
                         $conv1 .= ' <span dir="' . I18N::direction() . '">(' . $d1tmp . ')</span>';
@@ -159,7 +167,7 @@ class Date
                 }
                 if ($this->date2 !== null && $d2 !== $d2tmp && $d1tmp !== '') {
                     if ($tree instanceof Tree) {
-                        $conv2 .= ' <span dir="' . I18N::direction() . '">(<a href="' . e($d2conv->calendarUrl($date_format, $tree)) . '" rel="nofollow">' . $d2tmp . '</a>)</span>';
+                        $conv2 .= ' <span dir="' . I18N::direction() . '">(' . $this->renderLink($link_to_calendar, $d2conv, $date_format, $tree, $d2tmp) . ')</span>';
                     } else {
                         $conv2 .= ' <span dir="' . I18N::direction() . '">(' . $d2tmp . ')</span>';
                     }
@@ -169,9 +177,9 @@ class Date
 
         // Add URLs, if requested
         if ($tree instanceof Tree) {
-            $d1 = '<a href="' . e($this->date1->calendarUrl($date_format, $tree)) . '" rel="nofollow">' . $d1 . '</a>';
+            $d1 = $this->renderLink($link_to_calendar, $this->date1, $date_format, $tree, $d1);
             if ($this->date2 instanceof AbstractCalendarDate) {
-                $d2 = '<a href="' . e($this->date2->calendarUrl($date_format, $tree)) . '" rel="nofollow">' . $d2 . '</a>';
+                $d2 = $this->renderLink($link_to_calendar, $this->date2, $date_format, $tree, $d2);
             }
         }
 
@@ -233,6 +241,11 @@ class Date
         }
 
         return '<span class="date">' . $tmp . '</span>';
+    }
+
+    private function renderLink(bool $link_to_calendar, AbstractCalendarDate $calendar_date, string $date_format, Tree $tree, string $date_text): string
+    {
+        return !$link_to_calendar ? $date_text : '<a href="' . e($calendar_date->calendarUrl($date_format, $tree)) . '" rel="nofollow">' . $date_text . '</a>';
     }
 
     /**

--- a/app/Http/RequestHandlers/CalendarPage.php
+++ b/app/Http/RequestHandlers/CalendarPage.php
@@ -19,10 +19,13 @@ declare(strict_types=1);
 
 namespace Fisharebest\Webtrees\Http\RequestHandlers;
 
+use Fisharebest\Webtrees\Auth;
 use Fisharebest\Webtrees\Date;
 use Fisharebest\Webtrees\Http\ViewResponseTrait;
 use Fisharebest\Webtrees\I18N;
+use Fisharebest\Webtrees\Module\ModuleMenuInterface;
 use Fisharebest\Webtrees\Services\CalendarService;
+use Fisharebest\Webtrees\Services\ModuleService;
 use Fisharebest\Webtrees\Validator;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -33,6 +36,7 @@ final class CalendarPage implements RequestHandlerInterface
     use ViewResponseTrait;
 
     public function __construct(
+        private readonly ModuleService $module_service,
         private readonly CalendarService $calendar_service,
     ) {
     }
@@ -40,6 +44,10 @@ final class CalendarPage implements RequestHandlerInterface
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $tree     = Validator::attributes($request)->tree();
+        $user     = Validator::attributes($request)->user();
+        $module   = $this->module_service->findByName('calendar-menu');
+        Auth::checkComponentAccess($module, ModuleMenuInterface::class, $tree, $user);
+
         $view     = Validator::attributes($request)->isInArray(['day', 'month', 'year'])->string('view');
         $cal      = Validator::queryParams($request)->string('cal', '');
         $day      = Validator::queryParams($request)->string('day', '');

--- a/app/Module/CalendarMenuModule.php
+++ b/app/Module/CalendarMenuModule.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace Fisharebest\Webtrees\Module;
 
+use Fisharebest\Webtrees\Auth;
 use Fisharebest\Webtrees\Http\RequestHandlers\CalendarPage;
 use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\Menu;
@@ -30,6 +31,9 @@ use Fisharebest\Webtrees\Tree;
 class CalendarMenuModule extends AbstractModule implements ModuleMenuInterface
 {
     use ModuleMenuTrait;
+
+    /** @var int The default access level for this module.  It can be changed in the control panel. */
+    protected int $access_level = Auth::PRIV_USER;
 
     public function title(): string
     {


### PR DESCRIPTION
We know that the calendar page in webtrees can work as a tarpit for bots, and imho it will be a matter of time before bots will find a way to break through the defense in our BadBotChecker.

As a preparation the following is changed with this PR:

* The default access level of the `CalendarMenuModule` is changed from visitor to member, so visitors do not get a link to the Calendar in the main menu. Administrators can explicitly grant access to visitors via the Control Panel if they want.
* The `Date` class only renders links to the calendar page when the current user has access to the calendar module.
* The `CalendarPage` itself checks access for the current user to the calendar module, in order to not rely on availability of a link.

These changes should definitely close the calendar tarpit for unauthenticated users.