### PR TITLE
fix #5417: case-insensitive comparison of NAME:TYPE and FAM:MARR:TYPE in reports

### DIFF
--- a/app/Report/ExpressionLanguageProvider.php
+++ b/app/Report/ExpressionLanguageProvider.php
@@ -34,6 +34,7 @@ final class ExpressionLanguageProvider implements ExpressionFunctionProviderInte
     {
         return [
             ExpressionFunction::fromPhp('stristr'),
+            ExpressionFunction::fromPhp('strcasecmp'),
         ];
     }
 }

--- a/resources/xml/reports/death_report.xml
+++ b/resources/xml/reports/death_report.xml
@@ -63,7 +63,7 @@
             <GetPersonName/>
             <if condition="$adlist=='_MARNM'">
               <RepeatTag tag="NAME">
-                <if condition="@NAME:TYPE=='married'">
+                <if condition="strcasecmp(@NAME:TYPE,'married')===0">
                   <br/>
                   <GedcomValue tag="NAME"/>
                 </if>

--- a/resources/xml/reports/fact_sources.xml
+++ b/resources/xml/reports/fact_sources.xml
@@ -201,13 +201,13 @@
                   <if condition="@MARR:TYPE==''">
                     <var var="@fact"/>
                   </if>
-                  <if condition="@MARR:TYPE=='Religious'">
+                  <if condition="strcasecmp(@MARR:TYPE,'Religious')===0">
                     <var var="I18N::translate('Religious marriage')"/>
                   </if>
-                  <if condition="@MARR:TYPE=='Civil'">
+                  <if condition="strcasecmp(@MARR:TYPE,'Civil')===0">
                     <var var="I18N::translate('Civil marriage')"/>
                   </if>
-                  <if condition="@MARR:TYPE=='Partners'">
+                  <if condition="strcasecmp(@MARR:TYPE,'Partners')===0">
                     <var var="I18N::translate('Registered partnership')"/>
                   </if>
                 </if>


### PR DESCRIPTION
fixes #5417