### PR TITLE
add config option to bypass BAD_ROBOTS list of user agents 

### DIFF
--- a/app/Http/Middleware/BadBotBlocker.php
+++ b/app/Http/Middleware/BadBotBlocker.php
@@ -1535,9 +1535,12 @@ class BadBotBlocker implements MiddlewareInterface
             return $this->response('Not acceptable: no-ua');
         }
 
-        foreach (self::BAD_ROBOTS as $robot) {
-            if (str_contains($ua, $robot)) {
-                return $this->response('Not acceptable: bad-ua');
+        $allow_ua = Validator::attributes($request)->string('allow_ua', '');
+        if (array_filter(explode(',', $allow_ua), static fn (string $x): bool => str_contains($ua, trim($x))) === []) {
+            foreach (self::BAD_ROBOTS as $robot) {
+                if (str_contains($ua, $robot)) {
+                    return $this->response('Not acceptable: bad-ua');
+                }
             }
         }
 


### PR DESCRIPTION
Since the last release the `$BAD_ROBOTS` list (partial user agent strings) in `BadBotBlocker` is vastly extended.
Administrators do not have the ability yet to configure which of these bots they explicitly want or need to allow.

With this PR an entry `allow_ua` can be added in `config.ini.php` for allowing otherwise blocked robots.
The list is comma separated, entries are trimmed for spaces but case sensitive, eg:
```
allow_ua="Baiduspider, BingPreview, facebookexternalhit, Google-InspectionTool, SeznamBot, Uptime-Kuma, Yandex"
```

If this is merged and released, this option needs to be documented in https://webtrees.net/admin/block/

this fixes issue #5376