### PR TITLE
Respect explicit privacy restrictions even when HIDE_LIVE_PEOPLE is disabled

### DIFF
--- a/app/GedcomRecord.php
+++ b/app/GedcomRecord.php
@@ -947,11 +947,6 @@ class GedcomRecord
      */
     private function canShowRecord(AccessLevel $access_level): bool
     {
-        // This setting would better be called "$ENABLE_PRIVACY"
-        if ($this->tree->getPreference('HIDE_LIVE_PEOPLE') !== '1') {
-            return true;
-        }
-
         // We should always be able to see our own record (unless an admin is applying download restrictions)
         if ($this->xref() === $this->tree->getUserPreference(Auth::user(), UserInterface::PREF_TREE_ACCOUNT_XREF) && $access_level === Auth::accessLevel($this->tree)) {
             return true;
@@ -974,6 +969,13 @@ class GedcomRecord
 
         // Privacy rules do not apply to admins
         if (AccessLevel::Manager->allows($access_level)) {
+            return true;
+        }
+
+        // This setting would better be called "$ENABLE_PRIVACY".
+        // It only controls the *default* rules for living people (see canShowByType()) -
+        // explicit restrictions (RESN tags, individual privacy overrides, above) always apply.
+        if (!$this->tree->getPreference('HIDE_LIVE_PEOPLE')) {
             return true;
         }
 


### PR DESCRIPTION
Replaces #5426, which was accidentally closed by a fork sync (no code review implications — same change).

Previously, disabling the tree's "hide living people" setting caused
canShowRecord() to return true immediately, bypassing RESN restriction
notices and individual-level privacy overrides for every record. This
moves that check after the explicit restriction checks so an individual
marked private is still hidden, even when living people are otherwise
shown to visitors.