### PR TITLE
added the contact page of a tree to `Disallow` list in `robots.txt`

### DIFF
--- a/resources/views/robots-txt.phtml
+++ b/resources/views/robots-txt.phtml
@@ -33,6 +33,7 @@ Disallow: <?= $base_path ?>/tree/<?= $tree ?>/ancestors
 Disallow: <?= $base_path ?>/tree/<?= $tree ?>/branches
 Disallow: <?= $base_path ?>/tree/<?= $tree ?>/calendar
 Disallow: <?= $base_path ?>/tree/<?= $tree ?>/compact
+Disallow: <?= $base_path ?>/tree/<?= $tree ?>/contact
 Disallow: <?= $base_path ?>/tree/<?= $tree ?>/descendants
 Disallow: <?= $base_path ?>/tree/<?= $tree ?>/family-book
 Disallow: <?= $base_path ?>/tree/<?= $tree ?>/family-list


### PR DESCRIPTION
Inspection of my Google Search Console learned that google tried to index a lot of pages like:
```
https://stamboom.bertkoor.nl/tree/BertKoor/contact?to=bertkoor&url=https://stamboom.bertkoor.nl/tree/BertKoor/individual/**
```

The link in the footer of the Individual page itself has attribute `rel="nofollow"` but that is apparently not stopping Google.
It seems that google still does respect `robots.txt`, so let's add the contact page there.

Perhaps semantics have shifted in the last decades, and thus we should change all `rel="nofollow"` to `rel="noindex,nofollow"` but I'll leave that to others to decide.