### PR TITLE
correcting dutch ancestors after commit 1937c91

### DIFF
--- a/app/I18N/Languages/Dutch.php
+++ b/app/I18N/Languages/Dutch.php
@@ -280,15 +280,15 @@ final readonly class Dutch extends AbstractLanguage
     }
 
     /**
-     * Dynamic descendant relationship using the "over" prefix.
+     * Dynamic descendant relationship using the "achter" prefix.
      *
-     * kleinkind → overkleinkind → overoverkleinkind
+     * kleinkind → achterkleinkind → achterachterkleinkind
      *
      * @return array{string, string}
      */
-    private function over(int $n, string $suffix, Closure $genitive): array
+    private function achter(int $n, string $suffix, Closure $genitive): array
     {
-        return $this->repeat($n, $suffix, 'over', $genitive);
+        return $this->repeat($n, $suffix, 'achter', $genitive);
     }
 
     /**
@@ -390,16 +390,16 @@ final readonly class Dutch extends AbstractLanguage
             // Dynamic relationships
             Relationship::dynamic(fn (int $n) => $this->oud($n - 1, 'tante', $this->vanDe(...)))->ancestor()->sister(),
             Relationship::dynamic(fn (int $n) => $this->oud($n - 1, 'oom', $this->vanDe(...)))->ancestor()->brother(),
-            Relationship::dynamic(fn (int $n) => $this->oud($n - 1, 'nicht', $this->vanDe(...)))->sibling()->descendant()->female(),
-            Relationship::dynamic(fn (int $n) => $this->oud($n - 1, 'nicht', $this->vanDe(...)))->married()->spouse()->sibling()->descendant()->female(),
-            Relationship::dynamic(fn (int $n) => $this->oud($n - 1, 'neef', $this->vanDe(...)))->sibling()->descendant()->male(),
-            Relationship::dynamic(fn (int $n) => $this->oud($n - 1, 'neef', $this->vanDe(...)))->married()->spouse()->sibling()->descendant()->male(),
+            Relationship::dynamic(fn (int $n) => $this->achter($n - 1, 'nicht', $this->vanDe(...)))->sibling()->descendant()->female(),
+            Relationship::dynamic(fn (int $n) => $this->achter($n - 1, 'nicht', $this->vanDe(...)))->married()->spouse()->sibling()->descendant()->female(),
+            Relationship::dynamic(fn (int $n) => $this->achter($n - 1, 'neef', $this->vanDe(...)))->sibling()->descendant()->male(),
+            Relationship::dynamic(fn (int $n) => $this->achter($n - 1, 'neef', $this->vanDe(...)))->married()->spouse()->sibling()->descendant()->male(),
             Relationship::dynamic(fn (int $n) => $this->bet($n - 3, 'overgrootmoeder', $this->vanDe(...)))->ancestor()->female(),
             Relationship::dynamic(fn (int $n) => $this->bet($n - 3, 'overgrootvader', $this->vanDe(...)))->ancestor()->male(),
             Relationship::dynamic(fn (int $n) => $this->bet($n - 3, 'overgrootouder', $this->vanDe(...)))->ancestor(),
-            Relationship::dynamic(fn (int $n) => $this->over($n - 2, 'kleindochter', $this->vanDe(...)))->descendant()->female(),
-            Relationship::dynamic(fn (int $n) => $this->over($n - 2, 'kleinzoon', $this->vanDe(...)))->descendant()->male(),
-            Relationship::dynamic(fn (int $n) => $this->over($n - 2, 'kleinkind', $this->vanHet(...)))->descendant(),
+            Relationship::dynamic(fn (int $n) => $this->achter($n - 2, 'kleindochter', $this->vanDe(...)))->descendant()->female(),
+            Relationship::dynamic(fn (int $n) => $this->achter($n - 2, 'kleinzoon', $this->vanDe(...)))->descendant()->male(),
+            Relationship::dynamic(fn (int $n) => $this->achter($n - 2, 'kleinkind', $this->vanHet(...)))->descendant(),
         ];
     }
 }


### PR DESCRIPTION
First simple fix for grandchildren and nephews/nieces

See also https://www.dutchgenealogy.nl/achternicht-achternicht/

Todo
More generations for grandparents. We do not use multiple 'bet'. Officially the dutch professional genealogists use the OSSEE-scheme; see e.g. https://www.yory.nl/hoe-noem-je-generaties-voorouders/

BUT,... this not common knowledge in the broader dutch speaking population. Most people do not go beyond the 4th Generation: ouder, grootouder, overgrootouder, betovergrootouder