### PR TITLE
better handling of bad requests

### DIFF
--- a/app/Http/Middleware/HandleExceptions.php
+++ b/app/Http/Middleware/HandleExceptions.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace Fisharebest\Webtrees\Http\Middleware;
 
+use Error;
 use Fig\Http\Message\RequestMethodInterface;
 use Fig\Http\Message\StatusCodeInterface;
 use Fisharebest\Webtrees\Http\Exceptions\HttpException;
@@ -143,10 +144,14 @@ class HandleExceptions implements MiddlewareInterface, StatusCodeInterface
      */
     private function httpExceptionResponse(ServerRequestInterface $request, HttpException $exception): ResponseInterface
     {
-        $tree    = Validator::attributes($request)->treeOptional();
-        $default = Site::getPreference('DEFAULT_GEDCOM');
-        $tree    ??= $this->tree_service->all()[$default] ?? $this->tree_service->all()->first();
-
+        $tree = Validator::attributes($request)->treeOptional();
+        try {
+            $default = Site::getPreference('DEFAULT_GEDCOM');
+            $tree ??= $this->tree_service->all()[$default] ?? $this->tree_service->all()->first();
+        } catch (Error) {
+            // httpException can be thrown before database connection is made: return a simple stack trace dump
+            return response(nl2br((string) $exception), $exception->getCode());
+        }
         $status_code = $exception->getCode();
 
         // If this was a GET request, then we were probably fetching HTML to display, for

--- a/app/Validator.php
+++ b/app/Validator.php
@@ -260,7 +260,7 @@ class Validator
         }
 
         if ($default === null) {
-            throw new HttpBadRequestException(I18N::translate('The parameter “%s” is missing.', $parameter));
+            throw $this->newBadRequestException($parameter);
         }
 
         return $default;
@@ -276,7 +276,7 @@ class Validator
         $value = $this->parameters[$parameter] ?? null;
 
         if (!is_array($value) && $value !== null) {
-            throw new HttpBadRequestException(I18N::translate('The parameter “%s” is missing.', $parameter));
+            throw $this->newBadRequestException($parameter);
         }
 
         $callback = static fn (array|null $value, Closure $rule): array|null => $rule($value);
@@ -305,7 +305,7 @@ class Validator
         $value = array_reduce($this->rules, $callback, $value) ?? $default;
 
         if ($value === null) {
-            throw new HttpBadRequestException(I18N::translate('The parameter “%s” is missing.', $parameter));
+            throw $this->newBadRequestException($parameter);
         }
 
         return $value;
@@ -338,7 +338,7 @@ class Validator
         $value = array_reduce($this->rules, $callback, $value) ?? $default;
 
         if ($value === null) {
-            throw new HttpBadRequestException(I18N::translate('The parameter “%s” is missing.', $parameter));
+            throw $this->newBadRequestException($parameter);
         }
 
         return $value;
@@ -357,7 +357,7 @@ class Validator
             return $value;
         }
 
-        throw new HttpBadRequestException(I18N::translate('The parameter “%s” is missing.', $parameter));
+        throw $this->newBadRequestException($parameter);
     }
 
     /**
@@ -379,7 +379,7 @@ class Validator
         $value =  array_reduce($this->rules, $callback, $value) ?? $default;
 
         if ($value === null) {
-            throw new HttpBadRequestException(I18N::translate('The parameter “%s” is missing.', $parameter));
+            throw $this->newBadRequestException($parameter);
         }
 
         return $value;
@@ -398,7 +398,7 @@ class Validator
             return $value;
         }
 
-        throw new HttpBadRequestException(I18N::translate('The parameter “%s” is missing.', $parameter));
+        throw $this->newBadRequestException($parameter);
     }
 
     public function treeOptional(string $parameter = 'tree'): Tree|null
@@ -409,7 +409,7 @@ class Validator
             return $value;
         }
 
-        throw new HttpBadRequestException(I18N::translate('The parameter “%s” is missing.', $parameter));
+        throw $this->newBadRequestException($parameter);
     }
 
     public function user(string $parameter = 'user'): UserInterface
@@ -420,6 +420,12 @@ class Validator
             return $value;
         }
 
-        throw new HttpBadRequestException(I18N::translate('The parameter “%s” is missing.', $parameter));
+        throw $this->newBadRequestException($parameter);
     }
+
+    private function newBadRequestException(string $parameter): HttpBadRequestException
+    {
+        return new HttpBadRequestException('The parameter “' . $parameter . '” is missing.');
+    }
+
 }


### PR DESCRIPTION
A truely bad request results in this error message:
```
I18N::$translator must not be accessed before initialization
```

While validating a http request the `I18N` class is not yet initialised and there's no connection yet with the database.
The error handler thus should not depend on either.

Changes in this PR make sure that at least a stack trace with the appropriate error message is shown to the user.

This can be tested with e.g. changing `client-ip` to another string e.g. `client-eyepea` on line 1530 of `BadBotBlocker`.