### PR TITLE
fix #5391 - query only locations on General Search

### DIFF
--- a/app/Http/RequestHandlers/SearchGeneralPage.php
+++ b/app/Http/RequestHandlers/SearchGeneralPage.php
@@ -92,7 +92,7 @@ final class SearchGeneralPage implements RequestHandlerInterface
             ->exists();
 
         // Default to families and individuals only
-        if (!$search_individuals && !$search_families && !$search_repositories && !$search_sources && !$search_notes) {
+        if (!$search_individuals && !$search_families && !$search_locations && !$search_repositories && !$search_sources && !$search_notes) {
             $search_families    = true;
             $search_individuals = true;
         }


### PR DESCRIPTION
Added missing check on `$search_locations` so defaults do not apply.

Fixes #5391 