### PR TITLE
Fix select components with backed enums

### DIFF
--- a/resources/views/components/select.phtml
+++ b/resources/views/components/select.phtml
@@ -6,10 +6,12 @@ declare(strict_types=1);
  * @var string|null             $class
  * @var string|null             $id
  * @var string                  $name
- * @var array-key|array<string> $selected
+ * @var \BackedEnum|array-key|array<string> $selected
  * @var array<string>           $options
  * @var string|null             $aria_label
  */
+
+$selected_value = $selected instanceof BackedEnum ? $selected->value : $selected;
 
 ?>
 
@@ -17,12 +19,12 @@ declare(strict_types=1);
     class="form-select <?= $class ?? '' ?>"
     name="<?= e($name) ?>"
     id="<?= e($id ?? $name) ?>"
-    <?= is_array($selected) ? 'multiple="multiple"' : '' ?>
+    <?= is_array($selected_value) ? 'multiple="multiple"' : '' ?>
     aria-label="<?= e($aria_label ?? '') ?>"
 
 >
     <?php foreach ($options as $key => $value) : ?>
-        <option value="<?= e((string) $key) ?>"<?= (is_array($selected) ? in_array((string) $key, $selected, true) : (string) $key === (string) $selected) ?  ' selected="selected"' : '' ?>>
+        <option value="<?= e((string) $key) ?>"<?= (is_array($selected_value) ? in_array((string) $key, $selected_value, true) : (string) $key === (string) $selected_value) ?  ' selected="selected"' : '' ?>>
             <?= $value === '' ? '&nbsp;' : e($value) ?>
         </option>
     <?php endforeach ?>

--- a/tests/Unit/ViewTest.php
+++ b/tests/Unit/ViewTest.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 
 namespace Fisharebest\Webtrees\Tests\Unit;
 
+use Fisharebest\Webtrees\Enums\AccessLevel;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Fisharebest\Webtrees\Tests\TestCase;
 use Fisharebest\Webtrees\View;
@@ -29,5 +30,16 @@ class ViewTest extends TestCase
     public function testClass(): void
     {
         self::assertTrue(class_exists(View::class));
+    }
+
+    public function testSelectAcceptsBackedEnum(): void
+    {
+        $html = view('components/select', [
+            'name'     => 'access-level',
+            'selected' => AccessLevel::Member,
+            'options'  => [AccessLevel::Member->value => 'Member'],
+        ]);
+
+        self::assertStringContainsString('<option value="1" selected="selected">', $html);
     }
 }


### PR DESCRIPTION
## Summary

- normalize backed-enum selections to their scalar value in the shared select component
- add regression coverage using `AccessLevel::Member`
- restore module access-level management pages affected by #5476

Fixes #5476.

## Testing

- reproduced the original exception with the real select view in Docker using PHP 8.5.9
- `vendor/bin/phpunit --no-coverage tests/Unit/ViewTest.php`
- `vendor/bin/phpcs resources/views/components/select.phtml tests/Unit/ViewTest.php`
- `vendor/bin/phpstan analyze --no-progress resources/views/components/select.phtml tests/Unit/ViewTest.php`