### PR TITLE
Fix Tamil translation of "Child" - stray %s crashes every page for Tamil users

### DIFF
--- a/resources/lang/ta/messages.po
+++ b/resources/lang/ta/messages.po
@@ -3511,7 +3511,7 @@ msgstr ""
 #: resources/views/edit/change-family-members.phtml:73
 #: resources/views/modules/pedigree-chart/previous.phtml:42
 msgid "Child"
-msgstr "%s குழந்தை"
+msgstr "குழந்தை"
 
 #: resources/xml/reports/ahnentafel_report.xml:388
 #: resources/xml/reports/descendancy_report.xml:480


### PR DESCRIPTION
Fixes #5412.

The Tamil translation of msgid "Child" contains a stray %s. This crashes every page with error 500 for Tamil users, because `I18N::translate('Child')` is called with no arguments in gedcom551Tags() and the translation goes through sprintf.

This is the only entry in the ta catalog where the msgstr has a sprintf specifier that the msgid does not have.

Normally this should go through Weblate, but the translation server is offline (#5401), so sending the one line fix directly.
