### PR TITLE
fix exception when SetupWizard was about to create a tree

### DIFF
--- a/resources/views/admin/trees-create.phtml
+++ b/resources/views/admin/trees-create.phtml
@@ -35,13 +35,13 @@ use Fisharebest\Webtrees\I18N;
         <div class="col-sm-10">
             <div class="input-group" dir="ltr">
                 <span class="input-group-text" dir="ltr">
-                    <?= e(explode('{tree}', rawurldecode(route('example', ['tree' => '{tree}'])))[0]) ?>
+                    <?= e(explode('arbre', rawurldecode(route('example', ['tree' => 'arbre'])))[0]) ?>
                 </span>
 
                 <input class="form-control" id="name" maxlength="31" name="name" pattern="[^&lt;&gt;&quot;*?{}():/\\$%|]*" required="required" type="text" value="<?= e($tree_name) ?>" dir="ltr">
 
                 <span class="input-group-text" dir="ltr">
-                    <?= e(explode('{tree}', rawurldecode(route('example', ['tree' => '{tree}'])))[1]) ?>
+                    <?= e(explode('arbre', rawurldecode(route('example', ['tree' => 'arbre'])))[1]) ?>
                 </span>
             </div>
             <div class="form-text">


### PR DESCRIPTION
this fixes #5446 
Same exception was thrown when rewrite_url=0
Avoided the problematic split by chosing another value than `tree` and without characters which need escaping.
<img width="1294" height="422" alt="Screenshot 2026-08-18 at 16 46 44" src="https://github.com/user-attachments/assets/2c522df2-f6bd-4c2b-ba73-666becf8c33c" />
