### PR TITLE
Fix for Issue 5461 "URL redirect"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 /robots.txt
 
 /vendor/
+
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,3 @@
 /robots.txt
 
 /vendor/
-
-.DS_Store

--- a/app/Factories/RouteFactory.php
+++ b/app/Factories/RouteFactory.php
@@ -32,6 +32,7 @@ use function array_map;
 use function is_bool;
 use function parse_url;
 use function str_contains;
+use function str_starts_with;
 use function strlen;
 use function substr;
 
@@ -75,6 +76,13 @@ class RouteFactory implements RouteFactoryInterface
 
         // Extract path portion only (without query string that UrlGenerator may add)
         $path = parse_url($url, PHP_URL_PATH);
+
+        // Strip the base path prefix — the Router expects route-relative paths.
+        $base_path = parse_url($base_url, PHP_URL_PATH);
+        $base_path = is_string($base_path) ? $base_path : '';
+        if ($base_path !== '' && str_starts_with((string) $path, $base_path)) {
+            $path = substr($path, strlen($base_path));
+        }
 
         // All parameters that weren't consumed by the path become query params
         $parameters = array_filter($parameters, static fn (string $key): bool => !str_contains($route->url, '{' . $key . '}') && !str_contains($route->url, '{/' . $key . '}'), ARRAY_FILTER_USE_KEY);

--- a/app/Factories/RouteFactory.php
+++ b/app/Factories/RouteFactory.php
@@ -80,7 +80,8 @@ class RouteFactory implements RouteFactoryInterface
         // Strip the base path prefix — the Router expects route-relative paths.
         $base_path = parse_url($base_url, PHP_URL_PATH);
         $base_path = is_string($base_path) ? $base_path : '';
-        if ($base_path !== '' && str_starts_with((string) $path, $base_path)) {
+
+        if (str_starts_with((string) $path, $base_path)) {
             $path = substr($path, strlen($base_path));
         }
 


### PR DESCRIPTION
Strips the base path prefix from the route parameter in `RouteFactory::route()` before building the URL.


    // In RouteFactory::route(), after extracting the path:
    $base_path = parse_url($base_url, PHP_URL_PATH);
    $base_path = is_string($base_path) ? $base_path : '';
    if ($base_path !== '' && str_starts_with((string) $path, $base_path)) {
        $path = substr($path, strlen($base_path));
    }

This produces `?route=/tree/test` instead of `?route=/test/tree/test`, which `RouteMatcher` can match correctly.