### PR TITLE
Preserve deep-link when a guest hits a private-tree URL (#5388)

### DIFF
--- a/app/Http/Middleware/Router.php
+++ b/app/Http/Middleware/Router.php
@@ -24,7 +24,9 @@ use Aura\Router\RouterContainer;
 use Aura\Router\Rule\Accepts;
 use Aura\Router\Rule\Allows;
 use Fig\Http\Message\StatusCodeInterface;
+use Fisharebest\Webtrees\Auth;
 use Fisharebest\Webtrees\Http\Dispatcher;
+use Fisharebest\Webtrees\Http\RequestHandlers\LoginPage;
 use Fisharebest\Webtrees\Registry;
 use Fisharebest\Webtrees\Services\ModuleService;
 use Fisharebest\Webtrees\Services\TreeService;
@@ -37,6 +39,8 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 use function explode;
 use function implode;
+use function redirect;
+use function route;
 use function str_contains;
 
 readonly class Router implements MiddlewareInterface
@@ -118,8 +122,18 @@ readonly class Router implements MiddlewareInterface
                     Registry::container()->set(Tree::class, $value);
                 }
 
-                // Missing mandatory parameter? Let the default handler take care of it.
+                // The tree is missing, or it is private and the current user cannot see it.
                 if ($value === null && str_contains($route->path, '{tree}')) {
+                    // A guest may be able to see this tree once they sign in - and we must
+                    // not reveal whether a private tree exists. Send them to the login page,
+                    // preserving the requested URL so they return to it afterwards (the same
+                    // pattern as AuthLoggedIn/AuthMember). LoginPage and LoginAction both
+                    // enforce isLocalUrl() on that URL, so this is not an open redirect.
+                    if (Auth::id() === null) {
+                        return redirect(route(LoginPage::class, ['url' => (string) $request->getUri()]));
+                    }
+
+                    // A logged-in user has nothing to gain by signing in again.
                     return $handler->handle($request);
                 }
             }


### PR DESCRIPTION
Fixes the deep-link loss described in #5388.

## Problem
When an unauthenticated visitor follows a deep link into a **private** tree (e.g. an email link to `/tree/<name>/individual/I1`, or any custom-module tree URL), `TreeService::all()` hides the tree from them, so `Router::process()` reaches its `{tree}` fall-through and defers to `NotFound`, which `redirect()`s to the home page. The original URL is discarded, so after signing in the visitor lands on the home page instead of the page they clicked. This breaks "click this link to see the post" workflows on sites with private trees.

## Why here, and not in `NotFound`
As you noted in #5388, rendering a 404 *in place* at the tree URL would be a dead-end (no valid tree → no genealogy menu). This change avoids that by redirecting guests to the **login page** carrying the requested URL, which is a normal navigable page. `Router::process()` is also where the information actually is: we already know the matched route required `{tree}` and that the tree was not resolvable for this user, so `NotFound` itself stays stock.

## What it does
At the `{tree}`-null branch:

- **Guest** → `redirect(route(LoginPage::class, ['url' => (string) $request->getUri()]))`. This is the same pattern `AuthLoggedIn` and `AuthMember` already use for auth-required routes. `LoginPage` reads that URL and `LoginAction` redirects to it on success, both through `isLocalUrl()`, so it is **not** an open redirect. It also avoids disclosing to a guest whether a private tree exists: a missing tree and a private-but-inaccessible tree are handled identically.
- **Logged-in user** → unchanged (falls through to `NotFound` as before). Signing in again would not help, and we must not mislabel a genuinely missing tree as access-denied.

## Testing
- webtrees `main` + `php -l` on this branch; behaviour confirmed on 2.2.6 / PHP 8.3.
- Guest deep-link to a private tree (individual, family, and a custom-module route) → login page → after sign-in lands on the originally-requested URL.
- Guest deep-link to a **public** tree → unchanged (tree resolves, no redirect).
- Logged-in member without access → unchanged.
- Non-`{tree}` 404s (typos, unknown routes) → unchanged.

Happy to adjust. For example, if you'd prefer the logged-in-but-no-access case to render `HttpAccessDeniedException` rather than fall through, that's a small addition, though it needs distinguishing a private tree from a missing one (an extra `gedcom`-table lookup), which is why I left it out here.
