### PR TITLE
Escape favicon asset URL in webmanifest

### DIFF
--- a/resources/views/webmanifest-json.phtml
+++ b/resources/views/webmanifest-json.phtml
@@ -8,7 +8,7 @@
     'theme_color'      => '#2694e8',
     'display'          => 'standalone',
     'icons'            => [(object) [
-        'src'   => asset('favicon-192.png'),
+        'src'   => e(asset('favicon-192.png')),
         'sizes' => '192x192',
         'type'  => 'image/png',
     ]],


### PR DESCRIPTION
Use 'e' function to escape asset URL for favicon. according to browserconfig-xml.phtml