### PR TITLE
fix #5090: gedcomRecordFactory might return null for a pending change

### DIFF
--- a/app/Module/ReviewChangesModule.php
+++ b/app/Module/ReviewChangesModule.php
@@ -23,6 +23,7 @@ use Fisharebest\Webtrees\Auth;
 use Fisharebest\Webtrees\Contracts\UserInterface;
 use Fisharebest\Webtrees\DB;
 use Fisharebest\Webtrees\Enums\ChangeStatus;
+use Fisharebest\Webtrees\GedcomRecord;
 use Fisharebest\Webtrees\Http\Controllers\PendingChanges;
 use Fisharebest\Webtrees\I18N;
 use Fisharebest\Webtrees\Registry;
@@ -154,7 +155,7 @@ class ReviewChangesModule extends AbstractModule implements ModuleBlockInterface
 
             foreach ($changes as $change) {
                 $record = Registry::gedcomRecordFactory()->make($change->xref, $tree, $change->new_gedcom !== '' ? $change->new_gedcom : $change->old_gedcom);
-                if ($record->canShow()) {
+                if ($record instanceof GedcomRecord && $record->canShow()) {
                     $content .= '<li><a href="' . e($record->url()) . '">' . $record->fullName() . '</a></li>';
                 }
             }


### PR DESCRIPTION
fix #5090 again (apparently a closed PR #5310 cannot be reopened after a forced push)
Forum discussion: https://www.webtrees.net/index.php/forum/help-for-release-2-2-x/40498-error-on-my-page

If you want to hunt down the root cause, then good luck.
But the `GedcomRecordFactoryInterface` declares that `make` _may_ return null.
And there are plenty cases in the code where a check on `null` or `instanceof` of this exact result is done.