### PR TITLE
fix #5478: edit raw GEDCOM record, missing param level0

### DIFF
--- a/resources/views/edit/raw-gedcom-record.phtml
+++ b/resources/views/edit/raw-gedcom-record.phtml
@@ -31,7 +31,7 @@ use Fisharebest\Webtrees\Webtrees;
         <label class="card-header py-1 px-2" for="level0">
             <?= $record->fullName() ?>
         </label>
-        <textarea class="card-body form-control py-1 px-2" id="level0" name="level0" rows="1" dir="ltr" readonly="readonly" disabled="disabled"><?= e($level0) ?></textarea>
+        <textarea class="card-body form-control py-1 px-2" id="level0" name="level0" rows="1" dir="ltr" readonly="readonly"><?= e($level0) ?></textarea>
     </div>
 
     <div class="wt-sortable-list" data-wt-sortable-list>


### PR DESCRIPTION
fix #5478
`level0` is readonly textarea, should not have been `disabled`, it is required by the controller!
