### PR TITLE
Remove references to deleted 32x32 loading image

### DIFF
--- a/resources/css/_colorbox.css
+++ b/resources/css/_colorbox.css
@@ -99,10 +99,6 @@
     text-align: center;
 }
 
-#cboxLoadingGraphic {
-    background: url(images/loading-32x32.gif) no-repeat center center;
-}
-
 #cboxPrevious, #cboxNext, #cboxSlideshow, #cboxClose {
     background-color: transparent;
     border: 0;

--- a/resources/css/clouds.css
+++ b/resources/css/clouds.css
@@ -1164,15 +1164,6 @@ footer .error {
 }
 
 /*
- * Any element that is loaded dynamically has the class wt-ajax-load.
- * We can provide a "loading" placeholder for empty elements with this class.
- */
-.wt-ajax-load:empty {
-    height: 32px;
-    background: url(images/loading-32x32.gif) no-repeat 50% 50%;
-}
-
-/*
  * Default icons are provided by FontAwesome.
  */
 .wt-icon-anniversary {

--- a/resources/css/fab.css
+++ b/resources/css/fab.css
@@ -842,15 +842,6 @@ div.faq_body {
 }
 
 /*
- * Any element that is loaded dynamically has the class wt-ajax-load.
- * We can provide a "loading" placeholder for empty elements with this class.
- */
-.wt-ajax-load:empty {
-    height: 32px;
-    background: url(images/loading-32x32.gif) no-repeat 50% 50%;
-}
-
-/*
  * Default icons are provided by FontAwesome.
  */
 .wt-icon-anniversary {

--- a/resources/css/minimal.css
+++ b/resources/css/minimal.css
@@ -611,10 +611,6 @@ div.faq_body {
     content: url(images/indicator.gif);
 }
 
-.icon-loading-large {
-    content: url(images/loading-32x32.gif);
-}
-
 .icon-minus {
     content: url(icons/minus.png);
 }

--- a/resources/css/webtrees.css
+++ b/resources/css/webtrees.css
@@ -1021,15 +1021,6 @@ div.faq_body {
 }
 
 /*
- * Any element that is loaded dynamically has the class wt-ajax-load.
- * We can provide a "loading" placeholder for empty elements with this class.
- */
-.wt-ajax-load:empty {
-    height: 32px;
-    background: url(images/loading-32x32.gif) no-repeat 50% 50%;
-}
-
-/*
  * Default icons are provided by FontAwesome.
  */
 .wt-icon-anniversary {

--- a/resources/css/xenea.css
+++ b/resources/css/xenea.css
@@ -1010,15 +1010,6 @@ div.faq_body {
 }
 
 /*
- * Any element that is loaded dynamically has the class wt-ajax-load.
- * We can provide a "loading" placeholder for empty elements with this class.
- */
-.wt-ajax-load:empty {
-    height: 32px;
-    background: url(images/loading-32x32.gif) no-repeat 50% 50%;
-}
-
-/*
  * Default icons are provided by FontAwesome.
  */
 .wt-icon-anniversary {


### PR DESCRIPTION
Commit a30e37c5 removes the `loading-32x32.gif` image, but it is still referenced here and there in the CSS files.

In terms of impact:
- `.wt-ajax-load` disappeared as part of the previous commit, so no impact expected
- I could not find any reference to the class `.icon-loading-large` in `minimal.css`, so no impact expected
- Colorbox already comes with its own loading icon, so it actually fixes the loading image that stopped appearing.

I will let you build the CSS bundles.