### PR TITLE
Add Development Container configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
-FROM php:8.5-cli-bookworm
+FROM php:8.5-cli-trixie
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
-COPY --from=node:22-bookworm /usr/local/ /usr/local/
+COPY --from=node:22-trixie /usr/local/ /usr/local/
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
     && docker-php-ext-install -j1 gd \
     && docker-php-ext-install -j1 intl \
     && docker-php-ext-install -j1 mbstring \
+    && docker-php-ext-install -j1 exif \
     && docker-php-ext-install -j1 pdo_sqlite \
     && docker-php-ext-install -j1 zip \
     && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
         libjpeg62-turbo-dev \
         libonig-dev \
         libpng-dev \
+        libpq-dev \
         libsqlite3-dev \
         libzip-dev \
         unzip \
@@ -21,6 +22,8 @@ RUN apt-get update \
     && docker-php-ext-install -j1 mbstring \
     && docker-php-ext-install -j1 exif \
     && docker-php-ext-install -j1 pdo_sqlite \
+    && docker-php-ext-install -j1 pdo_mysql \
+    && docker-php-ext-install -j1 pdo_pgsql \
     && docker-php-ext-install -j1 zip \
     && rm -rf /var/lib/apt/lists/*
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,26 @@
+FROM php:8.5-cli-bookworm
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+COPY --from=node:22-bookworm /usr/local/ /usr/local/
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+        libfreetype6-dev \
+        libicu-dev \
+        libjpeg62-turbo-dev \
+        libonig-dev \
+        libpng-dev \
+        libsqlite3-dev \
+        libzip-dev \
+        unzip \
+        zip \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-install -j1 gd \
+    && docker-php-ext-install -j1 intl \
+    && docker-php-ext-install -j1 mbstring \
+    && docker-php-ext-install -j1 pdo_sqlite \
+    && docker-php-ext-install -j1 zip \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspaces/webtrees

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "webtrees",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "forwardPorts": [8080],
+  "postCreateCommand": "composer install --no-interaction && npm ci"
+}

--- a/README.md
+++ b/README.md
@@ -174,13 +174,14 @@ needed to develop and test webtrees.
 Prerequisites:
 
 * An OCI-compatible container engine, such as Docker or Podman
-* A client that supports the Development Container specification
-* Internet access to download container images and project dependencies
+* A Development Container client, such as Visual Studio Code with the
+	Dev Containers extension, GitHub Codespaces, or the Dev Container CLI
 
 Clone the repository or extract a source archive, then use your Development
-Container client to open the source directory in its container. The container
-creation process runs `composer install` and `npm ci` automatically. Then build
-the assets and start the development server:
+Container client to open the source directory in its container. The initial
+container setup downloads the container image and project dependencies, then
+runs `composer install` and `npm ci` automatically. Then build the assets and
+start the development server:
 
 ```bash
 npm run build
@@ -190,10 +191,13 @@ php -S 0.0.0.0:8080
 Open <http://localhost:8080> on the host. Port 8080 is declared by the container
 configuration and should be forwarded by the client.
 
-Complete the setup wizard and select SQLite for the database. The database is
-stored as `data/<name>.sqlite` in the source directory, so it remains available
-when the container is rebuilt or replaced. The Development Container does not
-include a MySQL, PostgreSQL, or SQL Server service.
+Complete the setup wizard and select SQLite for the simplest setup. The
+container includes PHP PDO drivers for SQLite, MySQL/MariaDB, and PostgreSQL,
+but it does not run a database server. SQLite is stored as
+`data/<name>.sqlite` in the source directory, so it remains available when the
+container is rebuilt or replaced. To use MySQL/MariaDB, PostgreSQL, or SQL
+Server, provide a separately running database server and configure its
+connection details in the setup wizard.
 
 #### Local environment
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,38 @@ All dependencies are pinned to exact version numbers (no ranges).
 
 ### Building from source
 
+#### Development Container
+
+The repository includes a [Development Container](https://containers.dev/)
+configuration with PHP 8.5, Composer, Node.js 22, npm, and the PHP extensions
+needed to develop and test webtrees.
+
+Prerequisites:
+
+* An OCI-compatible container engine, such as Docker or Podman
+* A client that supports the Development Container specification
+* Internet access to download container images and project dependencies
+
+Clone the repository or extract a source archive, then use your Development
+Container client to open the source directory in its container. The container
+creation process runs `composer install` and `npm ci` automatically. Then build
+the assets and start the development server:
+
+```bash
+npm run build
+php -S 0.0.0.0:8080
+```
+
+Open <http://localhost:8080> on the host. Port 8080 is declared by the container
+configuration and should be forwarded by the client.
+
+Complete the setup wizard and select SQLite for the database. The database is
+stored as `data/<name>.sqlite` in the source directory, so it remains available
+when the container is rebuilt or replaced. The Development Container does not
+include a MySQL, PostgreSQL, or SQL Server service.
+
+#### Local environment
+
 Prerequisites: PHP 8.3+, [Composer](https://getcomposer.org/),
 [Node.js](https://nodejs.org/) with npm.
 


### PR DESCRIPTION
Add Development Container configuration for webtrees to provide a consistent PHP and Node.js development environment. This makes it easy to get a development environment up and running with e.g. VS Code.

## Changes
- Add a PHP 8.5 development image based on Debian Trixie.
- Include Composer 2 and Node.js 22 with npm.
- Install the PHP extensions required to develop and test webtrees.
- Add PDO drivers for SQLite, MySQL/MariaDB, and PostgreSQL.
- Forward port 8080 for the built-in PHP development server.
- Automatically run composer install and npm ci when the container is created.
- Update README